### PR TITLE
fix(chimelong): add retries to upstream API calls

### DIFF
--- a/src/parks/chimelong/chimelong.ts
+++ b/src/parks/chimelong/chimelong.ts
@@ -169,7 +169,9 @@ export class Chimelong extends Destination {
 
   // ── HTTP Methods ─────────────────────────────────────────────
 
-  @http({cacheSeconds: 60})
+  // The Chimelong upstream returns 504 GATEWAY_TIMEOUT intermittently;
+  // the framework retries 5xx with exponential backoff when retries > 0.
+  @http({cacheSeconds: 60, retries: 3})
   async fetchWaitTimes(parkId: string): Promise<HTTPObj> {
     return {
       method: 'POST',
@@ -180,7 +182,7 @@ export class Chimelong extends Destination {
     } as any as HTTPObj;
   }
 
-  @http({cacheSeconds: 3600})
+  @http({cacheSeconds: 3600, retries: 3})
   async fetchCalendarPage(calendarURL: string): Promise<HTTPObj> {
     return {
       method: 'GET',


### PR DESCRIPTION
## Summary

The Chimelong upstream returns 504 GATEWAY_TIMEOUT intermittently — observed roughly 1 call in 5 during local testing. The framework already retries 5xx with exponential backoff, but each `@http` decorator opts in via `retries > 0` and both fetchers defaulted to 0.

Set `retries: 3` on `fetchWaitTimes` and `fetchCalendarPage` so transient upstream timeouts no longer fail the harness or collector sync.

## Test plan
- [x] `npm run build`
- [x] `npm run dev -- chimelong --clear-cache` × 5 — all pass (2 destinations, 80 entities, 72 live items, 5 schedules)
- [x] Verified 504 reproduces on the upstream's `findWaitTimeList` endpoint without the retry policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)