### PR TITLE
Updated Six Flags api to v3, excluded parkId 49

### DIFF
--- a/lib/parks/sixflags/sixflags.js
+++ b/lib/parks/sixflags/sixflags.js
@@ -64,19 +64,19 @@ export class SixFlags extends Destination {
 
   async fetchAllDestinations() {
     '@cache|1d'; // cache for 1 day
-    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v1/park`);
+    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v3/park`);
     return resp.body;
   }
 
   async fetchRidePOI({parkID}) {
     '@cache|1d'; // cache for 1 day
-    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v1/park/${parkID}/ride`);
+    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v3/park/${parkID}/ride`);
     return resp.body;
   }
 
   async fetchRestaurantPOI({parkID}) {
     '@cache|1d'; // cache for 1 day
-    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v1/park/${parkID}/restaurant`);
+    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v3/park/${parkID}/restaurant`);
     return resp.body;
   }
 
@@ -85,19 +85,19 @@ export class SixFlags extends Destination {
     // TODO - fix show times
     return {};
 
-    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v1/park/${parkID}/entertainment`);
+    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v3/park/${parkID}/entertainment`);
     return resp.body;
   }
 
   async fetchRideStatus({parkID}) {
     '@cache|60'; // cache for 1 minute
-    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v1/park/${parkID}/rideStatus`);
+    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v3/park/${parkID}/rideStatus`);
     return resp.body;
   }
 
   async fetchParkHours({parkID}) {
     '@cache|1h'; // cache for 1 hour
-    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v1/park/${parkID}/hours`);
+    const resp = await this.http.get(`${this.config.baseURL}/mobileapi/v3/park/${parkID}/hours`);
     return resp.body;
   }
 
@@ -151,7 +151,8 @@ export class SixFlags extends Destination {
   async _getParkData() {
     '@cache|1d'; // cache for 1 day
     const destinations = await this.fetchAllDestinations();
-    return destinations.parks.filter((x) => !x.isWaterPark);
+    // Exlcudes water parks and Six Flags Wild Safari (id: 49)
+    return destinations.parks.filter((x) => !x.isWaterPark && x.parkId !== 49);
   }
 
   async _getParkIDs() {


### PR DESCRIPTION
- Excluded Park id 49 (Six Flags Wild Safari)
It's resulting data does not contain the "rides" key and causing the buildAttractionEntities function to fail

- Updated api version to v3
Confirmed this is the current version used in the Six Flags mobile app