### PR TITLE
ci: serialize API Docs workflow to prevent gh-pages push races

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
 
+# Serialize gh-pages pushes. Without this, multiple merges in quick
+# succession race on `git push origin gh-pages` and one run fails with
+# `! [rejected] (fetch first)`. Letting in-flight runs finish (rather
+# than cancelling them) means the newest commit's docs always end up
+# published.
+concurrency:
+  group: api-docs
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Three back-to-back merges (#153, #155, #161) each triggered the API Docs workflow. They raced on `git push origin gh-pages`, one failed with `! [rejected] (fetch first)`. Result: a red ❌ on the actions tab, even though the latest run did publish current docs.

## Fix

Add a workflow-level concurrency group. `cancel-in-progress: false` keeps any in-flight run going (so it doesn't waste a partial build) but blocks new runs from starting until it finishes. The next queued run picks up the latest commit on main when it starts, so the newest docs still get published.

```yaml
concurrency:
  group: api-docs
  cancel-in-progress: false
```

## Test plan
- [ ] Merge then trigger a second commit immediately; verify the second run waits in queue rather than running concurrently.
- [ ] Confirm `gh-pages` ends up at the latest commit's docs after the queue drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)