### PR TITLE
Fix changes in V2 of EP-API for live opening times

### DIFF
--- a/lib/parks/europa/europapark.js
+++ b/lib/parks/europa/europapark.js
@@ -406,13 +406,13 @@ export class EuropaPark extends Destination {
     // fetch live opening times to inject on top
     if (parkConfig.scope === 'europapark') { // only do this for the actual theme park
       const livedata = await this.db.getLiveCalendar();
-      if (livedata?.opentime?.today) {
-        const date = livedata.opentime.today.date.substring(0, 10);
+      if (livedata?.today) {
+        const date = livedata.today.date.substring(0, 10);
         const matchingDates = times.find((x) => x.date === date);
         if (matchingDates) {
           // replace existing opening times with live data
-          matchingDates.openingTime = livedata.opentime.today.start;
-          matchingDates.closingTime = livedata.opentime.today.end;
+          matchingDates.openingTime = livedata.today.start;
+          matchingDates.closingTime = livedata.today.end;
         }
       }
     }


### PR DESCRIPTION
In V1 the "today"-array was inside the "opentime"-array. With V2 the "opentime"-array was removed.
The live opening times for today and yesterday were not updated. I think these change should fix this.