### PR TITLE
Hardcode Parc Asterix geolocation if api don't return it

### DIFF
--- a/lib/parks/parcasterix/parcasterix.js
+++ b/lib/parks/parcasterix/parcasterix.js
@@ -190,8 +190,8 @@ export class ParcAsterix extends Destination {
         name: 'Parc Asterix',
         entityType: entityType.park,
         location: {
-          longitude: parkData.data.configuration.longitude || 49.136750,
-          latitude: parkData.data.configuration.latitude || 2.573816,
+          longitude: parkData.data.configuration.longitude || 2.573816,
+          latitude: parkData.data.configuration.latitude || 49.136750,
         },
       }
     ];

--- a/lib/parks/parcasterix/parcasterix.js
+++ b/lib/parks/parcasterix/parcasterix.js
@@ -190,8 +190,8 @@ export class ParcAsterix extends Destination {
         name: 'Parc Asterix',
         entityType: entityType.park,
         location: {
-          longitude: parkData.data.configuration.longitude,
-          latitude: parkData.data.configuration.latitude,
+          longitude: parkData.data.configuration.longitude || 49.136750,
+          latitude: parkData.data.configuration.latitude || 2.573816,
         },
       }
     ];


### PR DESCRIPTION
If the API don't return the correct geolocation data or if the API don't respond this element, instead of a null value, it get the hardcoded one.