### PR TITLE
fix(dlp): align live data with legacy collector behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@themeparks/typelib": "^1.1.3",
+        "@themeparks/typelib": "^1.1.5",
         "adm-zip": "^0.5.16",
         "ajv": "^8.17.1",
         "sift": "^17.1.3",
@@ -972,9 +972,10 @@
       "license": "MIT"
     },
     "node_modules/@themeparks/typelib": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@themeparks/typelib/-/typelib-1.1.3.tgz",
-      "integrity": "sha512-876yxTVscmFzVYsVBggPwB+ZNFmeJn46ZCSSFV5eZhFnXtR5rsNFqa7B+RkDPef98FbWrOyAHyuS5RSc2GRMaQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@themeparks/typelib/-/typelib-1.1.5.tgz",
+      "integrity": "sha512-zxKatrGw/Dw+e+wcu0xIR1Oe0+SSSWy4pUitivW2uD/qz4eWVHNJd3NRgBEeiM8/rNtwVN4CP2dldh6hVOzXQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@themeparks/typelib": "^1.1.3",
+    "@themeparks/typelib": "^1.1.5",
     "adm-zip": "^0.5.16",
     "ajv": "^8.17.1",
     "sift": "^17.1.3",

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -33,6 +33,7 @@ const IGNORE_ENTITIES = new Set([
 const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
+  'P2EA02', // Entry to World of Frozen
 ]);
 
 /** Hide rules that exclude entities from the POI list */
@@ -90,12 +91,19 @@ type DLPWaitTimeEntry = {
   entityId: string;
   type: string;
   status: string | null;
-  postedWaitMinutes: number | null;
+  // API returns numeric strings ("5", "40"); coerce via parseDLPWait before use.
+  postedWaitMinutes: string | number | null;
   singleRider?: {
     isAvailable: boolean;
-    singleRiderWaitMinutes?: number;
+    singleRiderWaitMinutes?: string | number;
   };
 };
+
+function parseDLPWait(v: unknown): number | undefined {
+  if (v === null || v === undefined || v === '') return undefined;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
 
 type DLPPremierAccessEntry = {
   attractionId: string;
@@ -317,22 +325,40 @@ export class DisneylandParis extends Destination {
           Attraction: activities(market: $market, types: "Attraction") {
             ${this.entityFields}
           }
-          Entertainment: activities(market: $market, types: "Entertainment") {
-            ${this.entityFields}
-          }
-          Restaurant: activities(market: $market, types: "Restaurant") {
-            ${this.entityFields}
-          }
-          ThemePark: activities(market: $market, types: "ThemePark") {
-            ${this.entityFields}
-          }
           DiningEvent: activities(market: $market, types: "DiningEvent") {
             ${this.entityFields}
           }
           DinnerShow: activities(market: $market, types: "DinnerShow") {
             ${this.entityFields}
           }
+          Entertainment: activities(market: $market, types: "Entertainment") {
+            ${this.entityFields}
+          }
+          Event: activities(market: $market, types: "Event") {
+            ${this.entityFields}
+          }
+          GuestService: activities(market: $market, types: "GuestService") {
+            ${this.entityFields}
+          }
+          Recreation: activities(market: $market, types: "Recreation") {
+            ${this.entityFields}
+          }
+          Resort: activities(market: $market, types: "Resort") {
+            ${this.entityFields}
+          }
+          Restaurant: activities(market: $market, types: "Restaurant") {
+            ${this.entityFields}
+          }
           Shop: activities(market: $market, types: "Shop") {
+            ${this.entityFields}
+          }
+          Spa: activities(market: $market, types: "Spa") {
+            ${this.entityFields}
+          }
+          Tour: activities(market: $market, types: "Tour") {
+            ${this.entityFields}
+          }
+          ThemePark: activities(market: $market, types: "ThemePark") {
             ${this.entityFields}
           }
         }`,
@@ -347,7 +373,7 @@ export class DisneylandParis extends Destination {
   /**
    * Get POI data (cached 12h)
    */
-  @cache({ttlSeconds: 43200})
+  @cache({ttlSeconds: 43200, cacheVersion: 2})
   async getPOIData(): Promise<Record<string, DLPPOIEntity[]>> {
     const resp = await this.fetchPOI();
     const data = await resp.json();
@@ -745,7 +771,21 @@ export class DisneylandParis extends Destination {
     const liveData: LiveData[] = [];
     const liveDataMap = new Map<string, LiveData>();
 
-    const getOrCreate = (id: string): LiveData => {
+    // Build the set of entity IDs we actually emit, so live data stays in
+    // lockstep with buildEntityList. Without this, the wait-times feed
+    // (and premier-access / virtual-queue / showtimes) leaks IDs for
+    // characters, hidden POI entries, and codes Disney returns that aren't
+    // in the public POI dataset at all.
+    const poiData = await this.getPOIData();
+    const allEntities = this.flattenPOI(poiData);
+    const filteredEntities = this.filterPOIEntities(allEntities);
+    const validEntityIds = new Set<string>();
+    for (const poi of filteredEntities) {
+      if (this.mapEntityType(poi)) validEntityIds.add(poi.id);
+    }
+
+    const getOrCreate = (id: string): LiveData | undefined => {
+      if (!validEntityIds.has(id)) return undefined;
       let entry = liveDataMap.get(id);
       if (!entry) {
         entry = {id, status: 'CLOSED'} as LiveData;
@@ -763,19 +803,20 @@ export class DisneylandParis extends Destination {
       if (IGNORE_ENTITIES.has(wt.entityId)) continue;
 
       const ld = getOrCreate(wt.entityId);
+      if (!ld) continue;
       ld.status = this.mapStatus(wt.status) as any;
 
       // Standby queue
       if (!ld.queue) ld.queue = {};
       ld.queue.STANDBY = {
-        waitTime: ld.status === 'OPERATING' ? (wt.postedWaitMinutes ?? undefined) : undefined,
+        waitTime: ld.status === 'OPERATING' ? (parseDLPWait(wt.postedWaitMinutes) ?? null) : null,
       };
 
       // Single rider
       if (wt.singleRider?.isAvailable === true) {
         ld.queue.SINGLE_RIDER = {
           waitTime: ld.status === 'OPERATING'
-            ? (wt.singleRider.singleRiderWaitMinutes ?? null)
+            ? (parseDLPWait(wt.singleRider.singleRiderWaitMinutes) ?? null)
             : null,
         };
       }
@@ -788,12 +829,16 @@ export class DisneylandParis extends Destination {
       if (!pa.attractionId) continue;
 
       const ld = getOrCreate(pa.attractionId);
+      if (!ld) continue;
       if (!ld.queue) ld.queue = {};
 
+      // DLP emits `2026-04-25T21:35:00.000+0200` (millis, no offset colon).
+      // Wrap in Date so the framework re-emits the canonical
+      // `2026-04-25T21:35:00+02:00` form rather than passing through verbatim.
       ld.queue.PAID_RETURN_TIME = this.buildPaidReturnTimeQueue(
         pa.available ? 'AVAILABLE' : 'FINISHED',
-        pa.nextTimeSlotStartDateTime || null,
-        pa.nextTimeSlotEndDateTime || null,
+        pa.nextTimeSlotStartDateTime ? new Date(pa.nextTimeSlotStartDateTime) : null,
+        pa.nextTimeSlotEndDateTime ? new Date(pa.nextTimeSlotEndDateTime) : null,
         'EUR',
         pa.price != null ? Math.round(pa.price * 100) : null,
       );
@@ -818,6 +863,7 @@ export class DisneylandParis extends Destination {
       );
 
       const ld = getOrCreate(q.queueContentId);
+      if (!ld) continue;
       if (!ld.queue) ld.queue = {};
 
       if (allFinished || !activeWave) {
@@ -829,8 +875,8 @@ export class DisneylandParis extends Destination {
         // wiki can render the upcoming slot.
         ld.queue.RETURN_TIME = this.buildReturnTimeQueue(
           'AVAILABLE',
-          activeWave.openAt || null,
-          activeWave.closedAt || null,
+          activeWave.openAt ? new Date(activeWave.openAt) : null,
+          activeWave.closedAt ? new Date(activeWave.closedAt) : null,
         );
       }
     }
@@ -877,6 +923,7 @@ export class DisneylandParis extends Destination {
           }
         } else {
           const ld = getOrCreate(sched.id);
+          if (!ld) continue;
           ld.status = 'OPERATING' as any;
           ld.showtimes = showtimes;
         }

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -105,6 +105,19 @@ function parseDLPWait(v: unknown): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+/**
+ * Parse a DLP API timestamp like `2026-04-25T21:35:00.000+0200` into a Date.
+ * Returns null for empty/invalid input. The non-canonical offset format
+ * (`+0200` without a colon) is accepted by V8 but is not RFC 3339 — guard
+ * against runtimes that reject it by falling back to null rather than
+ * emitting an Invalid Date through the queue helpers.
+ */
+function parseDLPDate(v: string | null | undefined): Date | null {
+  if (!v) return null;
+  const d = new Date(v);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
 type DLPPremierAccessEntry = {
   attractionId: string;
   available: boolean;
@@ -638,6 +651,18 @@ export class DisneylandParis extends Destination {
   }
 
   /**
+   * Resolve POI down to the entities we actually emit. Shared by
+   * buildEntityList and buildLiveData so the wait-times / premier-access /
+   * vqueue / showtimes paths can't surface IDs that fall outside the
+   * published POI set.
+   */
+  private async getEmittablePOIEntities(): Promise<Array<DLPPOIEntity & {category: string}>> {
+    const poiData = await this.getPOIData();
+    const allEntities = this.flattenPOI(poiData);
+    return this.filterPOIEntities(allEntities).filter((poi) => this.mapEntityType(poi) !== undefined);
+  }
+
+  /**
    * Map DLP wait time status to our status
    */
   private mapStatus(status: string | null): string {
@@ -776,13 +801,9 @@ export class DisneylandParis extends Destination {
     // (and premier-access / virtual-queue / showtimes) leaks IDs for
     // characters, hidden POI entries, and codes Disney returns that aren't
     // in the public POI dataset at all.
-    const poiData = await this.getPOIData();
-    const allEntities = this.flattenPOI(poiData);
-    const filteredEntities = this.filterPOIEntities(allEntities);
-    const validEntityIds = new Set<string>();
-    for (const poi of filteredEntities) {
-      if (this.mapEntityType(poi)) validEntityIds.add(poi.id);
-    }
+    const validEntityIds = new Set<string>(
+      (await this.getEmittablePOIEntities()).map((poi) => poi.id),
+    );
 
     const getOrCreate = (id: string): LiveData | undefined => {
       if (!validEntityIds.has(id)) return undefined;
@@ -837,8 +858,8 @@ export class DisneylandParis extends Destination {
       // `2026-04-25T21:35:00+02:00` form rather than passing through verbatim.
       ld.queue.PAID_RETURN_TIME = this.buildPaidReturnTimeQueue(
         pa.available ? 'AVAILABLE' : 'FINISHED',
-        pa.nextTimeSlotStartDateTime ? new Date(pa.nextTimeSlotStartDateTime) : null,
-        pa.nextTimeSlotEndDateTime ? new Date(pa.nextTimeSlotEndDateTime) : null,
+        parseDLPDate(pa.nextTimeSlotStartDateTime),
+        parseDLPDate(pa.nextTimeSlotEndDateTime),
         'EUR',
         pa.price != null ? Math.round(pa.price * 100) : null,
       );
@@ -875,8 +896,8 @@ export class DisneylandParis extends Destination {
         // wiki can render the upcoming slot.
         ld.queue.RETURN_TIME = this.buildReturnTimeQueue(
           'AVAILABLE',
-          activeWave.openAt ? new Date(activeWave.openAt) : null,
-          activeWave.closedAt ? new Date(activeWave.closedAt) : null,
+          parseDLPDate(activeWave.openAt ?? null),
+          parseDLPDate(activeWave.closedAt ?? null),
         );
       }
     }


### PR DESCRIPTION
## Summary

Audit found local DLP output diverged from the wiki/legacy collector in four ways. This PR closes all of them.

- **waitTime always null on operating rides.** The DLP API returns `postedWaitMinutes` / `singleRiderWaitMinutes` as numeric *strings* (`"5"`, `"40"`). The TS type claimed `number | null` and the base sanitiser then dropped them as non-finite. New `parseDLPWait` helper coerces explicitly.
- **Live data leaked orphan entity IDs.** Wait-times, premier-access, virtual-queue and showtimes paths all called `getOrCreate` without checking that the ID belonged to a published, non-hidden, mappable POI entry. Now `buildLiveData` builds the same filter set as `buildEntityList` and drops anything outside it.
- **POI query missing types.** Restored `Event`, `GuestService`, `Recreation`, `Resort`, `Spa`, `Tour` to match legacy. `getPOIData` `cacheVersion` bumped to 2 since the response shape changes.
- **Premier Access date format.** Source emits `2026-04-25T21:35:00.000+0200`; wiki/legacy use `2026-04-25T21:35:00+02:00`. Wrapping the strings in `new Date()` forces the framework's canonical ISO 8601 formatter to run.

Also restored `P2EA02` (Entry to World of Frozen) in `VISIBILITY_EXCEPTIONS` for parity with legacy, and bumped `@themeparks/typelib` to 1.1.5.

## Test plan
- [x] `npm run build`
- [x] `npm test` (1070/1070)
- [x] `npm run dev -- disneylandparis` — 4/4 tests pass, 62 live items (49 OPERATING / 12 CLOSED / 1 DOWN)
- [x] `npm run audit:live -- --diff --only=disneylandparis` — no schema errors, no warnings
- [x] Deep field-level diff vs. wiki — 0 type mismatches, 0 structural diffs, only minute-by-minute snapshot drift remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)