### PR TITLE
[+] Added entertainment schedule

### DIFF
--- a/lib/parks/dlp/disneylandparis.js
+++ b/lib/parks/dlp/disneylandparis.js
@@ -84,7 +84,7 @@ async function getResortSchedules(date) {
             'status': ['REFURBISHMENT', 'CLOSED'],
           }, {
             'type': 'Restaurant',
-            'status': ['REFURBISHMENT', 'CLOSED'],
+            'status': ['REFURBISHMENT', 'CLOSED', 'OPERATING'],
           }, {
             'type': 'DiningEvent',
             'status': ['REFURBISHMENT', 'CLOSED'],
@@ -105,6 +105,7 @@ async function getResortSchedules(date) {
     throw e;
   }
 }
+
 
 /**
  * Get the park wait times for both parks at once.
@@ -589,6 +590,54 @@ export class DisneylandParisPark extends Park {
         type: hours.status === 'EXTRA_MAGIC_HOURS' ? scheduleType.extraHours : scheduleType.operating,
       };
     });
+  }
+
+  /**
+     * Return restaurant operating hours for the supplied date
+     * @param {moment} date
+     */
+  async _getRestaurantOperatingHoursForDate(date) {
+    if (parkDataController === undefined) {
+      parkDataController = this;
+    }
+
+    // fetch all calendars for the day
+    const dateString = date.format('YYYY-MM-DD');
+    const dateCal = await getResortSchedules(dateString);
+    if (dateCal === undefined) return undefined;
+
+    const parkDate = dateCal.filter((x) => x.id.startsWith(this.config.parkId) && x.type == 'Restaurant');
+    if (parkDate === undefined) return undefined;
+
+    const momentParseFormat = 'YYYY-MM-DDTHH:mm:ss';
+
+    return parkDate.map((restaurantActivity) => {
+      return restaurantActivity.schedules.map((restaurantSchedule) => {
+        let restaurantStatus = null;
+
+        if (restaurantSchedule.status === 'CLOSED') {
+          restaurantStatus = statusType.closed;
+        } else if (restaurantSchedule.status === 'OPERATING') {
+          restaurantStatus = statusType.operating;
+        } else if (restaurantSchedule.status === 'REFURBISHMENT') {
+          restaurantStatus = statusType.refurbishment;
+        }
+
+        if (restaurantStatus === null) {
+          this.emit('error', new Error(`Unknown DLP restaurantStatus ${JSON.stringify(restaurantStatus)}`));
+          console.log('Unknown DLP restaurantStatus', JSON.stringify(restaurantStatus));
+        }
+
+        return {
+          restaurantID: restaurantActivity.id,
+          // eslint-disable-next-line max-len
+          openingTime: moment.tz(`${dateString}T${restaurantSchedule.startTime}`, momentParseFormat, this.config.timezone).format(),
+          // eslint-disable-next-line max-len
+          closingTime: moment.tz(`${dateString}T${restaurantSchedule.endTime}`, momentParseFormat, this.config.timezone).format(),
+          type: restaurantStatus,
+        };
+      });
+    }).flatMap((x) => x);
   }
 }
 

--- a/lib/parks/dlp/disneylandparis.js
+++ b/lib/parks/dlp/disneylandparis.js
@@ -639,6 +639,42 @@ export class DisneylandParisPark extends Park {
       });
     }).flatMap((x) => x);
   }
+
+  /**
+   * Return entertainment schedule for today
+   */
+  async _getEntertainmentForToday() {
+    if (parkDataController === undefined) {
+      parkDataController = this;
+    }
+
+    // fetch all calendars for the day
+    const date = moment();
+    const dateString = date.format('YYYY-MM-DD');
+    const dateCal = await getResortSchedules(dateString);
+    if (dateCal === undefined) return undefined;
+
+    const parkDate = dateCal.filter((x) => x.id.startsWith(this.config.parkId) && x.type == 'Entertainment');
+    if (parkDate === undefined) return undefined;
+
+    const momentParseFormat = 'YYYY-MM-DDTHH:mm:ss';
+
+    return parkDate.map((entry) => {
+      return entry.schedules.map((scheduleEntry) =>{
+        return {
+          entertainmentID: entry.Key,
+          startTime: moment.tz(
+              `${dateString}T${scheduleEntry.startTime}`,
+              momentParseFormat,
+              this.config.timezone).format(),
+          endTime: moment.tz(
+              `${dateString}T${scheduleEntry.endTime}`,
+              momentParseFormat,
+              this.config.timezone).format(),
+        };
+      });
+    }).flatMap((x) => x);
+  }
 }
 
 export default DisneylandParisPark;

--- a/lib/parks/efteling/efteling.js
+++ b/lib/parks/efteling/efteling.js
@@ -380,6 +380,47 @@ export class Efteling extends Park {
       };
     }).filter((x) => x !== undefined);
   }
+
+  /**
+   * Get entertainment schedule from API
+   */
+  async getEntertainment() {
+    const date = moment();
+    return await this.cache
+        .wrap(`entertainment_${date.format('YYYY')}_${date.format('M')}_${date.format('D')}`, async () => {
+          const waitTimes = await this.http('GET', this.config.waitTimesUrl, {
+            language: 'en',
+          });
+
+          if (!waitTimes?.body?.AttractionInfo) {
+            throw new Error(`Unable to find entertainment schedule for Efteling ${data.body}`);
+          }
+
+          return waitTimes.body;
+        }, 1000 * 60 * 60 * 12); // 12 hours
+  }
+
+  /**
+   * Return entertainment schedule for today
+   */
+  async _getEntertainmentForToday() {
+    const cal = await this.getEntertainment();
+
+    if (cal === undefined) return undefined;
+
+    const data = cal.AttractionInfo.filter((x) => x.Type === 'Show');
+
+    return data.map((entry) => {
+      // TODO: Concat PastShowTimes to get a full schedule for today
+      return entry.ShowTimes.map((showTime) => {
+        return {
+          entertainmentID: entry.Id,
+          startTime: showTime.ShowDateTime,
+          endTime: showTime.ShowDateTime,
+        };
+      });
+    });
+  }
 }
 
 export default Efteling;

--- a/lib/parks/efteling/efteling.js
+++ b/lib/parks/efteling/efteling.js
@@ -1,5 +1,6 @@
 import {Park} from '../park.js';
 import {attractionType, statusType, queueType, tagType, scheduleType} from '../parkTypes.js';
+import moment from 'moment-timezone';
 
 /**
  * Efteling Park Object
@@ -13,9 +14,9 @@ export class Efteling extends Park {
     options.name = options.name || 'Efteling';
     options.timezone = options.timezone || 'Europe/Amsterdam';
 
-    options.apiKey = '';
-    options.apiVersion = '';
-    options.appVersion = '';
+    options.apiKey = options.apiKey || '';
+    options.apiVersion = options.apiVersion || '';
+    options.appVersion = options.appVersion || '';
 
     options.searchUrl = options.searchUrl || 'https://prd-search-acs.efteling.com/2013-01-01/search';
     options.waitTimesUrl = options.waitTimesUrl || 'https://api.efteling.com/app/wis/';
@@ -77,6 +78,7 @@ export class Efteling extends Park {
         'q': '(and (phrase field=language \'en\'))',
       });
 
+      console.log(fetchedPOIData);
       const data = fetchedPOIData?.body?.hits?.hit;
       if (!data) {
         throw new Error('Failed to fetch Efteling POI data');
@@ -190,7 +192,7 @@ export class Efteling extends Park {
     if (data.type === 'attraction') {
       // all attractions default to "ride"
       type = attractionType.ride;
-    } else if (data.type ==='show') {
+    } else if (data.type === 'show') {
       type = attractionType.show;
     }
 
@@ -249,8 +251,8 @@ export class Efteling extends Park {
         // update queue status
         await this.updateAttractionQueue(
             entry.Id,
-            rideStatus == statusType.operating ? rideWaitTime : null,
-            queueType.standBy,
+          rideStatus == statusType.operating ? rideWaitTime : null,
+          queueType.standBy,
         );
       } else {
         // if we don't have POI data for this attraction, check for single rider IDs and update the main attraction
@@ -323,6 +325,60 @@ export class Efteling extends Park {
       });
     }
     return undefined;
+  }
+
+  /**
+ * Get restaurant operating hours from API
+ * @param {string} day
+ * @param {string} month
+ * @param {string} year
+ */
+  async getRestaurantOperatingHours(day, month, year) {
+    return await this.cache.wrap(`restaurant_${year}_${month}_${day}`, async () => {
+      const waitTimes = await this.http('GET', this.config.waitTimesUrl, {
+        language: 'en',
+      });
+
+      if (!waitTimes?.body?.AttractionInfo) {
+        throw new Error(`Unable to find restaurant operating hours for Efteling ${data.body}`);
+      }
+
+      return waitTimes.body;
+    }, 1000 * 60 * 60 * 12); // 12 hours
+  }
+
+  /**
+   * Return restaurant operating hours for the supplied date
+   * @param {moment} date
+   */
+  async _getRestaurantOperatingHoursForDate(date) {
+    const cal = await this.getRestaurantOperatingHours(date.format('D'), date.format('M'), date.format('YYYY'));
+
+    if (cal === undefined) return undefined;
+
+    const data = cal.AttractionInfo;
+
+    return data.map((entry) => {
+      if (entry.Type !== 'Horeca') return;
+
+      if (!entry.OpeningTimes || entry.OpeningTimes.length == 0) {
+        return {
+          restaurantID: entry.Id,
+          openingTime: 0,
+          closingTime: 0,
+          status: statusType.closed,
+        };
+      }
+
+      const openingTimes = entry.OpeningTimes;
+
+      return {
+        restaurantID: entry.Id,
+        openingTime: moment(openingTimes[0].HourFrom).format(),
+        closingTime: moment(openingTimes[0].HourTo).format(),
+        type: scheduleType.operating,
+      };
+    }).filter((x) => x !== undefined);
   }
 }
 

--- a/lib/parks/efteling/efteling.js
+++ b/lib/parks/efteling/efteling.js
@@ -411,14 +411,23 @@ export class Efteling extends Park {
     const data = cal.AttractionInfo.filter((x) => x.Type === 'Show');
 
     return data.map((entry) => {
-      // TODO: Concat PastShowTimes to get a full schedule for today
-      return entry.ShowTimes.map((showTime) => {
+      const scheduledShowTimes = entry.ShowTimes?.map((showTime) => {
         return {
           entertainmentID: entry.Id,
           startTime: showTime.ShowDateTime,
           endTime: showTime.ShowDateTime,
         };
-      });
+      }) ?? [];
+
+      const pastShowTimes = entry.PastShowTimes?.map((showTime) => {
+        return {
+          entertainmentID: entry.Id,
+          startTime: showTime.ShowDateTime,
+          endTime: showTime.ShowDateTime,
+        };
+      }) ?? [];
+
+      return pastShowTimes.concat(scheduledShowTimes);
     });
   }
 }

--- a/lib/parks/park.js
+++ b/lib/parks/park.js
@@ -653,7 +653,7 @@ export class Park extends Entity {
 
   /**
    * Given a moment date, return an array of opening hours for the restaurants in this park, or undefined
-   * Ech entry should contain openingTime closingTime
+   * Each entry should contain openingTime closingTime
    * @param {moment} date
    */
   async _getRestaurantOperatingHoursForDate(date) {
@@ -668,6 +668,25 @@ export class Park extends Entity {
   async getRestaurantOperatingHoursForDate(date) {
     return this.cache.wrap(`restaurant_${date.format('YYYY-MM-DD')}`, async () => {
       return await this._getRestaurantOperatingHoursForDate(date);
+    }, 1000 * 60 * 60 * 6); // cache for 6 hours
+  }
+
+  /**
+   * Each entry should contain startTime and endTime
+   * @private
+   * @abstract
+   */
+  async _getEntertainmentForToday() {
+    // implementation should be setup in child classes
+    throw new Error('_getEntertainmentForToday() needs an implementation', this.constructor.name);
+  }
+
+  /**
+   * Get the entertainment schedule for today
+   */
+  async getEntertainmentForToday() {
+    return this.cache.wrap(`entertainment_${date.format('YYYY-MM-DD')}`, async () => {
+      return await this._getEntertainmentForToday();
     }, 1000 * 60 * 60 * 6); // cache for 6 hours
   }
 

--- a/lib/parks/park.js
+++ b/lib/parks/park.js
@@ -652,6 +652,26 @@ export class Park extends Entity {
   }
 
   /**
+   * Given a moment date, return an array of opening hours for the restaurants in this park, or undefined
+   * Ech entry should contain openingTime closingTime
+   * @param {moment} date
+   */
+  async _getRestaurantOperatingHoursForDate(date) {
+    // implementation should be setup in child classes
+    throw new Error('_getRestaurantOperatingHoursForDate() needs an implementation', this.constructor.name);
+  }
+
+  /**
+   * Get the restaurant operating hours for the supplied date
+   * @param {moment} date
+   */
+  async getRestaurantOperatingHoursForDate(date) {
+    return this.cache.wrap(`restaurant_${date.format('YYYY-MM-DD')}`, async () => {
+      return await this._getRestaurantOperatingHoursForDate(date);
+    }, 1000 * 60 * 60 * 6); // cache for 6 hours
+  }
+
+  /**
    * Get Operating Calendar for this park
    * @return{object} Object keyed to dates in YYYY-MM-DD format.
    * Each date entry will contain an array of operating hours.

--- a/lib/parks/shdr/shanghaidisneyresort.js
+++ b/lib/parks/shdr/shanghaidisneyresort.js
@@ -302,7 +302,7 @@ export class ShanghaiDisneylandPark extends Park {
     tags.push({
       type: tagType.mayGetWet,
       value: attr.policies && (attr.policies.find((x) =>
-         x?.descriptions && x.descriptions.length > 0 && (x.descriptions[0].text.indexOf('You may get wet.') >= 0),
+        x?.descriptions && x.descriptions.length > 0 && (x.descriptions[0].text.indexOf('You may get wet.') >= 0),
       ) !== undefined),
     });
 
@@ -363,7 +363,7 @@ export class ShanghaiDisneylandPark extends Park {
           'GET',
           `${this.config.apiBase}explorer-service/public/ancestor-activities-schedules/shdr;entityType=destination`,
           {
-            filters: 'resort,theme-park,water-park,restaurant,Attraction',
+            filters: 'resort,theme-park,water-park,restaurant,Attraction,Entertainment',
             startDate: todaysDate.format('YYYY-MM-DD'),
             endDate: endOfTarget.format('YYYY-MM-DD'),
             region: 'cn',
@@ -449,7 +449,48 @@ export class ShanghaiDisneylandPark extends Park {
           status: scheduleType.operating,
         };
       } else {
-        console.trace(sched);
+        console.trace(todaysSchedule);
+        this.emit('error', new Error(`Unknown SHDR operating type ${todaysSchedule.type}`));
+      }
+    }).filter((x) => x !== undefined);
+  }
+
+  /**
+   * Return entertainment schedule for today
+   */
+  async _getEntertainmentForToday() {
+    const cal = await this._getUpcomingSchedule();
+
+    const date = moment();
+    const dateString = date.format('YYYY-MM-DD');
+    return cal.activities.map((entity) => {
+      const entityInfo = this.extractEntityData(entity.id);
+
+      if (entityInfo.entityType !== 'Entertainment' || !entity.schedule) return;
+
+      const todaysSchedule = entity.schedule.schedules.find((x) => x.date === dateString);
+
+      if (!todaysSchedule) {
+        return;
+      }
+
+      const timeFormat = 'YYYY-MM-DDTHH:mm:ss';
+      if (todaysSchedule.type === 'Operating' || todaysSchedule.type === 'Performance Time') {
+        return {
+          entertainmentID: entityInfo.id,
+          startTime: moment.tz(
+              `${dateString}T${todaysSchedule.startTime}`,
+              timeFormat,
+              this.config.timezone).format(),
+          endTime: moment.tz(
+              `${dateString}T${todaysSchedule.endTime}`,
+              timeFormat,
+              this.config.timezone).format(),
+        };
+      } else if (todaysSchedule.type === 'Refurbishment') {
+
+      } else {
+        console.trace(todaysSchedule);
         this.emit('error', new Error(`Unknown SHDR operating type ${todaysSchedule.type}`));
       }
     }).filter((x) => x !== undefined);

--- a/lib/parks/shdr/shanghaidisneyresort.js
+++ b/lib/parks/shdr/shanghaidisneyresort.js
@@ -413,6 +413,48 @@ export class ShanghaiDisneylandPark extends Park {
     });
   }
 
+
+  /**
+     * Return restaurant operating hours for the supplied date
+     * @param {moment} date
+     */
+  async _getRestaurantOperatingHoursForDate(date) {
+    const cal = await this._getUpcomingSchedule();
+
+    const dateString = date.format('YYYY-MM-DD');
+    return cal.activities.map((entity) => {
+      const entityInfo = this.extractEntityData(entity.id);
+
+      if (entityInfo.entityType !== 'restaurant' || !entity.schedule) return;
+
+      const todaysSchedule = entity.schedule.schedules.find((x) => x.date === dateString);
+
+      if (!todaysSchedule) {
+        return {
+          restaurantID: entityInfo.id,
+          openingTime: 0,
+          closingTime: 0,
+          status: statusType.closed,
+        };
+      }
+
+      const timeFormat = 'YYYY-MM-DDTHH:mm:ss';
+
+      if (todaysSchedule.type === 'Operating') {
+        return {
+          restaurantID: entityInfo.id,
+          // eslint-disable-next-line max-len
+          openingTime: moment.tz(`${dateString}T${todaysSchedule.startTime}`, timeFormat, this.config.timezone).format(),
+          closingTime: moment.tz(`${dateString}T${todaysSchedule.endTime}`, timeFormat, this.config.timezone).format(),
+          status: scheduleType.operating,
+        };
+      } else {
+        console.trace(sched);
+        this.emit('error', new Error(`Unknown SHDR operating type ${todaysSchedule.type}`));
+      }
+    }).filter((x) => x !== undefined);
+  }
+
   /**
    * Dump the SHDR database to a buffer
    * @return {buffer}

--- a/lib/parks/tdr/tokyodisneyresort.js
+++ b/lib/parks/tdr/tokyodisneyresort.js
@@ -395,6 +395,44 @@ export class TokyoDisneyResortPark extends Park {
     if (!cal) return undefined;
     return cal;
   }
+
+  /**
+   * Fecth the actual entertainment data
+   */
+  async fetchEntertainmentData() {
+    const resp = await this.http(
+        'GET',
+        `${this.config.apiBase}/rest/v2/facilities/conditions`,
+    );
+
+    return resp.body.entertainments;
+  }
+
+  /**
+   * Return entertainment schedule for today
+   */
+  async _getEntertainmentForToday() {
+    const cal = await this.fetchEntertainmentData();
+    if (!cal) return undefined;
+
+    const momentParseFormat = 'YYYY-MM-DDTHH:mm';
+
+    return cal.map((entry) => {
+      return entry.operatings.map((entertainmentSchedule) => {
+        return {
+          entertainmentID: entry.facilityCode,
+          startTime: moment.tz(
+              entertainmentSchedule.startAt,
+              momentParseFormat,
+              this.config.timezone).format(),
+          endTime: moment.tz(
+              entertainmentSchedule.startAt,
+              momentParseFormat,
+              this.config.timezone).format(),
+        };
+      });
+    }).flatMap((x) => x);
+  }
 }
 
 export default TokyoDisneyResortPark;

--- a/lib/parks/tdr/tokyodisneyresort.js
+++ b/lib/parks/tdr/tokyodisneyresort.js
@@ -346,6 +346,55 @@ export class TokyoDisneyResortPark extends Park {
 
     return undefined;
   }
+
+  /**
+   * Fetch the restaurant operating hours
+   */
+  async fetchRestaurantOperatingHours() {
+    const resp = await this.http(
+        'GET',
+        `${this.config.apiBase}/rest/v2/facilities/conditions`,
+    );
+
+    return resp.body.restaurants.map((restaurant) => {
+      // console.log(restaurant);
+      if (!restaurant.operatings || restaurant.operatings.length === 0) {
+        return {
+          restaurantID: restaurant.facilityCode,
+          openingTime: 0,
+          closingTime: 0,
+          status: statusType.closed,
+        };
+      }
+
+      // TODO: restaurant.facilityStatus check needed?
+      const momentParseFormat = 'YYYY-MM-DDTHH:mm';
+      const schedule = restaurant.operatings[0];
+
+      return {
+        restaurantID: restaurant.facilityCode,
+        openingTime: moment.tz(
+            schedule.startAt,
+            momentParseFormat,
+            this.config.timezone).format(),
+        closingTime: moment.tz(
+            schedule.endAt,
+            momentParseFormat,
+            this.config.timezone).format(),
+        status: statusType.operating,
+      };
+    });
+  }
+
+  /**
+     * Return restaurant operating hours for the supplied date
+     * @param {moment} date
+     */
+  async _getRestaurantOperatingHoursForDate(date) {
+    const cal = await this.fetchRestaurantOperatingHours();
+    if (!cal) return undefined;
+    return cal;
+  }
 }
 
 export default TokyoDisneyResortPark;

--- a/lib/parks/universal/universalstudios.js
+++ b/lib/parks/universal/universalstudios.js
@@ -388,6 +388,47 @@ export class UniversalParkBase extends Park {
 
     return ret;
   }
+
+  /**
+   * Get entertainment schedule from API
+   */
+  async getEntertainment() {
+    return await this.cache.wrap('entertainment_data', async () => {
+      const resp = await this.http('GET', `${this.config.baseURL}/pointsofinterest/shows/showtimes`, {
+        city: this.config.city,
+        pageSize: 'All',
+      });
+      return resp.body;
+    }, 1000 * 60 * 60 * 24); // 1 day
+  }
+
+  /**
+   * Return entertainment schedule for today
+   */
+  async _getEntertainmentForToday() {
+    const cal = await this.getEntertainment();
+
+    if (cal === undefined) return undefined;
+    const date = moment();
+    const dateString = date.format('YYYY-MM-DD');
+    const momentParseFormat = 'YYYY-MM-DDTHH:mm';
+
+    return cal.Results.map((entry) => {
+      return entry.StartTimes.map((startTime) => {
+        return {
+          entertainmentID: entry.Key,
+          startTime: moment.tz(
+              `${dateString}T${startTime}`,
+              momentParseFormat,
+              this.config.timezone).format(),
+          endTime: moment.tz(
+              `${dateString}T${startTime}`,
+              momentParseFormat,
+              this.config.timezone).format(),
+        };
+      });
+    }).flatMap((x) => x);
+  }
 }
 
 export default UniversalParkBase;

--- a/lib/parks/wdw/waltdisneyworldbase.js
+++ b/lib/parks/wdw/waltdisneyworldbase.js
@@ -222,6 +222,26 @@ export class DisneyPark extends Park {
 
     return undefined;
   }
+
+  /**
+   * Return entertainment schedule for today
+   */
+  async _getEntertainmentForToday() {
+    const today = await this.db.getByChannel(
+        `${this.config.resort_id}.today.1_0`,
+    );
+
+    // TODO: Check if id filter is correct & add filter to this.config.park_id
+    return today.filter((entry) => entry.id === 'Entertainment' && entry.scheduleType !== 'Closed')
+        .map((entertainmentEntry) => {
+          const entityID = getEntityID(entertainmentEntry.facilityId);
+          return {
+            entertainmentID: entityID,
+            startTime: entertainmentEntry.startTime,
+            endTime: entertainmentEntry.endTime,
+          };
+        });
+  }
 }
 
 export default DisneyPark;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themeparks/parksapi",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@themeparks/parksapi",
   "type": "module",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "description": "",
   "engines": {
     "npm": ">=6",


### PR DESCRIPTION
Added entertainment schedule for the following theme parks:

- Disneyland Paris
- Efteling
- Shanghai Disneyland
- Tokyo Disney Resort
- Universal Hollywood
- Universal Orlando

The following theme parks are implemented, but needs to be tested:
- Disneyland
- HongKong Disneyland
- Walt Disney World

The following theme parks aren't implemented, because of the current situation (can't be tested):
- Europa Park