### PR TITLE
docs(claude): correct getDestinations() override guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,10 @@ Promise reuse to prevent duplicate async execution. `@reusable({forever: true})`
 
 All parks extend `Destination` using the **Template Method Pattern**.
 
-**Public API (DO NOT OVERRIDE):** `getDestinations()`, `getEntities()`, `getLiveData()`, `getSchedules()`
+**Public API (DO NOT OVERRIDE — marked `@final` in base class):** `getEntities()`, `getLiveData()`, `getSchedules()`. These call `init()`, then delegate to the corresponding `build*()` method, then run hierarchy resolution / sanitisation / validation.
+
+**Public API (OVERRIDE TO PROVIDE):**
+- `getDestinations()` — Return the top-level `DESTINATION` entity (or entities). Default returns `[]`. Common pattern across parks.
 
 **Protected API (IMPLEMENT IN SUBCLASSES):**
 - `_init()` — Optional one-time initialization


### PR DESCRIPTION
## Summary

CLAUDE.md listed `getDestinations()` alongside `getEntities()`, `getLiveData()`, and `getSchedules()` under "Public API (DO NOT OVERRIDE)". That's wrong — only the latter three are marked `@final` in the base class:

- `Destination#getEntities()`  → `@final` (line 785)
- `Destination#getLiveData()`  → `@final` (line 855)
- `Destination#getSchedules()` → `@final` (line 942)
- `Destination#getDestinations()` → returns `[]` by default, designed to be overridden

8+ existing park implementations override `getDestinations()` to provide the top-level DESTINATION entity (phantasialand, plopsa, fujiq, lotteworld, qiddiyacity, seaworld, toverland, parcsreunidos). The `.claude/skills/implementing-parks.md` guide already documents the correct pattern; only the top-level CLAUDE.md was misleading.

Discovered while reviewing #173 (Flamingo Land), which also overrides `getDestinations()`.

## Test plan

- [x] No code change — docs only
- [x] Verified base-class `@final` annotations on `getEntities` / `getLiveData` / `getSchedules`
- [x] Verified `getDestinations()` returns `[]` by default and is not marked `@final`

🤖 Generated with [Claude Code](https://claude.com/claude-code)