### PR TITLE
Adding Geolocation data for parks

### DIFF
--- a/lib/parks/bellewaerde/walibiholland.js
+++ b/lib/parks/bellewaerde/walibiholland.js
@@ -106,7 +106,7 @@ export class WalibiHolland extends Destination {
         entityType: entityType.park,
         location: {
           longitude: this.config.longitude,
-          latittude: this.config.latitude
+          latitude: this.config.latitude
         }
       }
     ];

--- a/lib/parks/bellewaerde/walibiholland.js
+++ b/lib/parks/bellewaerde/walibiholland.js
@@ -17,6 +17,8 @@ export class WalibiHolland extends Destination {
     options.apiShortcode = options.apiShortcode || 'who';
     options.culture = options.culture || 'en';
 
+    options.latitude = options.latitude || 52.440140;
+    options.longitude = options.longitude || 5.767490;
     super(options);
 
     if (!this.config.apiKey) throw new Error('Missing Walibi Holland API key');
@@ -102,6 +104,10 @@ export class WalibiHolland extends Destination {
         _parentId: this.config.destinationSlug,
         name: this.config.name,
         entityType: entityType.park,
+        location: {
+          longitude: this.config.longitude,
+          latittude: this.config.latitude
+        }
       }
     ];
   }
@@ -316,6 +322,9 @@ export class Bellewaerde extends WalibiHolland {
     options.culture = options.culture || 'nl';
 
     options.timezone = options.timezone || 'Europe/Brussels';
+
+    options.latitude = 50.84647412354691;
+    options.longitude = 2.9502020602188184;
 
     super(options);
   }

--- a/lib/parks/efteling/efteling.js
+++ b/lib/parks/efteling/efteling.js
@@ -329,6 +329,10 @@ export class Efteling extends Destination {
         _parentId: destination._id,
         slug: 'efteling',
         entityType: entityType.park,
+        location: {
+          latitude: 51.649515,
+          longitude: 5.043776
+        }
       },
     ];
   }

--- a/lib/parks/hansapark/hansapark.js
+++ b/lib/parks/hansapark/hansapark.js
@@ -161,6 +161,10 @@ export class HansaPark extends Destination {
         slug: 'hansa-park',
         name: this.config.name,
         entityType: entityType.park,
+        location: {
+          longitude: 10.77961,
+          latitude: 54.0747402
+        }
       }
     ];
   }

--- a/lib/parks/herschend/herschendparks.js
+++ b/lib/parks/herschend/herschendparks.js
@@ -30,6 +30,10 @@ export class HerschendDestination extends Destination {
 
     options.cacheVersion = options.cacheVersion || '1';
 
+    //Geolocation datas
+    options.latitude = options.latitude || '';
+    options.longitude = options.longitude || '';
+
     super(options);
 
     if (!this.config.destinationId) throw new Error('Missing destinationId');
@@ -174,6 +178,10 @@ export class HerschendDestination extends Destination {
         name: this.config.name,
         slug: this.config.parkId,
         entityType: entityType.park,
+        location: {
+          longitude: options.longitude,
+          latitude: options.latitude
+        }
       }
     ];
   }
@@ -394,6 +402,9 @@ export class Dollywood extends HerschendDestination {
     options.crmDiningId = "9d3de6ae-ebb1-4cb8-9423-bee864daef3c";
     options.crmShowId = "b9acfd27-0545-4bb2-a6e8-072fda3b06dd";
 
+    options.longitude = -83.530368
+    options.latitude = 35.794496
+
     super(options);
   }
 }
@@ -410,6 +421,9 @@ export class SilverDollarCity extends HerschendDestination {
     options.crmAttractionsId = "6cbebd47-facc-4c26-b1b2-4e0da4de0e6e";
     options.crmDiningId = "31b3a1c6-93cc-4b93-b84e-bf512afe770c";
     options.crmShowId = "58a4e3a3-c889-4130-93d1-5ba802442444";
+
+    options.latitude = 36.604152;
+    options.longitude = -93.29991;
 
     super(options);
   }

--- a/lib/parks/herschend/herschendparks.js
+++ b/lib/parks/herschend/herschendparks.js
@@ -179,8 +179,8 @@ export class HerschendDestination extends Destination {
         slug: this.config.parkId,
         entityType: entityType.park,
         location: {
-          longitude: options.longitude,
-          latitude: options.latitude
+          longitude: this.config.longitude,
+          latitude: this.config.latitude
         }
       }
     ];

--- a/lib/parks/liseberg/liseberg.js
+++ b/lib/parks/liseberg/liseberg.js
@@ -70,6 +70,10 @@ export class Liseberg extends Destination {
         slug: 'lisebergpark',
         name: 'Liseberg',
         entityType: entityType.park,
+        location: {
+          latitude: 57.6945173,
+          longitude: 11.9936954
+        }
       }
     ];
   }

--- a/lib/parks/parcasterix/parcasterix.js
+++ b/lib/parks/parcasterix/parcasterix.js
@@ -190,8 +190,8 @@ export class ParcAsterix extends Destination {
         name: 'Parc Asterix',
         entityType: entityType.park,
         location: {
-          longitude: parkData.data.configuration.longitude || 49.136750,
-          latitude: parkData.data.configuration.latitude || 2.573816,
+          longitude: parkData.data.configuration.longitude || 2.573816,
+          latitude: parkData.data.configuration.latitude || 49.136750,
         },
       }
     ];

--- a/lib/parks/parcasterix/parcasterix.js
+++ b/lib/parks/parcasterix/parcasterix.js
@@ -190,8 +190,8 @@ export class ParcAsterix extends Destination {
         name: 'Parc Asterix',
         entityType: entityType.park,
         location: {
-          longitude: parkData.data.configuration.longitude,
-          latitude: parkData.data.configuration.latitude,
+          longitude: parkData.data.configuration.longitude || 49.136750,
+          latitude: parkData.data.configuration.latitude || 2.573816,
         },
       }
     ];

--- a/lib/parks/phantasialand/phantasialand.js
+++ b/lib/parks/phantasialand/phantasialand.js
@@ -203,6 +203,10 @@ export class Phantasialand extends Destination {
         slug: 'phantasialandpark',
         name: 'Phantasialand',
         entityType: entityType.park,
+        location: {
+          longitude:6.8792554,
+          latitude:50.8005075
+        }
       }
     ];
   }

--- a/lib/parks/phantasialand/phantasialand.js
+++ b/lib/parks/phantasialand/phantasialand.js
@@ -204,8 +204,8 @@ export class Phantasialand extends Destination {
         name: 'Phantasialand',
         entityType: entityType.park,
         location: {
-          longitude:6.8792554,
-          latitude:50.8005075
+          longitude: 6.8792554,
+          latitude: 50.8005075
         }
       }
     ];
@@ -245,9 +245,9 @@ export class Phantasialand extends Destination {
   async buildShowEntities() {
     return await this._buildEntitiesFromCategory({
       $or: [
-        { category: 'SHOWS' },
-        { category: 'THE_SIX_DRAGONS' },
-        { category: 'THEATER' },
+        {category: 'SHOWS'},
+        {category: 'THE_SIX_DRAGONS'},
+        {category: 'THEATER'},
       ],
     }, {
       entityType: entityType.show,
@@ -260,8 +260,8 @@ export class Phantasialand extends Destination {
   async buildRestaurantEntities() {
     return await this._buildEntitiesFromCategory({
       $or: [
-        { category: 'RESTAURANTS_AND_SNACKS' },
-        { category: 'PHANTASIALAND_HOTELS_RESTAURANTS' },
+        {category: 'RESTAURANTS_AND_SNACKS'},
+        {category: 'PHANTASIALAND_HOTELS_RESTAURANTS'},
       ],
       tags: {
         $elemMatch: {

--- a/lib/parks/portaventura/portaventura.js
+++ b/lib/parks/portaventura/portaventura.js
@@ -176,6 +176,10 @@ export class PortAventuraWorld extends Destination {
         _parentId: this.destinationId,
         name: x.attributes.name,
         entityType: entityType.park,
+        location: {
+          latitude: 41.0986786,
+          longitude: 1.151773
+        }
       };
     });
   }

--- a/lib/parks/toverland/toverland.js
+++ b/lib/parks/toverland/toverland.js
@@ -130,6 +130,10 @@ export class Toverland extends Destination {
         name: this.config.name,
         slug: 'toverland',
         entityType: entityType.park,
+        location: {
+          latitude: 51.3982068,
+          longitude: 5.9838255
+        }
       }
     ];
   }


### PR DESCRIPTION
Geolocation data added for : 
- Walibi Holland
- Silver Dollar City
- Dollywood
- Phantasialand
- Hansa-Park
- Liseberg
- Efteling
- Toverland
- Parc Asterix (Improved, fallback on hardcoded if api don't return it) (Previous Commit and PR)
- PortAventura World
- Bellewaerde

I don't do for Tokyo Disney Resort, if you want to enjoy a ride :)