### PR TITLE
Fix baseURL for Plopsaland de Panne and HolidayPark

### DIFF
--- a/lib/parks/plopsaland/plopsa.js
+++ b/lib/parks/plopsaland/plopsa.js
@@ -354,7 +354,7 @@ export class Plopsaland extends PlopsaBase {
   constructor(config = {}) {
     config.destinationSlug = 'plopsaland-de-panne';
     config.parkSlug = 'plopsaland';
-    config.baseURL = 'https://www.plopsalanddepanne.be/';
+    config.baseURL = 'https://www.old.plopsa.com/';
     config.baseLang = 'nl';
     config.name = 'Plopsaland De Panne';
     config.parkLatitude = 51.0808363;
@@ -368,7 +368,7 @@ export class HolidayPark extends PlopsaBase {
   constructor(config = {}) {
     config.destinationSlug = 'holiday-park';
     config.parkSlug = 'holidaypark';
-    config.baseURL = 'https://www.holidaypark.de/';
+    config.baseURL = 'https://www.old.plopsa.com/';
     config.baseLang = 'de';
     config.name = 'Holiday Park';
     config.parkLatitude = 49.3175972;


### PR DESCRIPTION
The waitTime was frozen because Plopsa update their API endpoint URL.

This current value was given by Proxyman and the Plopsaland de Panne app.