### PR TITLE
fix(httpProxy): use undici's bundled fetch for dispatcher contract parity

### DIFF
--- a/src/__tests__/httpProxyMTLS.test.ts
+++ b/src/__tests__/httpProxyMTLS.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for `src/httpProxy.ts` mutual-TLS plumbing.
+ *
+ * If `makeHttpRequest` pairs Node's *global* `fetch` (which is backed
+ * by Node's bundled undici) with an `Agent` constructed from the
+ * npm-installed undici, the two undici copies' Dispatcher interceptor
+ * contracts can diverge and undici throws
+ *   "invalid onRequestStart method"
+ * at request start. The fix is to import `fetch` from `undici` so both
+ * halves of the dispatcher contract come from the same module copy.
+ *
+ * We don't need a working TLS handshake to catch this — the failure
+ * fires at the very start of the request, before the socket is opened.
+ * Pointing at an unroutable address with cert/key set is enough: a
+ * connect error is fine; the interceptor-mismatch error is the failure.
+ */
+import {describe, test, expect, afterAll} from 'vitest';
+import {makeHttpRequest} from '../httpProxy.js';
+import {stopHttpQueue} from '../http.js';
+
+afterAll(() => {
+  stopHttpQueue();
+});
+
+// Inline self-signed PEMs are awkward to assemble in pure node:crypto, so
+// we use a static fixture committed below. They're not real keys, just
+// valid-looking PEM blobs that Node's `tls` parser will load — undici
+// only needs them to *exist* and parse before it tries to talk to the
+// (unreachable) target host.
+const TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIUWOdTl0KXY1fPq1Y6f6CEv3YjJxgwCgYIKoZIzj0EAwIw
+GTEXMBUGA1UEAwwOcGFya3NhcGktdGVzdHMwHhcNMjUwMTAxMDAwMDAwWhcNMzUw
+MTAxMDAwMDAwWjAZMRcwFQYDVQQDDA5wYXJrc2FwaS10ZXN0czBZMBMGByqGSM49
+AgEGCCqGSM49AwEHA0IABBuvixFwhk2hLN4Vqdsx0X+SYvEqHxlfKMhbsaeMd7+I
+4yTUnAhMaMFL/pvJiwOsDp8RfbtyJyTQ2Iudw3sBEnujUzBRMB0GA1UdDgQWBBSo
+0a4FH5W8eC4Vsd8c4OuNaS9w0DAfBgNVHSMEGDAWgBSo0a4FH5W8eC4Vsd8c4OuN
+aS9w0DAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCqLPsgwGfA
+0WK1B4UBVnKcS3kDwh8gW1+oeYWk31IJiwIgWCkj/dRZIBeYuyYTlR+B+JD1BoBT
+oRUGCMQRFvdnpMo=
+-----END CERTIFICATE-----
+`;
+const TEST_KEY = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIBQXl7vSnHgxRovGXJ6sJV+ddbEZHVGqNdaZ47PsgIWoAoGCCqGSM49
+AwEHoUQDQgAEG6+LEXCGTaEs3hWp2zHRf5Ji8SofGV8oyFuxp4x3v4jjJNScCExo
+wUv+m8mLA6wOnxF9u3InJNDYi53DewESew==
+-----END EC PRIVATE KEY-----
+`;
+
+describe('makeHttpRequest mTLS plumbing', () => {
+  test('attaches cert/key dispatcher without "invalid onRequestStart method"', async () => {
+    // 192.0.2.1 is RFC 5737 TEST-NET-1 — guaranteed unroutable. The
+    // request will fail with a connect error (timeout/ECONNREFUSED),
+    // which is fine. The bug we're catching fires *before* the connect
+    // attempt: undici walks the dispatcher interceptor chain at request
+    // start, and a version-mismatched Agent throws "invalid
+    // onRequestStart method" synchronously from inside the handler.
+    let caught: any = null;
+    try {
+      await makeHttpRequest({
+        method: 'GET',
+        url: 'https://192.0.2.1/',
+        cert: TEST_CERT,
+        key: TEST_KEY,
+        timeoutMs: 1500,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    // We expect *some* error (connect timeout) — but specifically NOT
+    // an interceptor-contract mismatch. Walk both .message and any
+    // chained `cause` for the regression marker.
+    const messages: string[] = [];
+    let e: any = caught;
+    while (e) {
+      if (e.message) messages.push(String(e.message));
+      if (e.cause && e.cause !== e) e = e.cause;
+      else break;
+    }
+    const joined = messages.join(' | ').toLowerCase();
+    expect(joined, `Saw the dispatcher version-mismatch regression: ${messages.join(' / ')}`)
+      .not.toMatch(/invalid onrequeststart method/);
+  });
+});

--- a/src/__tests__/httpProxyMTLS.test.ts
+++ b/src/__tests__/httpProxyMTLS.test.ts
@@ -67,9 +67,13 @@ describe('makeHttpRequest mTLS plumbing', () => {
       caught = err;
     }
 
-    // We expect *some* error (connect timeout) — but specifically NOT
-    // an interceptor-contract mismatch. Walk both .message and any
-    // chained `cause` for the regression marker.
+    // We expect *some* error (connect timeout). If the request somehow
+    // resolves (e.g. a network where 192.0.2.1 happens to be reachable),
+    // the regression assertion below would be vacuous, so assert first
+    // that an error was actually caught.
+    expect(caught, 'expected makeHttpRequest to fail against an unroutable host').toBeTruthy();
+
+    // Walk .message and any chained `cause` for the regression marker.
     const messages: string[] = [];
     let e: any = caught;
     while (e) {
@@ -77,6 +81,8 @@ describe('makeHttpRequest mTLS plumbing', () => {
       if (e.cause && e.cause !== e) e = e.cause;
       else break;
     }
+    expect(messages.length, 'expected the caught error to carry at least one message').toBeGreaterThan(0);
+
     const joined = messages.join(' | ').toLowerCase();
     expect(joined, `Saw the dispatcher version-mismatch regression: ${messages.join(' / ')}`)
       .not.toMatch(/invalid onrequeststart method/);

--- a/src/httpProxy.ts
+++ b/src/httpProxy.ts
@@ -1,9 +1,20 @@
-// HTTP client built on Node's global fetch (undici).
+// HTTP client built on undici's own fetch (NOT Node's global `fetch`).
+//
 // Undici handles the socket/parse work on its own thread pool, so the main
 // event loop stays free for scheduling and timer callbacks. The previous
 // node:http/https implementation did everything on the main thread, which
 // starved setTimeout callbacks when 50+ destinations were pulling data at once.
-import {Agent, ProxyAgent, Socks5ProxyAgent, type Dispatcher} from 'undici';
+//
+// We must import `fetch` from `undici` rather than using Node's global
+// `fetch` because Node bundles its own (older) undici. When we pass an
+// `Agent` constructed from the npm-installed undici to the global fetch,
+// the version mismatch surfaces as
+//   "invalid onRequestStart method"
+// at request time — undici's `Dispatcher` interceptor contract evolved
+// between the bundled and installed versions. Pairing both halves through
+// the npm-installed module keeps the contract consistent regardless of
+// which Node release is in use.
+import {Agent, ProxyAgent, Socks5ProxyAgent, fetch as undiciFetch, type Dispatcher} from 'undici';
 
 /**
  * Make an HTTP request via fetch() with optional proxy / mutual-TLS support.
@@ -65,7 +76,9 @@ export async function makeHttpRequest(options: {
   }
 
   try {
-    return await fetch(url, init);
+    // Node's built-in `RequestInit` and undici 8's diverge slightly on
+    // BodyInit; the runtime contract is the same so cast through `unknown`.
+    return await undiciFetch(url, init as any) as unknown as Response;
   } catch (err: any) {
     // Surface timeouts with the same message shape we used before so callers
     // (and log greps) don't need to change.

--- a/src/httpProxy.ts
+++ b/src/httpProxy.ts
@@ -14,7 +14,14 @@
 // between the bundled and installed versions. Pairing both halves through
 // the npm-installed module keeps the contract consistent regardless of
 // which Node release is in use.
-import {Agent, ProxyAgent, Socks5ProxyAgent, fetch as undiciFetch, type Dispatcher} from 'undici';
+import {
+  Agent,
+  ProxyAgent,
+  Socks5ProxyAgent,
+  fetch as undiciFetch,
+  type Dispatcher,
+  type RequestInit as UndiciRequestInit,
+} from 'undici';
 
 /**
  * Make an HTTP request via fetch() with optional proxy / mutual-TLS support.
@@ -62,10 +69,13 @@ export async function makeHttpRequest(options: {
 
   const dispatcher = buildDispatcher(proxyUrl, cert, key);
 
-  const init: RequestInit & {dispatcher?: Dispatcher} = {
+  // Type the init object against undici's own RequestInit so the
+  // dispatcher field is recognised and there's no global-vs-undici
+  // BodyInit incompatibility at the call site below.
+  const init: UndiciRequestInit & {dispatcher?: Dispatcher} = {
     method,
     headers: hdrs,
-    body: fetchBody,
+    body: fetchBody as UndiciRequestInit['body'],
     signal: AbortSignal.timeout(timeoutMs),
     // Attractions.io uses 303 to signal new ZIP data — callers need the raw
     // status + Location header, not the redirected body.
@@ -76,9 +86,10 @@ export async function makeHttpRequest(options: {
   }
 
   try {
-    // Node's built-in `RequestInit` and undici 8's diverge slightly on
-    // BodyInit; the runtime contract is the same so cast through `unknown`.
-    return await undiciFetch(url, init as any) as unknown as Response;
+    // undici's `Response` type is structurally compatible with the
+    // global `Response`; cast through `unknown` to satisfy TS without
+    // disabling type-checking on the call itself.
+    return await undiciFetch(url, init) as unknown as Response;
   } catch (err: any) {
     // Surface timeouts with the same message shape we used before so callers
     // (and log greps) don't need to change.


### PR DESCRIPTION
## Summary

`src/httpProxy.ts` was calling Node's *global* `fetch` (backed by Node's bundled undici) while constructing the dispatcher `Agent` from the npm-installed undici. After undici 8.x landed, its `Dispatcher` interceptor contract diverged from Node's bundled copy. Any request that attached a custom dispatcher (cert/key, proxy) then started throwing

```
invalid onRequestStart method
```

at request start, before reaching the socket. Code paths without a custom dispatcher were unaffected.

## Fix

Import `fetch` from `undici` directly so both halves of the dispatcher contract come from the same undici module copy.

```ts
-import {Agent, ProxyAgent, Socks5ProxyAgent, type Dispatcher} from 'undici';
+import {Agent, ProxyAgent, Socks5ProxyAgent, fetch as undiciFetch, type Dispatcher} from 'undici';
…
-    return await fetch(url, init);
+    return await undiciFetch(url, init as any) as unknown as Response;
```

Cast through `unknown` because Node's built-in `RequestInit` and undici 8's diverge slightly on `BodyInit`; the runtime contract is the same.

## Test

New `src/__tests__/httpProxyMTLS.test.ts` regression test:
- Points `makeHttpRequest` at an unroutable address (TEST-NET-1) with cert/key set
- Catches the resulting error chain (connect timeout is fine; interceptor mismatch is the failure)
- Asserts the error message does not contain `invalid onRequestStart method`

Verified: the test FAILS when `httpProxy.ts` is reverted to global `fetch`, and PASSES with the fix in place.

## Test plan
- [x] `npm test` — 48 files / 1071 tests pass
- [x] Reverted fix locally → new test fails with the expected marker
- [x] Restored fix → new test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)