### PR TITLE
Ensure closed statuses are passed through for Phantasialand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test*.js
 !test.js
 *.har
 .vscode
+.idea
 *.themepark
 menus/
 scan.js

--- a/lib/parks/phantasialand/phantasialand.js
+++ b/lib/parks/phantasialand/phantasialand.js
@@ -324,6 +324,10 @@ export class Phantasialand extends Destination {
         };
       }
 
+      if (x.waitTime === null && x.showTimes === null && x.open !== null) {
+        liveData.status = x.open ? statusType.operating : statusType.closed;
+      }
+
       return liveData;
     }).filter((x) => !!x);
   }


### PR DESCRIPTION
Attractions with no waitTime attribute were incorrectly marked as operating, even when they had the open property marked as false.

## Testing 
Example closed attraction from Phantasialand API:
```json
{
  "open": false,
  "poiId": "19",
  "closing": null,
  "opening": "2022-11-18 11:00:00",
  "showTimes": null,
  "waitTime": null,
  "updatedAt": "2022-11-19T15:00:40.000Z",
  "messages": {
    "de": [
      "Wartebereich geschlossen",
      "-"
    ],
    "en": [
      "waiting area closed",
      "-"
    ],
    "fr": [
      "L'aire d'attente fermée",
      "-"
    ],
    "nl": [
      "ingang gesloten",
      "-"
    ]
  },
  "_primaryText": {
    "de": "__Wartebereich geschlossen__",
    "en": "__waiting area closed__",
    "fr": "__L'aire d'attente fermée__",
    "nl": "__ingang gesloten__"
  },
  "_secondaryText": {
    "de": null,
    "en": null,
    "fr": null,
    "nl": null
  },
  "createdAt": "2022-11-19T15:06:03.000Z",
  "updatedRow": "2022-11-19T15:06:03.000Z"
}
```

### Behaviour before:
Run test script
```bash
$ /usr/local/bin/node /Users/zachary/WebstormProjects/parksapi/test.js
```

Check contents of `testout_LiveData.json`:
```json
...
    {
        "_id": "19",
        "status": "OPERATING"
    },
...
```
### Behaviour after:
Run test script
```bash
$ /usr/local/bin/node /Users/zachary/WebstormProjects/parksapi/test.js
```

Check contents of `testout_LiveData.json`:
```json
...
    {
        "_id": "19",
        "status": "CLOSED"
    },
...
```
