### PR TITLE
Fix mismatched Universal special status codes

### DIFF
--- a/lib/parks/universal/universal.js
+++ b/lib/parks/universal/universal.js
@@ -344,29 +344,32 @@ export class UniversalResortBase extends Destination {
           queue = queueType.returnTime;
           break;
         case -8:
-          // not open yet
+          // "coming soon"
           status = statusType.closed;
           postWaitTime = null;
           break;
         case -7:
           // "ride now"
+          //  fallthrough to default "operating" state
           break;
         case -6:
+          // not open yet
         case -5:
-          // "closed inside of operating hours", not sure what that means, but it's closed
+          // "at capactity"
           status = statusType.closed;
           postWaitTime = null;
           break;
         case -4:
-        case -3:
           // bad weather
+        case -2:
+          // "Delayed"
           status = statusType.down;
           postWaitTime = null;
           break;
         case -1:
-        // not open yet (too early)
-        case -2:
-          // "delayed", but expected to open
+          // not open yet (too early)
+        case -3:
+          // closed, but expected to open during operating hours as normal
           status = statusType.closed;
           postWaitTime = null;
           break;


### PR DESCRIPTION
It seems like the base Universal class has the wrong special status codes, which means when you call the resort level endpoints it's not showing down or closed correctly.