### PR TITLE
Revert change for DLP and "Refurbishment"

### DIFF
--- a/lib/parks/dlp/disneylandparis.js
+++ b/lib/parks/dlp/disneylandparis.js
@@ -722,7 +722,8 @@ export class DisneylandParis extends Destination {
         live.status = statusType.down;
       } else if (time.status === 'REFURBISHMENT') {
         // it may say "refurbishment", but the DLP app actually displays this as "Closed all day"
-        live.status = statusType.refurbishment;
+        //live.stats= statusType.refurbishment
+        live.status = statusType.closed;
       } else if (time.status === 'CLOSED' || time.status === null) {
         live.status = statusType.closed;
       }


### PR DESCRIPTION
We can improve the detection of the Refurbishment :  Refurbishment has no operating schedule
Closed rides have an operating schedule