### PR TITLE
fix(plopsa): trust wait-times feed over stale temporarily_closed hint

### DIFF
--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Plopsa decision-logic regression tests.
+ *
+ * The full decision matrix for whether a ride emits OPERATING vs CLOSED.
+ * The interesting case is row 3: a numeric wait time + a stale
+ * `temporarily_closed: true` from POI must NOT downgrade to CLOSED, or
+ * multi-collector deployments will flap any ride whose POI snapshot
+ * disagrees between instances.
+ */
+import {describe, test, expect} from 'vitest';
+import {plopsaDecideOperating} from '../plopsa.js';
+
+describe('plopsaDecideOperating', () => {
+  test('park closed → ride always CLOSED regardless of other inputs', () => {
+    expect(plopsaDecideOperating(false, false, false)).toBe(false);
+    expect(plopsaDecideOperating(false, false, true)).toBe(false);
+    expect(plopsaDecideOperating(false, true,  false)).toBe(false);
+    expect(plopsaDecideOperating(false, true,  true)).toBe(false);
+  });
+
+  test('park open + ride open + has wait → OPERATING', () => {
+    expect(plopsaDecideOperating(true, false, true)).toBe(true);
+  });
+
+  test('park open + ride open + no wait → OPERATING (e.g. brand-new ride before first reading)', () => {
+    expect(plopsaDecideOperating(true, false, false)).toBe(true);
+  });
+
+  test('park open + POI says temp-closed + has wait → OPERATING (wait-times feed wins over stale POI hint)', () => {
+    // This is the case the bug report depends on: stale POI says closed,
+    // but the wait-times feed has a real number. Trust the live number.
+    expect(plopsaDecideOperating(true, true, true)).toBe(true);
+  });
+
+  test('park open + POI says temp-closed + no wait → CLOSED (the hint is authoritative when no live signal)', () => {
+    expect(plopsaDecideOperating(true, true, false)).toBe(false);
+  });
+});

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -97,6 +97,27 @@ function formatTodayInTimezone(tz: string): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
+/**
+ * Decide whether a Plopsa ride should emit as OPERATING right now.
+ *
+ * Inputs are intentionally flat booleans + a primitive — pure function so
+ * the matrix is easy to unit-test (see `__tests__/plopsa.test.ts`).
+ *
+ * The wait-times feed is treated as the ground truth: a numeric wait
+ * means the ride is taking guests right now. POI's `temporarily_closed`
+ * is a hint we use only when the wait-times feed has no number for the
+ * ride. Without that priority, a stale 12h-cached POI snapshot on one
+ * collector instance disagreeing with another instance's cached snapshot
+ * causes lockstep OPERATING ↔ CLOSED flapping for the affected rides.
+ */
+export function plopsaDecideOperating(
+  parkOpenNow: boolean,
+  tempClosed: boolean,
+  hasWait: boolean,
+): boolean {
+  return parkOpenNow && (hasWait || !tempClosed);
+}
+
 /** Is the park currently within an "open" timeslot from today's hours? */
 function isParkOpenNow(hours: PlopsaTodayHours | null, tz: string): boolean {
   if (!hours?.timeslots?.length) return false;
@@ -432,7 +453,9 @@ class PlopsaBase extends Destination {
     const lastUpdated = new Date().toISOString();
     return Object.entries(waitTimes).map(([attractionId, waitTime]) => {
       const id = String(attractionId);
-      const operating = parkOpenNow && closedById.get(id) !== true;
+      const tempClosed = closedById.get(id) === true;
+      const hasWait = typeof waitTime === 'number';
+      const operating = plopsaDecideOperating(parkOpenNow, tempClosed, hasWait);
 
       if (!operating) {
         return {id, status: 'CLOSED', lastUpdated} as unknown as LiveData;
@@ -441,7 +464,7 @@ class PlopsaBase extends Destination {
         id,
         status: 'OPERATING',
         queue: {
-          STANDBY: {waitTime: typeof waitTime === 'number' ? waitTime : null},
+          STANDBY: {waitTime: hasWait ? waitTime : null},
         },
         lastUpdated,
       } as unknown as LiveData;


### PR DESCRIPTION
## Symptom

Plopsaland Deutschland: a subset of ~8 rides (e.g. 100% Wolf, DinoSplash, Aqua Team Playground) flap OPERATING ↔ CLOSED every ~3 minutes, all day. Lockstep — same rides flip together. The rest of the park is steady.

```
13:08  OPERATING  30
13:11  CLOSED     -
13:14  OPERATING  30
13:14  CLOSED     -
13:17  OPERATING  30
13:18  CLOSED     -
…
```

`parkOpenNow` is stable (the v2 fix in #164 is doing its job). The thing flipping is per-ride: `closedById` (the `temporarily_closed` flag from POI).

## Cause

In `buildLiveData`:
```ts
const operating = parkOpenNow && closedById.get(id) !== true;
```
`closedById` is built from a 12-hour HTTP-cached POI response. On a multi-instance deployment, if two collectors fetched POI at slightly different moments, they end up with different cached snapshots — one says "ride X is temp-closed", the other says "open" — and they alternate writes on every poll cycle.

## Fix

Treat the wait-times feed as the ground truth for "is this ride currently taking guests". If the feed gives us a numeric value, the ride IS operating, regardless of what POI's cached `temporarily_closed` hint says. The hint is only authoritative when the wait-times feed has no number.

Decision logic extracted into a pure `plopsaDecideOperating(parkOpenNow, tempClosed, hasWait)` helper.

Behaviour matrix:
| parkOpenNow | tempClosed | hasWait | before | after |
|---|---|---|---|---|
| true  | false | true  | OPERATING ✓ | OPERATING ✓ |
| true  | false | false | OPERATING   | OPERATING   |
| true  | true  | **true**  | **CLOSED ❌** | **OPERATING ✓** |
| true  | true  | false | CLOSED      | CLOSED      |
| false | *     | *     | CLOSED      | CLOSED      |

Only one cell changes — the cell the bug is hitting.

## Test

New `src/parks/plopsa/__tests__/plopsa.test.ts` exercises all 8 input combinations of the helper, with the bug-case row pinned as a regression. 5 new tests / 1076 total / all pass.

## Test plan
- [x] `npm test` — 48 files / 1076 tests pass
- [ ] After deploy: lockstep OPERATING ↔ CLOSED flapping on the affected ride set should stop within one polling cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)