### PR TITLE
feat(universal): integrate Express Now paid return-time offers

### DIFF
--- a/src/__tests__/geo.test.ts
+++ b/src/__tests__/geo.test.ts
@@ -1,0 +1,45 @@
+import {describe, it, expect} from 'vitest';
+import {randomPointInRadius, randomPointInBoundingBox} from '../geo.js';
+
+const EARTH_RADIUS_M = 6_378_137;
+
+function haversineMetres(a: {latitude: number; longitude: number}, b: {latitude: number; longitude: number}): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+describe('randomPointInRadius', () => {
+  it('produces points within the requested radius (with small floating-point slack)', () => {
+    const centre = {latitude: 28.4747, longitude: -81.4682};
+    const radius = 150;
+    for (let i = 0; i < 500; i++) {
+      const p = randomPointInRadius(centre, radius);
+      const d = haversineMetres(centre, p);
+      expect(d).toBeLessThanOrEqual(radius + 1);
+    }
+  });
+
+  it('produces different points on successive calls', () => {
+    const centre = {latitude: 0, longitude: 0};
+    const a = randomPointInRadius(centre, 100);
+    const b = randomPointInRadius(centre, 100);
+    expect(a).not.toEqual(b);
+  });
+});
+
+describe('randomPointInBoundingBox', () => {
+  it('produces points inside the bounding box', () => {
+    for (let i = 0; i < 100; i++) {
+      const p = randomPointInBoundingBox(10, 20, -30, -20);
+      expect(p.latitude).toBeGreaterThanOrEqual(10);
+      expect(p.latitude).toBeLessThanOrEqual(20);
+      expect(p.longitude).toBeGreaterThanOrEqual(-30);
+      expect(p.longitude).toBeLessThanOrEqual(-20);
+    }
+  });
+});

--- a/src/__tests__/geo.test.ts
+++ b/src/__tests__/geo.test.ts
@@ -24,11 +24,13 @@ describe('randomPointInRadius', () => {
     }
   });
 
-  it('produces different points on successive calls', () => {
+  it('produces a non-degenerate spread across many calls', () => {
+    // Avoid asserting "two consecutive calls differ" — that's probabilistic.
+    // Instead: across 200 samples, we should see meaningful variance.
     const centre = {latitude: 0, longitude: 0};
-    const a = randomPointInRadius(centre, 100);
-    const b = randomPointInRadius(centre, 100);
-    expect(a).not.toEqual(b);
+    const samples = Array.from({length: 200}, () => randomPointInRadius(centre, 100));
+    const distinct = new Set(samples.map((p) => `${p.latitude},${p.longitude}`));
+    expect(distinct.size).toBeGreaterThan(150);
   });
 });
 

--- a/src/geo.ts
+++ b/src/geo.ts
@@ -1,0 +1,48 @@
+/**
+ * Geospatial utilities.
+ */
+
+const EARTH_RADIUS_M = 6_378_137; // WGS84 equatorial radius
+
+export type LatLng = {latitude: number; longitude: number};
+
+/**
+ * Generate a uniformly-distributed random point within `radiusMetres` of the
+ * given centre. Uses an equirectangular approximation, which is accurate for
+ * radii up to a few kilometres at non-polar latitudes — fine for theme parks.
+ */
+export function randomPointInRadius(
+  centre: LatLng,
+  radiusMetres: number,
+): LatLng {
+  // Uniform area distribution: r = R * sqrt(u)
+  const u = Math.random();
+  const t = 2 * Math.PI * Math.random();
+  const r = radiusMetres * Math.sqrt(u);
+
+  const dx = r * Math.cos(t);
+  const dy = r * Math.sin(t);
+
+  const dLat = (dy / EARTH_RADIUS_M) * (180 / Math.PI);
+  const dLng = (dx / (EARTH_RADIUS_M * Math.cos((centre.latitude * Math.PI) / 180))) * (180 / Math.PI);
+
+  return {
+    latitude: centre.latitude + dLat,
+    longitude: centre.longitude + dLng,
+  };
+}
+
+/**
+ * Generate a random point uniformly within an axis-aligned lat/lng bounding box.
+ */
+export function randomPointInBoundingBox(
+  minLat: number,
+  maxLat: number,
+  minLng: number,
+  maxLng: number,
+): LatLng {
+  return {
+    latitude: minLat + Math.random() * (maxLat - minLat),
+    longitude: minLng + Math.random() * (maxLng - minLng),
+  };
+}

--- a/src/geo.ts
+++ b/src/geo.ts
@@ -2,9 +2,25 @@
  * Geospatial utilities.
  */
 
+import {randomBytes} from 'node:crypto';
+
 const EARTH_RADIUS_M = 6_378_137; // WGS84 equatorial radius
 
 export type LatLng = {latitude: number; longitude: number};
+
+/**
+ * Cryptographically-strong uniform random in [0, 1) with full 53-bit
+ * mantissa precision. We don't actually need crypto strength for jittering
+ * coordinates — `Math.random` would be fine — but using `crypto.randomBytes`
+ * keeps CodeQL's "insecure randomness" alert quiet without further wiring.
+ */
+function randomDouble(): number {
+  const buf = randomBytes(8);
+  // 21 high bits + 32 low bits = 53-bit unsigned int → divide by 2^53
+  const high = buf.readUInt32BE(0) >>> 11;
+  const low = buf.readUInt32BE(4);
+  return (high * 0x1_0000_0000 + low) / 2 ** 53;
+}
 
 /**
  * Generate a uniformly-distributed random point within `radiusMetres` of the
@@ -16,8 +32,8 @@ export function randomPointInRadius(
   radiusMetres: number,
 ): LatLng {
   // Uniform area distribution: r = R * sqrt(u)
-  const u = Math.random();
-  const t = 2 * Math.PI * Math.random();
+  const u = randomDouble();
+  const t = 2 * Math.PI * randomDouble();
   const r = radiusMetres * Math.sqrt(u);
 
   const dx = r * Math.cos(t);
@@ -42,7 +58,7 @@ export function randomPointInBoundingBox(
   maxLng: number,
 ): LatLng {
   return {
-    latitude: minLat + Math.random() * (maxLat - minLat),
-    longitude: minLng + Math.random() * (maxLng - minLng),
+    latitude: minLat + randomDouble() * (maxLat - minLat),
+    longitude: minLng + randomDouble() * (maxLng - minLng),
   };
 }

--- a/src/parks/universal/__tests__/expressNow.test.ts
+++ b/src/parks/universal/__tests__/expressNow.test.ts
@@ -69,9 +69,30 @@ describe('parseExpressNowResponse', () => {
       predictions: [
         {place_id: 'uor.bad.price', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: 'not-a-number', vl_inventory: '1'},
         {place_id: 'uor.bad.mins', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '', product_price: '5.00', vl_inventory: '1'},
+        {place_id: 'uor.bad.inv', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: '5.00', vl_inventory: 'NaN'},
       ],
     });
     expect(out).toEqual({});
+  });
+
+  test('skips entries with missing or malformed inventory_time_slot', () => {
+    const base = {
+      offer_id: 'x',
+      inventory_time_minutes: '5',
+      product_price: '5.00',
+      vl_inventory: '1',
+    };
+    const out = parseExpressNowResponse({
+      predictions: [
+        {...base, place_id: 'uor.no.slot'},
+        {...base, place_id: 'uor.null.slot', inventory_time_slot: null},
+        {...base, place_id: 'uor.empty.slot', inventory_time_slot: ''},
+        {...base, place_id: 'uor.garbage.slot', inventory_time_slot: 'not-a-timestamp'},
+        {...base, place_id: 'uor.with.tz', inventory_time_slot: '2026-05-07T10:00:00Z'}, // we want naive form only
+        {...base, place_id: 'uor.ok', inventory_time_slot: '2026-05-07T10:00:00'},
+      ],
+    });
+    expect(Object.keys(out)).toEqual(['uor.ok']);
   });
 
   test('keeps earliest slot when multiple offers share a place_id', () => {

--- a/src/parks/universal/__tests__/expressNow.test.ts
+++ b/src/parks/universal/__tests__/expressNow.test.ts
@@ -53,23 +53,27 @@ describe('parseExpressNowResponse', () => {
     expect(parseExpressNowResponse(null)).toEqual({});
   });
 
-  test('skips entries without place_id', () => {
+  test('skips entries without place_id or offer_id', () => {
+    const ok = {offer_id: 'ok', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'};
     const out = parseExpressNowResponse({
       predictions: [
-        {place_id: null, inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'},
-        {inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'},
-        {place_id: 'uor.ride.one', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'},
+        {...ok, place_id: null},
+        {...ok}, // no place_id
+        {...ok, place_id: 'uor.no.offer', offer_id: undefined},
+        {...ok, place_id: 'uor.empty.offer', offer_id: ''},
+        {...ok, place_id: 'uor.ride.one'},
       ],
     });
     expect(Object.keys(out)).toEqual(['uor.ride.one']);
   });
 
   test('skips entries with NaN price or minutes (malformed strings)', () => {
+    const base = {offer_id: 'x', inventory_time_slot: '2026-05-07T10:00:00'};
     const out = parseExpressNowResponse({
       predictions: [
-        {place_id: 'uor.bad.price', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: 'not-a-number', vl_inventory: '1'},
-        {place_id: 'uor.bad.mins', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '', product_price: '5.00', vl_inventory: '1'},
-        {place_id: 'uor.bad.inv', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: '5.00', vl_inventory: 'NaN'},
+        {...base, place_id: 'uor.bad.price', inventory_time_minutes: '5', product_price: 'not-a-number', vl_inventory: '1'},
+        {...base, place_id: 'uor.bad.mins', inventory_time_minutes: '', product_price: '5.00', vl_inventory: '1'},
+        {...base, place_id: 'uor.bad.inv', inventory_time_minutes: '5', product_price: '5.00', vl_inventory: 'NaN'},
       ],
     });
     expect(out).toEqual({});

--- a/src/parks/universal/__tests__/expressNow.test.ts
+++ b/src/parks/universal/__tests__/expressNow.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Express Now `/get-offers` parser regression tests.
+ *
+ * The reference payload is the literal first real sample observed on the
+ * live endpoint (Spider-Man, Mardi Gras late-close window). The wire
+ * format reports every numeric field as a string — drift here would
+ * silently produce NaN / wrong-currency-amount, so pinning is worth it.
+ */
+import {describe, test, expect} from 'vitest';
+import {parseExpressNowResponse} from '../universal.js';
+
+const SAMPLE_PAYLOAD = {
+  predictions: [{
+    offer_id: 'udx.uor.expressnow.offer1',
+    place_id: 'uor.ioa.rides.the_amazing_adventures_of_spider_man',
+    inventory_time_slot: '2026-05-07T00:31:00',
+    inventory_time_minutes: '28',
+    return_time_detail_id: '445292',
+    product_price: '39.99',
+    max_quantity: '15',
+    detail_content_id: '170110100027-ExpressNow-0000',
+    vl_inventory: '1',
+  }],
+};
+
+describe('parseExpressNowResponse', () => {
+  test('parses the first observed real sample', () => {
+    const out = parseExpressNowResponse(SAMPLE_PAYLOAD);
+    const placeId = 'uor.ioa.rides.the_amazing_adventures_of_spider_man';
+
+    expect(Object.keys(out)).toEqual([placeId]);
+    expect(out[placeId]).toEqual({
+      offer_id: 'udx.uor.expressnow.offer1',
+      place_id: placeId,
+      inventory_time_slot: '2026-05-07T00:31:00',
+      inventory_time_minutes: 28,
+      product_price: 39.99,
+      vl_inventory: 1,
+    });
+  });
+
+  test('product_price * 100 rounds cleanly to cents (no float drift)', () => {
+    const out = parseExpressNowResponse(SAMPLE_PAYLOAD);
+    const placeId = 'uor.ioa.rides.the_amazing_adventures_of_spider_man';
+    // 39.99 * 100 = 3998.9999999999995 in IEEE-754 — Math.round saves us.
+    expect(Math.round(out[placeId].product_price * 100)).toBe(3999);
+  });
+
+  test('empty / non-array predictions → empty object', () => {
+    expect(parseExpressNowResponse({})).toEqual({});
+    expect(parseExpressNowResponse({predictions: null})).toEqual({});
+    expect(parseExpressNowResponse({predictions: 'not-an-array'})).toEqual({});
+    expect(parseExpressNowResponse(null)).toEqual({});
+  });
+
+  test('skips entries without place_id', () => {
+    const out = parseExpressNowResponse({
+      predictions: [
+        {place_id: null, inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'},
+        {inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'},
+        {place_id: 'uor.ride.one', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: '1.00', vl_inventory: '1'},
+      ],
+    });
+    expect(Object.keys(out)).toEqual(['uor.ride.one']);
+  });
+
+  test('skips entries with NaN price or minutes (malformed strings)', () => {
+    const out = parseExpressNowResponse({
+      predictions: [
+        {place_id: 'uor.bad.price', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '5', product_price: 'not-a-number', vl_inventory: '1'},
+        {place_id: 'uor.bad.mins', inventory_time_slot: '2026-05-07T10:00:00', inventory_time_minutes: '', product_price: '5.00', vl_inventory: '1'},
+      ],
+    });
+    expect(out).toEqual({});
+  });
+
+  test('keeps earliest slot when multiple offers share a place_id', () => {
+    const out = parseExpressNowResponse({
+      predictions: [
+        {place_id: 'uor.ride.x', offer_id: 'late', inventory_time_slot: '2026-05-07T18:00:00', inventory_time_minutes: '30', product_price: '20.00', vl_inventory: '5'},
+        {place_id: 'uor.ride.x', offer_id: 'early', inventory_time_slot: '2026-05-07T11:00:00', inventory_time_minutes: '30', product_price: '15.00', vl_inventory: '5'},
+        {place_id: 'uor.ride.x', offer_id: 'mid', inventory_time_slot: '2026-05-07T14:00:00', inventory_time_minutes: '30', product_price: '17.00', vl_inventory: '5'},
+      ],
+    });
+    expect(out['uor.ride.x'].offer_id).toBe('early');
+    expect(out['uor.ride.x'].product_price).toBe(15);
+  });
+});

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -151,13 +151,20 @@ export type ExpressNowOffer = {
  * sample that came back from the live endpoint (Spider-Man, Mardi Gras
  * late-close window).
  */
+// Required `inventory_time_slot` format. Must be enforced at parse time —
+// downstream emission feeds the value into `parseTimeInTimezone` and `new
+// Date()`, both of which would silently produce an Invalid Date for
+// anything else, then `formatInTimezone` would throw mid-buildLiveData.
+const SLOT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
+
 export function parseExpressNowResponse(data: unknown): Record<string, ExpressNowOffer> {
   const predictions: any[] = Array.isArray((data as any)?.predictions) ? (data as any).predictions : [];
   const grouped: Record<string, ExpressNowOffer> = {};
 
   for (const raw of predictions) {
     const placeId = raw?.place_id;
-    if (!placeId) continue;
+    if (typeof placeId !== 'string' || !placeId) continue;
+    if (typeof raw?.inventory_time_slot !== 'string' || !SLOT_RE.test(raw.inventory_time_slot)) continue;
 
     const parsed: ExpressNowOffer = {
       offer_id: raw.offer_id,
@@ -173,9 +180,10 @@ export function parseExpressNowResponse(data: unknown): Record<string, ExpressNo
         || !Number.isFinite(parsed.vl_inventory)) continue;
 
     const existing = grouped[placeId];
-    // The slot format is `YYYY-MM-DDTHH:mm:ss` — lexicographic compare is
-    // equivalent to chronological compare and avoids assuming the runtime
-    // and park timezone agree (`new Date()` parses naive ISO as local).
+    // The slot format is fixed `YYYY-MM-DDTHH:mm:ss` (validated above) —
+    // lexicographic compare is chronologically equivalent and avoids
+    // assuming the runtime and park timezone agree (`new Date()` parses
+    // naive ISO as local).
     if (!existing || parsed.inventory_time_slot < existing.inventory_time_slot) {
       grouped[placeId] = parsed;
     }
@@ -429,12 +437,14 @@ class Universal extends Destination {
       resp = await this.fetchExpressNowOffers();
     } catch (err: any) {
       const msg = String(err?.message ?? err);
-      // 404 / OFFERS_NOT_FOUND is the steady state when Express Now isn't
-      // selling — cache as empty (long TTL via callback above).
-      if (msg.includes('404') || msg.includes('OFFERS_NOT_FOUND')) return {};
-      // Anything else (network / 5xx / parse) is transient — let it bubble
-      // so @cache doesn't store an empty result that masks the outage. The
-      // caller (buildLiveData) catches and degrades gracefully.
+      // The 404 response always carries `"problem":"OFFERS_NOT_FOUND"` in
+      // the body — match on that specifically. A bare `404` substring would
+      // also swallow misconfiguration / wrong path / auth-rejection-as-404,
+      // masking real bugs behind the long empty-result TTL.
+      if (msg.includes('OFFERS_NOT_FOUND')) return {};
+      // Anything else (network / 5xx / parse / unexpected 404) is transient
+      // or a real bug — let it bubble so @cache doesn't poison the result.
+      // buildLiveData catches and degrades gracefully.
       throw err;
     }
 
@@ -1051,15 +1061,27 @@ class Universal extends Destination {
 
       const entry = liveDataMap.get(poiId);
       if (!entry) continue;
+
+      // Defensive: parseExpressNowResponse already validates the slot
+      // format, so this should never throw — but if `parseTimeInTimezone`
+      // or `formatInTimezone` ever surprises us on a future format change,
+      // skip just this one offer rather than bringing down buildLiveData
+      // for the whole destination.
+      let startIso: string;
+      let endIso: string;
+      try {
+        startIso = parseTimeInTimezone(offer.inventory_time_slot, this.timezone);
+        const endDate = addMinutes(new Date(startIso), offer.inventory_time_minutes);
+        if (Number.isNaN(endDate.getTime())) throw new Error('invalid end date');
+        endIso = formatInTimezone(endDate, this.timezone, 'iso');
+      } catch (err: any) {
+        console.warn(
+          `Universal: skipping Express Now offer for ${placeId} — bad time slot ${offer.inventory_time_slot}: ${err?.message ?? err}`,
+        );
+        continue;
+      }
+
       if (!entry.queue) entry.queue = {};
-
-      const startIso = parseTimeInTimezone(offer.inventory_time_slot, this.timezone);
-      const endIso = formatInTimezone(
-        addMinutes(new Date(startIso), offer.inventory_time_minutes),
-        this.timezone,
-        'iso',
-      );
-
       entry.queue.PAID_RETURN_TIME = {
         returnStart: startIso,
         returnEnd: endIso,

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -247,8 +247,9 @@ class Universal extends Destination {
 
   /**
    * Park centre latitude — used to jitter Express Now offers requests.
-   * NaN by default so the truthy-check in `getExpressNowOffers` doesn't
-   * misclassify a configured `0` (equator) as "unset".
+   * NaN by default so the `Number.isFinite` guard in `getExpressNowOffers`
+   * fails until the value is actually configured. (A literal `0` for a
+   * park sited at the equator is a valid finite value and would pass.)
    */
   @config
   parkLatitude: number = NaN;
@@ -332,8 +333,10 @@ class Universal extends Destination {
     requestObj.headers = headers;
   }
 
-  /** Fetch UDX OAuth2 token via client credentials. */
-  @http({tags: ['udxAuth']} as any)
+  /** Fetch UDX OAuth2 token via client credentials. The request-level
+   * `tags: ['udxAuth']` (on the returned HTTPObj) is what `injectUdxToken`
+   * matches against to skip itself for this call. */
+  @http()
   async fetchUdxToken(): Promise<HTTPObj> {
     if (!this.udxBase || !this.udxClientId || !this.udxClientSecret) {
       throw new Error(
@@ -409,7 +412,7 @@ class Universal extends Destination {
    * within 150m of the park centre per request so successive polls don't
    * fingerprint as identical.
    */
-  @http({tags: ['expressNowOffers'], retries: 0} as any)
+  @http({retries: 0})
   async fetchExpressNowOffers(): Promise<HTTPObj> {
     const instanceId = await this.getExpressNowInstanceId();
     const point = randomPointInRadius(

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -164,6 +164,7 @@ export function parseExpressNowResponse(data: unknown): Record<string, ExpressNo
   for (const raw of predictions) {
     const placeId = raw?.place_id;
     if (typeof placeId !== 'string' || !placeId) continue;
+    if (typeof raw?.offer_id !== 'string' || !raw.offer_id) continue;
     if (typeof raw?.inventory_time_slot !== 'string' || !SLOT_RE.test(raw.inventory_time_slot)) continue;
 
     const parsed: ExpressNowOffer = {
@@ -244,13 +245,17 @@ class Universal extends Destination {
   @config
   flutterAppVersion: string = "";
 
-  /** Park centre latitude — used to jitter Express Now offers requests. */
+  /**
+   * Park centre latitude — used to jitter Express Now offers requests.
+   * NaN by default so the truthy-check in `getExpressNowOffers` doesn't
+   * misclassify a configured `0` (equator) as "unset".
+   */
   @config
-  parkLatitude: number = 0;
+  parkLatitude: number = NaN;
 
-  /** Park centre longitude. */
+  /** Park centre longitude. NaN by default — see `parkLatitude`. */
   @config
-  parkLongitude: number = 0;
+  parkLongitude: number = NaN;
 
   @config
   city: string = "orlando";
@@ -330,6 +335,12 @@ class Universal extends Destination {
   /** Fetch UDX OAuth2 token via client credentials. */
   @http({tags: ['udxAuth']} as any)
   async fetchUdxToken(): Promise<HTTPObj> {
+    if (!this.udxBase || !this.udxClientId || !this.udxClientSecret) {
+      throw new Error(
+        `Universal UDX: missing config (udxBase=${!!this.udxBase}, udxClientId=${!!this.udxClientId}, udxClientSecret=${!!this.udxClientSecret}). ` +
+        `Set UNIVERSALSTUDIOS_UDXBASE / UNIVERSALSTUDIOS_UDXCLIENTID / UNIVERSALSTUDIOS_UDXCLIENTSECRET in .env.`,
+      );
+    }
     const credentials = Buffer.from(`${this.udxClientId}:${this.udxClientSecret}`).toString('base64');
     return {
       method: 'POST',
@@ -430,7 +441,7 @@ class Universal extends Destination {
    */
   @cache({callback: (offers: Record<string, ExpressNowOffer>) => Object.keys(offers).length === 0 ? 600 : 60})
   async getExpressNowOffers(): Promise<Record<string, ExpressNowOffer>> {
-    if (!this.udxBase || !this.parkLatitude || !this.parkLongitude) return {};
+    if (!this.udxBase || !Number.isFinite(this.parkLatitude) || !Number.isFinite(this.parkLongitude)) return {};
 
     let resp: HTTPObj;
     try {
@@ -1064,16 +1075,16 @@ class Universal extends Destination {
 
       // Defensive: parseExpressNowResponse already validates the slot
       // format, so this should never throw — but if `parseTimeInTimezone`
-      // or `formatInTimezone` ever surprises us on a future format change,
-      // skip just this one offer rather than bringing down buildLiveData
-      // for the whole destination.
-      let startIso: string;
-      let endIso: string;
+      // ever surprises us on a future format change, skip just this offer
+      // rather than bringing down buildLiveData for the whole destination.
+      let startDate: Date;
+      let endDate: Date;
       try {
-        startIso = parseTimeInTimezone(offer.inventory_time_slot, this.timezone);
-        const endDate = addMinutes(new Date(startIso), offer.inventory_time_minutes);
-        if (Number.isNaN(endDate.getTime())) throw new Error('invalid end date');
-        endIso = formatInTimezone(endDate, this.timezone, 'iso');
+        startDate = new Date(parseTimeInTimezone(offer.inventory_time_slot, this.timezone));
+        endDate = addMinutes(startDate, offer.inventory_time_minutes);
+        if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+          throw new Error('invalid date');
+        }
       } catch (err: any) {
         console.warn(
           `Universal: skipping Express Now offer for ${placeId} — bad time slot ${offer.inventory_time_slot}: ${err?.message ?? err}`,
@@ -1082,15 +1093,13 @@ class Universal extends Destination {
       }
 
       if (!entry.queue) entry.queue = {};
-      entry.queue.PAID_RETURN_TIME = {
-        returnStart: startIso,
-        returnEnd: endIso,
-        state: 'AVAILABLE',
-        price: {
-          amount: Math.round(offer.product_price * 100), // dollars → cents
-          currency: 'USD',
-        },
-      };
+      entry.queue.PAID_RETURN_TIME = this.buildPaidReturnTimeQueue(
+        'AVAILABLE',
+        startDate,
+        endDate,
+        'USD',
+        Math.round(offer.product_price * 100), // dollars → cents
+      );
     }
 
     return liveData;

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -13,8 +13,9 @@ import {
   AttractionTypeEnum,
   QueueTypeEnum,
 } from '@themeparks/typelib';
-import {formatUTC, parseTimeInTimezone, formatInTimezone, addDays, isBefore, constructDateTime} from '../../datetime.js';
+import {formatUTC, parseTimeInTimezone, formatInTimezone, addDays, isBefore, constructDateTime, addMinutes, hostnameFromUrl} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
+import {randomPointInRadius} from '../../geo.js';
 
 // Only return restaurants using these dining types
 const WANTED_DINING_TYPES = ['CasualDining', 'FineDining'];
@@ -126,6 +127,22 @@ type UniversalVirtualQueueDetails = {
 };
 
 /**
+ * One Express Now offer, post-parsing.
+ *
+ * Numeric fields arrive as strings on the wire (Flutter parser uses
+ * `int.parse` / `double.parse` on every numeric field) — we coerce them
+ * once here so downstream code never has to.
+ */
+type ExpressNowOffer = {
+  offer_id: string;
+  place_id: string;
+  inventory_time_slot: string;   // ISO datetime — return window start (park-local, no offset)
+  inventory_time_minutes: number; // window length
+  product_price: number;          // USD, decimal
+  vl_inventory: number;           // remaining inventory
+};
+
+/**
  * Universal schedule API response
  */
 type UniversalScheduleResponse = Array<{
@@ -153,6 +170,38 @@ class Universal extends Destination {
 
   @config
   assetsBase: string = "";
+
+  /** UDX platform API base — used by Express Now (new Flutter app API). */
+  @config
+  udxBase: string = "";
+
+  /** UDX OAuth2 client ID. */
+  @config
+  udxClientId: string = "";
+
+  /** UDX OAuth2 client secret. */
+  @config
+  udxClientSecret: string = "";
+
+  /**
+   * Flutter app API key for UDX calls (e.g. `UORFlutterAndroidApp`). The
+   * legacy Android key (`AndroidMobileApp`) is rejected by the Express Now
+   * endpoint — a resort-specific Flutter key is required.
+   */
+  @config
+  flutterAppKey: string = "";
+
+  /** Flutter app version sent on UDX requests. Rotates with app updates. */
+  @config
+  flutterAppVersion: string = "";
+
+  /** Park centre latitude — used to jitter Express Now offers requests. */
+  @config
+  parkLatitude: number = 0;
+
+  /** Park centre longitude. */
+  @config
+  parkLongitude: number = 0;
 
   @config
   city: string = "orlando";
@@ -196,6 +245,180 @@ class Universal extends Destination {
       'X-UNIWebService-Token': apiKeyData.apiKey,
     };
   }
+
+  // ─── UDX platform API (Express Now, new Flutter app) ────────────────────
+
+  /**
+   * Inject Bearer token + Flutter-app fingerprint headers on UDX requests.
+   * Skipped for the OAuth call itself (tagged `udxAuth`).
+   */
+  @inject({
+    eventName: 'httpRequest',
+    hostname: function() {
+      if (!this.udxBase) return null;
+      return hostnameFromUrl(this.udxBase);
+    },
+    tags: {$nin: ['udxAuth']},
+  })
+  async injectUdxToken(requestObj: HTTPObj): Promise<void> {
+    if (!this.udxBase) return;
+    const {token} = await this.getUdxToken();
+    const headers: Record<string, string> = {
+      ...requestObj.headers,
+      'user-agent': 'Dart/3.6 (dart:io)',
+      'accept-language': 'en-US',
+      'x-uniwebservice-platform': 'Android',
+      'x-uniwebservice-platformversion': '14',
+      'x-uniwebservice-device': 'ONEPLUS A5000',
+      'Authorization': `Bearer ${token}`,
+    };
+    if (this.flutterAppVersion) {
+      headers['x-uniwebservice-appversion'] = this.flutterAppVersion;
+    }
+    requestObj.headers = headers;
+  }
+
+  /** Fetch UDX OAuth2 token via client credentials. */
+  @http({tags: ['udxAuth']} as any)
+  async fetchUdxToken(): Promise<HTTPObj> {
+    const credentials = Buffer.from(`${this.udxClientId}:${this.udxClientSecret}`).toString('base64');
+    return {
+      method: 'POST',
+      url: `${this.udxBase}/oidc/connect/token`,
+      body: 'scope=default&grant_type=client_credentials',
+      headers: {
+        'Authorization': `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+        'user-agent': 'Dart/3.6 (dart:io)',
+      },
+      tags: ['udxAuth'],
+    } as any as HTTPObj;
+  }
+
+  /** Cached UDX access token. */
+  @cache({callback: (resp: {token: string; expiresIn: number}) => resp?.expiresIn || 3600})
+  async getUdxToken(): Promise<{token: string; expiresIn: number}> {
+    const resp = await this.fetchUdxToken();
+    const data: any = await resp.json();
+    if (!data?.access_token) {
+      throw new Error('Universal UDX: no access_token in response');
+    }
+    return {
+      token: data.access_token,
+      expiresIn: (data.expires_in as number) || 3600,
+    };
+  }
+
+  /**
+   * Inject Express Now headers (resort code + Flutter app key). The legacy
+   * `X-UNIWebService-ApiKey: AndroidMobileApp` is rejected here — UDX wants
+   * the resort-specific Flutter key.
+   */
+  @inject({
+    eventName: 'httpRequest',
+    hostname: function() {
+      if (!this.udxBase) return null;
+      return hostnameFromUrl(this.udxBase);
+    },
+    tags: 'expressNowOffers',
+  })
+  async injectExpressNowHeaders(requestObj: HTTPObj): Promise<void> {
+    const flutterKey = this.flutterAppKey || `${this.resortKey.toUpperCase()}FlutterAndroidApp`;
+    requestObj.headers = {
+      ...requestObj.headers,
+      'x-resort-area-code': this.resortKey.toUpperCase(),
+      'X-UNIWebService-ApiKey': flutterKey,
+    };
+  }
+
+  /**
+   * Stable instance UUID for unauthenticated Express Now calls. The Flutter
+   * app generates one v4 UUID per install and reuses it as the long-lived
+   * guest identifier — we cache for 30 days to mirror that behaviour.
+   */
+  @cache({ttlSeconds: 60 * 60 * 24 * 30})
+  async getExpressNowInstanceId(): Promise<string> {
+    return crypto.randomUUID();
+  }
+
+  /**
+   * POST UDX `/instances/{instanceId}/get-offers`. The lat/lon are jittered
+   * within 150m of the park centre per request so successive polls don't
+   * fingerprint as identical.
+   */
+  @http({tags: ['expressNowOffers'], retries: 0} as any)
+  async fetchExpressNowOffers(): Promise<HTTPObj> {
+    const instanceId = await this.getExpressNowInstanceId();
+    const point = randomPointInRadius(
+      {latitude: this.parkLatitude, longitude: this.parkLongitude},
+      150,
+    );
+    return {
+      method: 'POST',
+      url: `${this.udxBase}/instances/${instanceId}/get-offers`,
+      body: {
+        location_lat: String(point.latitude),
+        location_long: String(point.longitude),
+        device_id: instanceId,
+      },
+      options: {json: true},
+      tags: ['expressNowOffers'],
+    } as any as HTTPObj;
+  }
+
+  /**
+   * Get parsed Express Now offers, grouped by `place_id`.
+   * Empty object when Express Now isn't selling (404 / `OFFERS_NOT_FOUND`).
+   *
+   * TTL is dynamic: 60s when there are live offers (we want fresh inventory),
+   * 10min when the endpoint reports OFFERS_NOT_FOUND (Express Now isn't
+   * selling, so we don't need to re-poll often — and re-polling generates
+   * a 404 console.error each time the http layer rejects).
+   */
+  @cache({callback: (offers: Record<string, ExpressNowOffer>) => Object.keys(offers).length === 0 ? 600 : 60})
+  async getExpressNowOffers(): Promise<Record<string, ExpressNowOffer>> {
+    if (!this.udxBase || !this.parkLatitude || !this.parkLongitude) return {};
+
+    let resp: HTTPObj | undefined;
+    try {
+      resp = await this.fetchExpressNowOffers();
+    } catch (err: any) {
+      const msg = String(err?.message ?? err);
+      // 404 / OFFERS_NOT_FOUND is the normal state when nothing is for sale.
+      if (msg.includes('404') || msg.includes('OFFERS_NOT_FOUND')) return {};
+      console.warn('Universal: Express Now offers fetch failed:', msg.split('\n')[0]);
+      return {};
+    }
+
+    const data: any = await resp.json();
+    const offers: any[] = Array.isArray(data?.predictions) ? data.predictions : [];
+    const grouped: Record<string, ExpressNowOffer> = {};
+
+    for (const raw of offers) {
+      const placeId = raw?.place_id;
+      if (!placeId) continue;
+
+      const parsed: ExpressNowOffer = {
+        offer_id: raw.offer_id,
+        place_id: placeId,
+        inventory_time_slot: raw.inventory_time_slot,
+        inventory_time_minutes: parseInt(raw.inventory_time_minutes, 10),
+        product_price: parseFloat(raw.product_price),
+        vl_inventory: parseInt(raw.vl_inventory, 10),
+      };
+
+      if (!Number.isFinite(parsed.product_price) || !Number.isFinite(parsed.inventory_time_minutes)) continue;
+
+      const existing = grouped[placeId];
+      // Pick the earliest available slot per place
+      if (!existing || new Date(parsed.inventory_time_slot) < new Date(existing.inventory_time_slot)) {
+        grouped[placeId] = parsed;
+      }
+    }
+    return grouped;
+  }
+
+  // ─── Legacy API (services.universalorlando.com) ─────────────────────────
 
   /**
    * Handle 401 responses by clearing cached API key
@@ -788,6 +1011,34 @@ class Universal extends Destination {
       }
     }
 
+    // Layer Express Now (paid return time) offers from the UDX API. Only
+    // attached to attractions that already appear in the live-data map —
+    // a paid return-time without a known ride is not actionable downstream.
+    const expressNowOffers = await this.getExpressNowOffers();
+    for (const [placeId, offer] of Object.entries(expressNowOffers)) {
+      if (offer.vl_inventory <= 0) continue;
+
+      const poiId = this.getRideIDFromWaitTimeId(poi, placeId);
+      if (!poiId) continue;
+
+      const entry = liveDataMap.get(poiId);
+      if (!entry) continue;
+      if (!entry.queue) entry.queue = {};
+
+      const startIso = parseTimeInTimezone(offer.inventory_time_slot, this.timezone);
+      const endIso = addMinutes(new Date(startIso), offer.inventory_time_minutes).toISOString();
+
+      entry.queue.PAID_RETURN_TIME = {
+        returnStart: startIso,
+        returnEnd: endIso,
+        state: 'AVAILABLE',
+        price: {
+          amount: Math.round(offer.product_price * 100), // dollars → cents
+          currency: 'USD',
+        },
+      };
+    }
+
     return liveData;
   }
 
@@ -850,6 +1101,8 @@ export class UniversalOrlando extends Universal {
         resortSlug: 'universalorlando',
         resortKey: 'uor',
         timezone: 'America/New_York',
+        parkLatitude: '28.4747',
+        parkLongitude: '-81.4682',
         ...options?.config,
       },
     });
@@ -872,6 +1125,8 @@ export class UniversalStudios extends Universal {
         resortSlug: 'universalstudios',
         resortKey: 'ush',
         timezone: 'America/Los_Angeles',
+        parkLatitude: '34.1381',
+        parkLongitude: '-118.3534',
         ...options?.config,
       },
     });

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -133,7 +133,7 @@ type UniversalVirtualQueueDetails = {
  * `int.parse` / `double.parse` on every numeric field) — we coerce them
  * once here so downstream code never has to.
  */
-type ExpressNowOffer = {
+export type ExpressNowOffer = {
   offer_id: string;
   place_id: string;
   inventory_time_slot: string;   // ISO datetime — return window start (park-local, no offset)
@@ -141,6 +141,42 @@ type ExpressNowOffer = {
   product_price: number;          // USD, decimal
   vl_inventory: number;           // remaining inventory
 };
+
+/**
+ * Pure parser for the Express Now `/get-offers` response body. Coerces the
+ * string-typed numeric fields, drops malformed entries, and groups by
+ * `place_id` keeping the earliest-starting offer per place.
+ *
+ * Exported for unit testing — the reference payload is the first real
+ * sample that came back from the live endpoint (Spider-Man, Mardi Gras
+ * late-close window).
+ */
+export function parseExpressNowResponse(data: unknown): Record<string, ExpressNowOffer> {
+  const predictions: any[] = Array.isArray((data as any)?.predictions) ? (data as any).predictions : [];
+  const grouped: Record<string, ExpressNowOffer> = {};
+
+  for (const raw of predictions) {
+    const placeId = raw?.place_id;
+    if (!placeId) continue;
+
+    const parsed: ExpressNowOffer = {
+      offer_id: raw.offer_id,
+      place_id: placeId,
+      inventory_time_slot: raw.inventory_time_slot,
+      inventory_time_minutes: parseInt(raw.inventory_time_minutes, 10),
+      product_price: parseFloat(raw.product_price),
+      vl_inventory: parseInt(raw.vl_inventory, 10),
+    };
+
+    if (!Number.isFinite(parsed.product_price) || !Number.isFinite(parsed.inventory_time_minutes)) continue;
+
+    const existing = grouped[placeId];
+    if (!existing || new Date(parsed.inventory_time_slot) < new Date(existing.inventory_time_slot)) {
+      grouped[placeId] = parsed;
+    }
+  }
+  return grouped;
+}
 
 /**
  * Universal schedule API response
@@ -390,32 +426,7 @@ class Universal extends Destination {
       return {};
     }
 
-    const data: any = await resp.json();
-    const offers: any[] = Array.isArray(data?.predictions) ? data.predictions : [];
-    const grouped: Record<string, ExpressNowOffer> = {};
-
-    for (const raw of offers) {
-      const placeId = raw?.place_id;
-      if (!placeId) continue;
-
-      const parsed: ExpressNowOffer = {
-        offer_id: raw.offer_id,
-        place_id: placeId,
-        inventory_time_slot: raw.inventory_time_slot,
-        inventory_time_minutes: parseInt(raw.inventory_time_minutes, 10),
-        product_price: parseFloat(raw.product_price),
-        vl_inventory: parseInt(raw.vl_inventory, 10),
-      };
-
-      if (!Number.isFinite(parsed.product_price) || !Number.isFinite(parsed.inventory_time_minutes)) continue;
-
-      const existing = grouped[placeId];
-      // Pick the earliest available slot per place
-      if (!existing || new Date(parsed.inventory_time_slot) < new Date(existing.inventory_time_slot)) {
-        grouped[placeId] = parsed;
-      }
-    }
-    return grouped;
+    return parseExpressNowResponse(await resp.json());
   }
 
   // ─── Legacy API (services.universalorlando.com) ─────────────────────────

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -168,10 +168,15 @@ export function parseExpressNowResponse(data: unknown): Record<string, ExpressNo
       vl_inventory: parseInt(raw.vl_inventory, 10),
     };
 
-    if (!Number.isFinite(parsed.product_price) || !Number.isFinite(parsed.inventory_time_minutes)) continue;
+    if (!Number.isFinite(parsed.product_price)
+        || !Number.isFinite(parsed.inventory_time_minutes)
+        || !Number.isFinite(parsed.vl_inventory)) continue;
 
     const existing = grouped[placeId];
-    if (!existing || new Date(parsed.inventory_time_slot) < new Date(existing.inventory_time_slot)) {
+    // The slot format is `YYYY-MM-DDTHH:mm:ss` — lexicographic compare is
+    // equivalent to chronological compare and avoids assuming the runtime
+    // and park timezone agree (`new Date()` parses naive ISO as local).
+    if (!existing || parsed.inventory_time_slot < existing.inventory_time_slot) {
       grouped[placeId] = parsed;
     }
   }
@@ -339,9 +344,12 @@ class Universal extends Destination {
     if (!data?.access_token) {
       throw new Error('Universal UDX: no access_token in response');
     }
+    // expires_in is normally a number, but some OAuth servers stringify it —
+    // coerce so the @cache TTL callback always sees a finite number.
+    const expiresIn = Number(data.expires_in);
     return {
       token: data.access_token,
-      expiresIn: (data.expires_in as number) || 3600,
+      expiresIn: Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 3600,
     };
   }
 
@@ -405,25 +413,29 @@ class Universal extends Destination {
   /**
    * Get parsed Express Now offers, grouped by `place_id`.
    * Empty object when Express Now isn't selling (404 / `OFFERS_NOT_FOUND`).
+   * Throws on any other error so transient failures aren't cached as empty.
    *
    * TTL is dynamic: 60s when there are live offers (we want fresh inventory),
-   * 10min when the endpoint reports OFFERS_NOT_FOUND (Express Now isn't
-   * selling, so we don't need to re-poll often — and re-polling generates
-   * a 404 console.error each time the http layer rejects).
+   * 10min when the endpoint confirms OFFERS_NOT_FOUND (no point re-polling
+   * a stable "nothing for sale" — and re-polling generates a 404 log entry
+   * from the http layer each time).
    */
   @cache({callback: (offers: Record<string, ExpressNowOffer>) => Object.keys(offers).length === 0 ? 600 : 60})
   async getExpressNowOffers(): Promise<Record<string, ExpressNowOffer>> {
     if (!this.udxBase || !this.parkLatitude || !this.parkLongitude) return {};
 
-    let resp: HTTPObj | undefined;
+    let resp: HTTPObj;
     try {
       resp = await this.fetchExpressNowOffers();
     } catch (err: any) {
       const msg = String(err?.message ?? err);
-      // 404 / OFFERS_NOT_FOUND is the normal state when nothing is for sale.
+      // 404 / OFFERS_NOT_FOUND is the steady state when Express Now isn't
+      // selling — cache as empty (long TTL via callback above).
       if (msg.includes('404') || msg.includes('OFFERS_NOT_FOUND')) return {};
-      console.warn('Universal: Express Now offers fetch failed:', msg.split('\n')[0]);
-      return {};
+      // Anything else (network / 5xx / parse) is transient — let it bubble
+      // so @cache doesn't store an empty result that masks the outage. The
+      // caller (buildLiveData) catches and degrades gracefully.
+      throw err;
     }
 
     return parseExpressNowResponse(await resp.json());
@@ -1025,7 +1037,12 @@ class Universal extends Destination {
     // Layer Express Now (paid return time) offers from the UDX API. Only
     // attached to attractions that already appear in the live-data map —
     // a paid return-time without a known ride is not actionable downstream.
-    const expressNowOffers = await this.getExpressNowOffers();
+    let expressNowOffers: Record<string, ExpressNowOffer> = {};
+    try {
+      expressNowOffers = await this.getExpressNowOffers();
+    } catch (err: any) {
+      console.warn('Universal: Express Now offers fetch failed:', String(err?.message ?? err).split('\n')[0]);
+    }
     for (const [placeId, offer] of Object.entries(expressNowOffers)) {
       if (offer.vl_inventory <= 0) continue;
 
@@ -1037,7 +1054,11 @@ class Universal extends Destination {
       if (!entry.queue) entry.queue = {};
 
       const startIso = parseTimeInTimezone(offer.inventory_time_slot, this.timezone);
-      const endIso = addMinutes(new Date(startIso), offer.inventory_time_minutes).toISOString();
+      const endIso = formatInTimezone(
+        addMinutes(new Date(startIso), offer.inventory_time_minutes),
+        this.timezone,
+        'iso',
+      );
 
       entry.queue.PAID_RETURN_TIME = {
         returnStart: startIso,


### PR DESCRIPTION
## Summary

Adds a UDX platform integration to fetch live Universal **Express Now** offers and surface them as `PAID_RETURN_TIME` on Universal Orlando and Universal Studios Hollywood attractions.

- **OAuth2 client credentials** against `{udxBase}/oidc/connect/token` (Basic auth in header, `grant_type=client_credentials&scope=default` in body). Token cached by API-supplied `expires_in`.
- **`POST {udxBase}/instances/{instanceId}/get-offers`** — instance UUID cached 30 days (mirrors the Flutter app's per-install identifier). Lat/lng jittered within 150m of park centre per request.
- **Response parser** coerces string-typed numeric fields (`inventory_time_minutes`, `product_price`, `vl_inventory`), groups by `place_id`, and picks the earliest available slot per place.
- **POI mapping** reuses `getRideIDFromWaitTimeId` (`ExternalIds.PlaceId` / `ContentId`).
- **`buildLiveData`** layer emits `PAID_RETURN_TIME` with `returnStart` / `returnEnd` / `state: 'AVAILABLE'` / `price` (cents, USD).
- **Dynamic cache TTL** — 60s when offers are live, 600s on `OFFERS_NOT_FOUND`. Prevents repeat 4xx logs during inactive selling windows (offers are typically only available at peak demand).
- **`flutterAppVersion`** is configurable via `UNIVERSALSTUDIOS_FLUTTERAPPVERSION` so it can rotate without a code change when Universal updates the Flutter app.
- **New `src/geo.ts`** with `randomPointInRadius` / `randomPointInBoundingBox` + unit tests.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` — 1079/1079 pass (50 files)
- [x] `npm run dev -- universalorlando` — 4/4, get-offers returns 404 OFFERS_NOT_FOUND outside selling hours, caught + cached for 10 min
- [x] `npm run dev -- universalstudios` — 4/4
- [ ] Verify a live `PAID_RETURN_TIME` emission once Express Now is actively selling

🤖 Generated with [Claude Code](https://claude.com/claude-code)