### PR TITLE
fix: integrate venue-status endpoint for accurate ride status

### DIFF
--- a/lib/parks/attractionsio/attractionsiov3.js
+++ b/lib/parks/attractionsio/attractionsiov3.js
@@ -129,6 +129,12 @@ export class AttractionsIOV3 extends Destination {
     return response.body;
   }
 
+  async fetchVenueStatus() {
+    '@cache|1'; // cache for 1 minute
+    const response = await this.http('GET', `${this.config.realTimeBaseURL}/venue-status/park/${this.config.parkId}`);
+    return response.body;
+  }
+
   async fetchParkConfig() {
     '@cache|1d'; // cache for 1 day
     const url = this.config.configPath ? `${this.config.realTimeBaseURL}/${this.config.configPath}` : `${this.config.realTimeBaseURL}/config/park/${this.config.parkId}`;
@@ -344,7 +350,25 @@ export class AttractionsIOV3 extends Destination {
    * @inheritdoc
    */
   async buildEntityLiveData() {
-    const liveData = await this.fetchWaitTimes();
+    // Fetch both wait times and venue status
+    const [liveData, venueStatusData] = await Promise.all([
+      this.fetchWaitTimes(),
+      this.fetchVenueStatus().catch(() => null) // Don't fail if venue status is unavailable
+    ]);
+
+    // Create a lookup map for venue status by ID
+    const venueStatusMap = {};
+    if (venueStatusData && venueStatusData.venues) {
+      venueStatusData.venues.forEach(venue => {
+        if (venue.details) {
+          venue.details.forEach(detail => {
+            if (detail.fimsId) {
+              venueStatusMap[detail.fimsId.toUpperCase()] = detail.status;
+            }
+          });
+        }
+      });
+    }
 
     const entries = liveData.venues.reduce((x, venue) => {
       x.push(...venue.details);
@@ -352,17 +376,26 @@ export class AttractionsIOV3 extends Destination {
     }, []);
 
     return entries.map((x) => {
+      const fimsId = `${x.fimsId}`.toUpperCase();
+      
       const entry = {
-        _id: `${x.fimsId}`.toUpperCase(),
+        _id: fimsId,
         status: statusType.closed,
       };
 
+      // Check venue status first - this is the authoritative source for operational status
+      const venueStatus = venueStatusMap[fimsId];
+      const isOpen = venueStatus === 'Opened';
+      
       // add standby time (if present)
       if (x.regularWaittime && x.regularWaittime.createdDateTime) {
         if (!entry.queue) {
           entry.queue = {};
         }
-        entry.status = statusType.operating;
+        // Only set to operating if venue status says it's open (or no venue status available)
+        if (isOpen || venueStatus === undefined) {
+          entry.status = statusType.operating;
+        }
         entry.queue[queueType.standBy] = {
           waitTime: x.regularWaittime.waitTime || 0,
         };
@@ -373,11 +406,19 @@ export class AttractionsIOV3 extends Destination {
         if (!entry.queue) {
           entry.queue = {};
         }
-        entry.status = statusType.operating;
+        // Only set to operating if venue status says it's open (or no venue status available)
+        if (isOpen || venueStatus === undefined) {
+          entry.status = statusType.operating;
+        }
         // paid standby type, basically normal queueing, but you get your own line
         entry.queue[queueType.paidStandBy] = {
           waitTime: x.fastlaneWaittime.waitTime || 0,
         };
+      }
+
+      // If venue status indicates closed, override status regardless of wait time data
+      if (venueStatus && venueStatus !== 'Opened') {
+        entry.status = statusType.closed;
       }
 
       return entry;


### PR DESCRIPTION
### Problem
The current attractionsiov3 implementation only uses the `wait-times` endpoint to determine ride operational status. When rides close due to weather, maintenance or the park is closed, they continue to show their previous wait times instead of reflecting that they are actually closed.

### Solution
This PR adds integration with the `venue-status` endpoint to get real-time operational status:

  - **Added `fetchVenueStatus()` method** - Calls `/venue-status/park/{parkId}` endpoint
  - **Enhanced `buildEntityLiveData()` method** - Prioritizes venue status over wait time data
  - **Graceful fallback** - If venue-status API fails, falls back to original behavior
  - **Preserves wait time data** - Still shows last known wait times even when rides are closed
  
### Changes Made
  - Modified `/lib/parks/attractionsio/attractionsiov3.js`
  - Only affects AttractionsIOV3-based parks (Cedar Fair parks)
  - No breaking changes to existing API
  
### Testing
  Tested with:
  - Cedar Point (Park ID: 1)
  - Kings Dominion (Park ID: 25)
  - Canada's Wonderland (Park ID: 40)

All parks now correctly show rides as `CLOSED` when venue status indicates:
  - "Temp Closed"
  - "Temp Closed due Weather"
  - Any status other than "Opened"

### Before/After Example
  **Before:** Ride shows "45 minutes wait" but is actually closed due to weather
  **After:** Ride shows "CLOSED" status with last known wait time preserved