### PR TITLE
DLP: exclude map-only attractions from queue live data

### DIFF
--- a/src/parks/dlp/__tests__/dlpQueuestatus.test.ts
+++ b/src/parks/dlp/__tests__/dlpQueuestatus.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest';
+import {
+  DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS,
+  dlpPoiEmitsQueueLiveData,
+} from '../disneylandparis.js';
+
+const DISCOVERY_ARCADE = '7d90d4e6-8c15-44ee-9e94-feb07788f02f';
+
+describe('DLP queue live data gating', () => {
+  it('exports five map-only standalone attraction ids', () => {
+    expect(DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS.size).toBe(5);
+    for (const id of DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS) {
+      expect(
+        dlpPoiEmitsQueueLiveData({category: 'Attraction', id}),
+      ).toBe(false);
+    }
+  });
+
+  it('matches discovery arcade case-insensitively', () => {
+    const variants = [
+      DISCOVERY_ARCADE.toUpperCase(),
+      '7D90D4E6-8C15-44EE-9E94-FEB07788F02F',
+      '7d90D4E6-8C15-44Ee-9E94-feb07788F02f',
+    ];
+    for (const id of variants) {
+      expect(dlpPoiEmitsQueueLiveData({category: 'Attraction', id})).toBe(
+        false,
+      );
+    }
+  });
+
+  it('does not block an arbitrary other attraction id', () => {
+    const other = 'a0000000-0000-4000-8000-000000000001';
+    expect(
+      dlpPoiEmitsQueueLiveData({category: 'Attraction', id: other}),
+    ).toBe(true);
+  });
+
+  it('only excludes when category is Attraction; same uuid as Entertainment or Restaurant is allowed', () => {
+    for (const id of DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS) {
+      expect(
+        dlpPoiEmitsQueueLiveData({category: 'Entertainment', id}),
+      ).toBe(true);
+      expect(
+        dlpPoiEmitsQueueLiveData({category: 'Restaurant', id}),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -51,6 +51,50 @@ const SHOW_SUBTYPES = new Set([
   'Parade',
 ]);
 
+/**
+ * DLP’s mobile app lists some map walkthroughs / placemarks as
+ * `Attraction` in GraphQL, but they are not in the wait-time product; the
+ * REST wait feed has no (or null) rows for them. We exclude their IDs from
+ * queue live data and the attraction STANDBY baseline so ParksAPI does not
+ * synthesize a misleading `CLOSED` with `STANDBY: null` for a non-queue POI.
+ */
+const dlpMapOnlyNonQueueAttractionIdSet = new Set(
+  [
+    '7d90d4e6-8c15-44ee-9e94-feb07788f02f', // Discovery Arcade
+    'a61aeee6-bed5-4890-8209-5249e689b1a1', // Liberty Arcade
+    '38bafc85-cb48-488e-aa68-3e2d01ae6a10', // La Galerie de la Belle au Bois
+    '6bb88973-80d0-45cf-bffe-433f1c551362', // Horsedrawn Streetcars
+    'a620015d-091d-4f82-b8b2-a97bc8641f07', // Sleeping Beauty Castle
+  ].map((id) => id.toLowerCase()),
+);
+
+/** IDs of map-only DLP “attractions” with no queue product (for tests / enumeration). */
+export const DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS: ReadonlySet<string> =
+  dlpMapOnlyNonQueueAttractionIdSet;
+
+/**
+ * @returns `false` for the {@link DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS}
+ *   when the POI is an `Attraction` (so those rows do not receive queue
+ *   live data). All other categories are unchanged.
+ */
+export function dlpPoiEmitsQueueLiveData(poi: {category: string; id: string}): boolean {
+  if (poi.category !== 'Attraction') return true;
+  return !dlpMapOnlyNonQueueAttractionIdSet.has(poi.id.toLowerCase());
+}
+
+function dlpPoiIdIsMapOnlyNonQueueAttractionId(entityId: string): boolean {
+  return dlpMapOnlyNonQueueAttractionIdSet.has(entityId.toLowerCase());
+}
+
+/**
+ * Internal key for DLP `LiveData` maps and cross-feed joins: REST, PA, and
+ * schedule rows sometimes use different casing for the same UUID as GraphQL
+ * `activities.id` — this prevents duplicate rows or `getOrCreate` misses.
+ */
+function dlpLiveDataEntityIdKey(id: string): string {
+  return id.toLowerCase();
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -794,23 +838,39 @@ export class DisneylandParis extends Destination {
 
   protected async buildLiveData(): Promise<LiveData[]> {
     const liveData: LiveData[] = [];
+    /** Map keys are {@link dlpLiveDataEntityIdKey} (lowercased), matching entity id from `buildEntityList`. */
     const liveDataMap = new Map<string, LiveData>();
 
-    // Build the set of entity IDs we actually emit, so live data stays in
-    // lockstep with buildEntityList. Without this, the wait-times feed
-    // (and premier-access / virtual-queue / showtimes) leaks IDs for
-    // characters, hidden POI entries, and codes Disney returns that aren't
-    // in the public POI dataset at all.
-    const validEntityIds = new Set<string>(
-      (await this.getEmittablePOIEntities()).map((poi) => poi.id),
-    );
+    const emittablePois = await this.getEmittablePOIEntities();
+    const queueLiveDataPois = emittablePois.filter((poi) => dlpPoiEmitsQueueLiveData(poi));
+    // One canonical `LiveData.id` per entity (GraphQL/POI casing). Wait/PA/schedule
+    // feeds may use different casing; we key maps by lowercase to merge correctly.
+    const canonicalEntityIdByKey = new Map<string, string>();
+    for (const poi of queueLiveDataPois) {
+      const key = dlpLiveDataEntityIdKey(poi.id);
+      if (!canonicalEntityIdByKey.has(key)) {
+        canonicalEntityIdByKey.set(key, poi.id);
+      }
+    }
 
-    const getOrCreate = (id: string): LiveData | undefined => {
-      if (!validEntityIds.has(id)) return undefined;
-      let entry = liveDataMap.get(id);
+    // Same issue as `LiveData` ids: show duration is keyed in `showDurationMap`
+    // by `buildEntityList`’s `poi.id` — look up with a case-insensitive key
+    // so schedule `sched.id` still finds duration if casing differs.
+    const showDurationByKey = new Map<string, number>();
+    for (const [entityId, minutes] of this.showDurationMap) {
+      const key = dlpLiveDataEntityIdKey(entityId);
+      if (!showDurationByKey.has(key)) showDurationByKey.set(key, minutes);
+    }
+
+    const getOrCreate = (rawId: string | null | undefined): LiveData | undefined => {
+      if (rawId == null || rawId === '') return undefined;
+      const key = dlpLiveDataEntityIdKey(rawId);
+      const canonicalId = canonicalEntityIdByKey.get(key);
+      if (canonicalId === undefined) return undefined;
+      let entry = liveDataMap.get(key);
       if (!entry) {
-        entry = {id, status: 'CLOSED'} as LiveData;
-        liveDataMap.set(id, entry);
+        entry = {id: canonicalId, status: 'CLOSED'} as LiveData;
+        liveDataMap.set(key, entry);
         liveData.push(entry);
       }
       return entry;
@@ -917,7 +977,7 @@ export class DisneylandParis extends Destination {
         const performances = sched.schedules.filter((s) => s.status === 'PERFORMANCE_TIME');
         if (performances.length === 0) continue;
 
-        const showDuration = this.showDurationMap.get(sched.id) || 0;
+        const showDuration = showDurationByKey.get(dlpLiveDataEntityIdKey(sched.id)) || 0;
 
         const showtimes = performances.map((p) => {
           const startTime = constructDateTime(todayStr, p.startTime, this.timezone);
@@ -936,7 +996,7 @@ export class DisneylandParis extends Destination {
           };
         });
 
-        const existing = liveDataMap.get(sched.id);
+        const existing = liveDataMap.get(dlpLiveDataEntityIdKey(sched.id));
         if (existing) {
           existing.showtimes = showtimes;
           if (showtimes.length > 0) {
@@ -960,30 +1020,45 @@ export class DisneylandParis extends Destination {
     // until the API wakes back up. Consumers expect these queues to stay
     // present so they can render `wait: null` rather than disappearing.
     //
+    // Map-only "attractions" (no wait product) are excluded here so we do
+    // not add a synthetic CLOSED/STANDBY for POIs the app never tracks as a queue.
+    //
     // Single-rider eligibility isn't on POI, so remember IDs we've seen
     // with `singleRider.isAvailable === true` and re-emit SINGLE_RIDER
-    // null for them while the feed is asleep.
+    // null for them while the feed is asleep. Keys are normalized to
+    // lowercase; map-only IDs are skipped to avoid spurious cache entries.
     const srCacheKey = `${this.getCacheKeyPrefix()}:dlp:singleRiderCapable`;
     const previouslySeenSR = CacheLib.get(srCacheKey) as string[] | null;
-    const seenSR = new Set<string>(Array.isArray(previouslySeenSR) ? previouslySeenSR : []);
+    const seenSR = new Set<string>(
+      Array.isArray(previouslySeenSR)
+        ? previouslySeenSR.map((id) => String(id).toLowerCase())
+        : [],
+    );
     for (const wt of waitTimes) {
-      if (wt.singleRider?.isAvailable === true && wt.entityId) seenSR.add(wt.entityId);
+      if (wt.singleRider?.isAvailable === true && wt.entityId) {
+        if (dlpPoiIdIsMapOnlyNonQueueAttractionId(wt.entityId)) continue;
+        seenSR.add(wt.entityId.toLowerCase());
+      }
     }
     CacheLib.set(srCacheKey, [...seenSR], 30 * 24 * 60 * 60); // 30 days
 
-    const attractionIds = (await this.getEmittablePOIEntities())
-      .filter((poi) => this.mapEntityType(poi) === 'ATTRACTION')
+    const attractionIds = emittablePois
+      .filter(
+        (poi) =>
+          this.mapEntityType(poi) === 'ATTRACTION' && dlpPoiEmitsQueueLiveData(poi),
+      )
       .map((poi) => poi.id);
     for (const id of attractionIds) {
-      let ld = liveDataMap.get(id);
+      const key = dlpLiveDataEntityIdKey(id);
+      let ld = liveDataMap.get(key);
       if (!ld) {
         ld = {id, status: 'CLOSED'} as LiveData;
-        liveDataMap.set(id, ld);
+        liveDataMap.set(key, ld);
         liveData.push(ld);
       }
       if (!ld.queue) ld.queue = {};
       if (!ld.queue.STANDBY) ld.queue.STANDBY = {waitTime: null};
-      if (!ld.queue.SINGLE_RIDER && seenSR.has(id)) {
+      if (!ld.queue.SINGLE_RIDER && seenSR.has(id.toLowerCase())) {
         ld.queue.SINGLE_RIDER = {waitTime: null};
       }
     }


### PR DESCRIPTION
# DLP: exclude map-only attractions from queue live data and normalize cross-feed entity IDs

## Summary

This pull request changes **Disneyland Paris** live-data handling so **map-only / non-queue** POIs that GraphQL still classifies as **`Attraction`** no longer get **synthetic queue state** (notably `CLOSED` + `STANDBY: null` from the global attraction baseline). It also **normalizes entity identity** (canonical ID from POI, lowercase map keys) so **wait, Premier Access, virtual queue, and schedule** data **merge to one `LiveData` row per entity** even when upstream APIs use **different UUID casing**.

**Entity list** (`buildEntityList`) and **operating-hour schedules** (`buildSchedules`) are **unchanged** — affected POIs stay on the map and keep schedule data.

---

## Background — What and why

### What was wrong

- The **DLP mobile app** treats some locations as **map walkthroughs / placemarks** (no in-app **wait** or open/closed queue product).
- **GraphQL** still returns them as **`Attraction`**, so they are **emittable** POIs in ParksAPI and appear in the entity list.
- **Live data** combines:
  - **REST wait times**,
  - **POI/GraphQL**-driven `getEmittablePOIEntities()`,
  - and a **baseline** that ensures every emittable **attraction** has at least a **`STANDBY`** queue and default status.
- For these map-only places, the **wait feed** often has **no row** (or not meaningful data). They only hit the **baseline** and looked **always closed**, which is **misleading** for “no queue product,” not “closed ride.”

### What we want

- Treat **queue-based live data** (waits, PA, VQ, STANDBY baseline, single-rider cache behavior tied to the wait feed) as a **subset** of emittable POIs.
- **Do not** change **`mapStatus()`** globally.
- **Do not** remove these from **entities** or **schedules** — they should still be **mappable** and **schedulable**.
- **Explicitly** exclude a small, **authoritative** set of **DLP `Attraction` entity UUIDs** (map-only, non-queue) from:
  - membership in the **queue live-data** allowlist,
  - **wait / PA / VQ** `getOrCreate` paths,
  - the **closed baseline** with **STANDBY**,
  - **spurious** single-rider cache keys for those ids.

### Secondary issue (same code path)

- **Wait**, **PA**, **VQ**, and **schedule** APIs can refer to the same entity with the **same UUID in different letter casing** than GraphQL `activities.id`. The previous design keyed **`validEntityIds` and `liveDataMap` by raw strings**, which could cause **missed merges** or **duplicate `LiveData` entries** for one logical entity. This PR fixes that by a **single normalization rule** and **canonical `LiveData.id`** aligned with **POI** (and thus **`buildEntityList`**).

---

## Where — Code and files

| Area | Location |
|------|----------|
| **Map-only set + gating** | `src/parks/dlp/disneylandparis.ts` — after `SHOW_SUBTYPES` |
| **Exported API for tests** | `DLP_NON_QUEUE_STANDALONE_ATTRACTION_IDS` (readonly set), `dlpPoiEmitsQueueLiveData()` |
| **Private helpers** | `dlpPoiIdIsMapOnlyNonQueueAttractionId()`, `dlpLiveDataEntityIdKey()` |
| **Live data pipeline** | `DisneylandParis.buildLiveData()` — `queueLiveDataPois` / `canonicalEntityIdByKey`, `getOrCreate`, wait loop, PA, VQ, showtimes (including `showDurationByKey`), single-rider cache, baseline STANDBY / SINGLE_RIDER |
| **Unit tests** | `src/parks/dlp/__tests__/dlpQueuestatus.test.ts` |

**Not changed:** `mapStatus()`, `buildEntityList()`, `buildSchedules()`, and GraphQL/REST **fetch** contracts except how **`buildLiveData`** consumes their ids.

---

## Technical details (what the code does)

1. **Authoritative set (5 UUIDs, lowercase in the set)**  
   DLP “attraction” map-only / non-queue POIs, e.g. **Discovery Arcade**, **Liberty Arcade**, **La Galerie de la Belle au Bois**, **Horsedrawn Streetcars**, **Sleeping Beauty Castle** (exact UUIDs in code; all runtime lookups use **`.toLowerCase()`** on the id being tested).

2. **`dlpPoiEmitsQueueLiveData(poi)`**  
   - If **`poi.category !== 'Attraction'`** → **true** (shows, restaurants, etc. **unchanged**).  
   - If **`Attraction`** → **true** only when the id is **not** in the map-only set (case-insensitive).

3. **`buildLiveData`**  
   - One pass: **`emittablePois = await getEmittablePOIEntities()`**.  
   - **Queue allowlist** = POIs for which `dlpPoiEmitsQueueLiveData` is true; **`canonicalEntityIdByKey`** maps **lowercase key → canonical `poi.id`** from GraphQL.  
   - **`getOrCreate(rawId)`** uses a **lowercase key** for the internal map; **`LiveData.id`** is the **canonical** POI id.  
   - **Show duration** for showtimes uses **`showDurationByKey`** so schedule `sched.id` still matches **`showDurationMap`** when casing differs.  
   - **Showtimes** `existing` lookup uses the **same** keying as `getOrCreate`.  
   - **Single-rider** cache: rehydrate with **lowercase** keys, **skip** map-only ids when recording from the wait feed, persist **lowercase** keys, baseline check **`seenSR.has(id.toLowerCase())`**.  
   - **Baseline** attractions: filter **`ATTRACTION` + `dlpPoiEmitsQueueLiveData`**, re-use **`emittablePois`**, use **normalized** map lookup.

4. **Tests**  
   - Exported set has **5** members; each as `Attraction` → **`dlpPoiEmitsQueueLiveData` false**.  
   - **Case-insensitive** id for a known map-only id.  
   - **Unrelated** attraction UUID still **emits** queue data.  
   - **Same UUID** with **`Entertainment` / `Restaurant`** → still **emits** (category matters).

---

## How to test

```bash
npm run build
npm test -- --run src/parks/dlp/__tests__/dlpQueuestatus.test.ts
```

Optionally run the full test suite: `npm test`.

**Manual / integration:** from the project harness, run DLP live data and confirm the five locations **no longer** appear with **synthetic** `CLOSED` / `STANDBY` from baseline only, and that a normal attraction still has **coherent** wait/baseline behavior.

---

## Risk and rollback

- **Risk:** Low for non-DLP code paths; changes are **scoped to** `disneylandparis.ts` and **new** DLP tests.  
- **Risk:** If Disney **adds** new map-only `Attraction` rows later, they may need to be **added to the set** in a follow-up (same as any explicit allowlist).  
- **Rollback:** Revert this PR; no migrations or data format changes.

---

## Checklist (optional)

- [x] `npm run build` passes  
- [x] `dlpQueuestatus.test.ts` passes  
- [ ] PR targets **`main`** (or your default branch) from your feature branch

---

*After pasting this into GitHub, you can delete `PR_DESCRIPTION.md` or add it to `.gitignore` if you do not want it in the repo.*
