### PR TITLE
fix(plopsa): never cache parkOpenNow=false; invalidate prior false-cache

### DIFF
--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -402,21 +402,24 @@ class PlopsaBase extends Destination {
     // for that poll, which manifests as park-wide lockstep flapping in the
     // wiki history.
     //
-    // Caching is *one-way*: we persist a TRUE reading for the rest of the
-    // hour, but never cache FALSE. A previous version of this code cached
-    // both, which meant any single quirky upstream response (or a
-    // misbehaving collector instance whose first fetch returned an empty
-    // body) locked in CLOSED for an hour and produced lockstep flapping
-    // when paired with a sibling instance whose cache held TRUE. Parks
-    // rarely shut mid-day, so once we've seen "open" today we trust it;
-    // if we haven't, we re-attempt every poll.
+    // We only trust the upstream response if it carries a non-empty
+    // `timeslots` array — anything else (network failure, truthy-but-empty
+    // body like `{}`, or `{timeslots: []}`) is treated as "no fresh
+    // signal" and we fall back to the last-known-TRUE in cache. Parks
+    // rarely shut mid-day, so once we've seen "open" today we trust it
+    // for the rest of the hour; otherwise we re-attempt every poll.
     //
-    // The cache key carries a `:v2` suffix so any cached `false` from the
-    // previous code revision is ignored on first deploy. Bump again if the
-    // shape ever changes.
+    // Caching is one-way: we persist TRUE for an hour but never FALSE. A
+    // previous code revision cached both, which let one quirky upstream
+    // response lock a sibling collector into CLOSED for an hour and
+    // produce lockstep flapping when paired with a sibling that had cached
+    // TRUE. The cache key carries a `:v2` suffix so any cached FALSE from
+    // that revision is unreachable on first deploy.
     const openCacheKey = `${this.getCacheKeyPrefix()}:parkOpenNow:v2:${today}`;
+    const hasValidHours =
+      Array.isArray(hoursData?.timeslots) && hoursData.timeslots.length > 0;
     let parkOpenNow: boolean;
-    if (hoursData) {
+    if (hasValidHours) {
       parkOpenNow = isParkOpenNow(hoursData, this.timezone);
       if (parkOpenNow) {
         CacheLib.set(openCacheKey, true, 60 * 60); // 1h, only cache TRUE

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -400,18 +400,30 @@ class PlopsaBase extends Destination {
     // `parkOpenNow` MUST NOT flicker on transient failures of
     // `fetchTodayHours`: a single false reading flips every ride to CLOSED
     // for that poll, which manifests as park-wide lockstep flapping in the
-    // wiki history. Persist the last successful value in CacheLib for an
-    // hour and only fall back to it if today's fetch came back empty/null.
-    // Park hours rarely change intra-day, so a stale boolean here is
-    // strictly better than mass CLOSED emissions.
-    const openCacheKey = `${this.getCacheKeyPrefix()}:parkOpenNow:${today}`;
+    // wiki history.
+    //
+    // Caching is *one-way*: we persist a TRUE reading for the rest of the
+    // hour, but never cache FALSE. A previous version of this code cached
+    // both, which meant any single quirky upstream response (or a
+    // misbehaving collector instance whose first fetch returned an empty
+    // body) locked in CLOSED for an hour and produced lockstep flapping
+    // when paired with a sibling instance whose cache held TRUE. Parks
+    // rarely shut mid-day, so once we've seen "open" today we trust it;
+    // if we haven't, we re-attempt every poll.
+    //
+    // The cache key carries a `:v2` suffix so any cached `false` from the
+    // previous code revision is ignored on first deploy. Bump again if the
+    // shape ever changes.
+    const openCacheKey = `${this.getCacheKeyPrefix()}:parkOpenNow:v2:${today}`;
     let parkOpenNow: boolean;
     if (hoursData) {
       parkOpenNow = isParkOpenNow(hoursData, this.timezone);
-      CacheLib.set(openCacheKey, parkOpenNow, 60 * 60); // 1h
+      if (parkOpenNow) {
+        CacheLib.set(openCacheKey, true, 60 * 60); // 1h, only cache TRUE
+      }
     } else {
       const cached = CacheLib.get(openCacheKey);
-      parkOpenNow = typeof cached === 'boolean' ? cached : false;
+      parkOpenNow = cached === true; // only fall back to a known-TRUE
     }
 
     const lastUpdated = new Date().toISOString();


### PR DESCRIPTION
## Background

Follow-up to #163. After that PR shipped, wiki history continued to show every Plopsaland Deutschland ride flapping `OPERATING ↔ CLOSED` every ~90s. Verified the fix was deployed to all collectors (compiled `dist/` modify time matched the merge), so why did the flapping persist?

## Root cause of the residual bug

The original fix cached both TRUE *and* FALSE readings of `parkOpenNow`:

```ts
if (hoursData) {
  parkOpenNow = isParkOpenNow(hoursData, this.timezone);
  CacheLib.set(openCacheKey, parkOpenNow, 60 * 60);   // ← caches FALSE too
}
```

If any collector instance got a quirky-but-successful upstream response (e.g. `{}` or `{timeslots: []}`) on its first fetch, `isParkOpenNow` returned `false`, we cached `false` for an hour, and *every* subsequent poll fell back to that cached `false` → emitted CLOSED. With multiple collectors writing concurrently, one cached TRUE and the other cached FALSE, and they happily produced lockstep flapping for the rest of the hour without re-attempting the upstream.

## Fix

```ts
if (hoursData) {
  parkOpenNow = isParkOpenNow(hoursData, this.timezone);
  if (parkOpenNow) {
    CacheLib.set(openCacheKey, true, 60 * 60);   // only cache TRUE
  }
} else {
  const cached = CacheLib.get(openCacheKey);
  parkOpenNow = cached === true;                 // fall back only to known-TRUE
}
```

- **Only cache TRUE.** Once we've seen "open today" once, trust it for the next hour. FALSE readings re-fetch on the next poll.
- **Bump cache key to `:parkOpenNow:v2:`** so any stale `false` cached by the previous code revision is unreachable on first deploy. (`@http` doesn't support `cacheVersion`, but the bad data here lives in raw `CacheLib.set/get` calls — the key suffix is the equivalent.)

## Test plan
- [x] `npm test` — 47 files / 1070 tests pass
- [ ] Watch wiki history post-deploy: alternating CLOSED/OPERATING entries should stop within one polling cycle, and CLOSED should only appear when the park is genuinely closed (after 18:00 Berlin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)