### PR TITLE
chore: remove WildAdventures destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Run `npm run dev -- --list` for the full list with IDs and categories, or see be
 | Walibi Rhone-Alpes | `walibirhonealpes` |
 | Warner Bros. Movie World | `warnerbrosmovieworld` |
 | Wet'n'Wild Gold Coast | `wetnwildgoldcoast` |
-| Wild Adventures | `wildadventures` |
 | Worlds of Fun | `worldsoffun` |
 
 </details>

--- a/src/__tests__/entityIdRegression.test.ts
+++ b/src/__tests__/entityIdRegression.test.ts
@@ -107,12 +107,11 @@ describe('Destination ID patterns', () => {
       Array.isArray(d.category) ? d.category.includes('Herschend') : d.category === 'Herschend'
     );
 
-    expect(hfe.length).toBe(4);
+    expect(hfe.length).toBe(3);
     const ids = hfe.map(d => d.id).sort();
     expect(ids).toContain('dollywood');
     expect(ids).toContain('silverdollarcity');
     expect(ids).toContain('kennywood');
-    expect(ids).toContain('wildadventures');
   });
 
   test('Six Flags class covers both Six Flags and Cedar Fair parks', async () => {

--- a/src/parks/hfe/hfe.ts
+++ b/src/parks/hfe/hfe.ts
@@ -588,25 +588,6 @@ export class SilverDollarCity extends HFEBase {
 }
 
 /**
- * Wild Adventures - Valdosta, Georgia
- * Wait Time Dest ID: 3
- */
-@destinationController({category: ['Herschend', 'Wild Adventures']})
-export class WildAdventures extends HFEBase {
-  constructor(options?: DestinationConstructor) {
-    super(options);
-    this.addConfigPrefix('WILDADVENTURES');
-
-    this.destinationSlug = 'wildadventures';
-    this.parkSlug = 'wildadventurespark';
-    this.destinationName = 'Wild Adventures';
-    this.parkName = 'Wild Adventures';
-    this.parkLatitude = 30.8474;
-    this.parkLongitude = -83.2790;
-  }
-}
-
-/**
  * Kennywood - West Mifflin, Pennsylvania
  * Wait Time Dest ID: 4
  */


### PR DESCRIPTION
## Summary

The Herschend HFE API doesn't expose live wait times for Wild Adventures, the destination is not registered on the wiki, and we have no other public source for ride status. The class was dragging through the registry without contributing usable live data — drop it.

- Removes the `WildAdventures` class from `src/parks/hfe/hfe.ts`
- Updates the HFE entity-ID regression test (3 destinations now)
- Drops the row from the README park list

## Test plan
- [x] `npm run build`
- [x] `npm test` — 1070/1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)