### PR TITLE
fix(sixflags): read park hours from operatings array

### DIFF
--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -122,6 +122,22 @@ type SixFlagsOperatingHours = {
         operatingTimeTo: string;
       }>;
     }>;
+    /**
+     * Park-level operating windows. The vendor publishes per-park hours
+     * (e.g. operatingTypeName="Park", id 24) here independently of the
+     * per-ride detailHours array, which is sometimes empty even for days
+     * the park is open. La Ronde publishes hours exclusively via this
+     * field. Always prefer this over detailHours when populated.
+     */
+    operatings?: Array<{
+      operatingTypeId: number;
+      operatingTypeName: string;
+      items: Array<{
+        assignmentDisplayName?: string;
+        timeFrom: string;
+        timeTo: string;
+      }>;
+    }>;
     shows?: Array<{
       fimsId: string;
       items: Array<{
@@ -1079,19 +1095,36 @@ export class SixFlags extends Destination {
       for (const dateObj of hoursData.dates) {
         if (dateObj.isParkClosed) continue;
 
-        // Find rides venue (venueId: 1) for park hours
-        const ridesVenue = dateObj.venues?.find(v => v.venueId === 1);
-        if (!ridesVenue?.detailHours || ridesVenue.detailHours.length === 0) continue;
+        // Prefer the canonical `operatings` array — vendors increasingly
+        // publish per-park hours here while leaving per-ride detailHours
+        // empty (La Ronde does this for its entire operating season).
+        const parkOperatings = (dateObj.operatings || []).flatMap(op =>
+          (op.operatingTypeName === 'Park' || op.operatingTypeId === 24)
+            ? (op.items || []).filter(i => i.timeFrom && i.timeTo)
+            : [],
+        );
 
-        // Get valid hours entries
-        const validHours = ridesVenue.detailHours.filter(h => h.operatingTimeFrom && h.operatingTimeTo);
-        if (validHours.length === 0) continue;
+        let earliestOpen: string;
+        let latestClose: string;
 
-        // Earliest open, latest close
-        const openingTimes = validHours.map(h => h.operatingTimeFrom).sort();
-        const closingTimes = validHours.map(h => h.operatingTimeTo).sort();
-        const earliestOpen = openingTimes[0];
-        const latestClose = closingTimes[closingTimes.length - 1];
+        if (parkOperatings.length > 0) {
+          const opens = parkOperatings.map(i => i.timeFrom).sort();
+          const closes = parkOperatings.map(i => i.timeTo).sort();
+          earliestOpen = opens[0];
+          latestClose = closes[closes.length - 1];
+        } else {
+          // Fall back to per-ride detailHours.
+          const ridesVenue = dateObj.venues?.find(v => v.venueId === 1);
+          if (!ridesVenue?.detailHours || ridesVenue.detailHours.length === 0) continue;
+
+          const validHours = ridesVenue.detailHours.filter(h => h.operatingTimeFrom && h.operatingTimeTo);
+          if (validHours.length === 0) continue;
+
+          const opens = validHours.map(h => h.operatingTimeFrom).sort();
+          const closes = validHours.map(h => h.operatingTimeTo).sort();
+          earliestOpen = opens[0];
+          latestClose = closes[closes.length - 1];
+        }
 
         // Parse date from MM/DD/YYYY format
         const dateParts = dateObj.date.split('/');


### PR DESCRIPTION
## Summary
- La Ronde reports junk calendar data on the wiki because its 2026 season hours are published only via the top-level `operatings` field on each date — the per-ride `detailHours` array is empty all season.
- Our `buildParkSchedule` only looked at `detailHours`, so it emitted 0 entries; the wiki retained 5 stale incorrect entries (10:30 AM → midnight, vs. the real 10:30 → 19:00) and never replaced them.
- Now we prefer `operatings` (filtered to `operatingTypeName: "Park"` / id `24`) and fall back to `detailHours` for parks that still publish only there.

## Verification
- La Ronde now produces 29 correct schedule entries (e.g. `2026-05-16 10:30:00-04:00 → 2026-05-16 19:00:00-04:00`).
- Verified Knott's Berry Farm / Carowinds produce identical opening/closing times via either path — no regression for parks that publish to both fields.
- Six Flags Over Texas / Six Flags Over Georgia (which publish neither field for the current month) continue to skip those dates as before.

## Test plan
- [x] `npm test` — 47 files / 1070 tests pass
- [x] `npm run dev -- sixflags` builds schedules cleanly
- [ ] After merge: bump collector and let it overwrite the stale La Ronde entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)