### PR TITLE
fix(usj): decouple wait-time and show-list fetches in live data

### DIFF
--- a/src/parks/usj/universalstudiosjapan.ts
+++ b/src/parks/usj/universalstudiosjapan.ts
@@ -366,10 +366,32 @@ export class UniversalStudiosJapan extends Destination {
   // ─── Live data ────────────────────────────────────────────────────────────
 
   protected async buildLiveData(): Promise<LiveData[]> {
-    const [waitTimeData, showListData] = await Promise.all([
+    // Fetch independently so one CDN endpoint failing doesn't suppress the other.
+    // Previously a single Promise.all rejection killed the whole emission and the
+    // collector skipped the write, producing a multi-hour staleness gap.
+    const [waitTimeResult, showListResult] = await Promise.allSettled([
       this.getWaitTimeData(),
       this.getShowListData(),
     ]);
+
+    const waitTimeData: USJWaitTimeEntry[] =
+      waitTimeResult.status === 'fulfilled' ? waitTimeResult.value : [];
+    const showListData: USJShowEntry[] =
+      showListResult.status === 'fulfilled' ? showListResult.value : [];
+
+    if (waitTimeResult.status === 'rejected') {
+      console.error('USJ: fetchWaitTimes failed', waitTimeResult.reason);
+    }
+    if (showListResult.status === 'rejected') {
+      console.error('USJ: fetchShowList failed', showListResult.reason);
+    }
+
+    // If both fetches failed, throw so the collector logs and skips this cycle
+    // rather than emitting an empty live-data set (which would mark every
+    // attraction CLOSED via the wiki's implicit-closed semantics).
+    if (waitTimeResult.status === 'rejected' && showListResult.status === 'rejected') {
+      throw waitTimeResult.reason;
+    }
 
     const results: LiveData[] = [];
 

--- a/src/parks/usj/universalstudiosjapan.ts
+++ b/src/parks/usj/universalstudiosjapan.ts
@@ -388,9 +388,14 @@ export class UniversalStudiosJapan extends Destination {
 
     // If both fetches failed, throw so the collector logs and skips this cycle
     // rather than emitting an empty live-data set (which would mark every
-    // attraction CLOSED via the wiki's implicit-closed semantics).
+    // attraction CLOSED via the wiki's implicit-closed semantics). Wrap both
+    // reasons in an AggregateError so neither is lost and stack traces stay
+    // useful even if a reason isn't an Error instance.
     if (waitTimeResult.status === 'rejected' && showListResult.status === 'rejected') {
-      throw waitTimeResult.reason;
+      throw new AggregateError(
+        [waitTimeResult.reason, showListResult.reason],
+        'USJ buildLiveData: both fetchWaitTimes and fetchShowList rejected',
+      );
     }
 
     const results: LiveData[] = [];


### PR DESCRIPTION
## Summary

Targeted hardening of USJ's `buildLiveData()` to address a multi-hour live-data staleness pattern.

Previously both CDN fetches (`wait-time-attraction-list.json` and `show-list.json`) ran in a single `Promise.all`. If either rejected — Akamai blip, DNS hiccup, transient 503 — the entire emission threw, the collector logged "Failed to fetch live data" and skipped the write. With `getWaitTimeData` cached only 60s and the collector polling on `updateLoopMinutes`, even a brief one-sided outage could compound into a long staleness gap if both endpoints didn't recover in the same window.

## Changes

- `Promise.all` → `Promise.allSettled`
- Emit live data from whichever fetch(es) succeeded
- Console-log which side failed (so the next prod incident names the endpoint)
- Still throw when *both* fail, so the collector skips the write rather than emitting empty live data (which would mark every attraction CLOSED via the wiki's implicit-closed semantics — worse than staying stale)

## Out of scope

The `/Venues/.../Hours` schedule endpoint is also broken (401 — auth on `mobile-service.usj.co.jp` has moved to a dynamic-token handshake the collector doesn't speak yet). User flagged that schedules may have moved to the website entirely (would need scraping), so deferred to a separate effort.

## Verified

- `npm run build` clean
- `npm test` 1086/1086 pass
- `npm run dev -- universalstudiosjapan` → 104 entities, 42 live data entries — same as before this change in the happy path

## Test plan

- [ ] Wait for next observed staleness incident; confirm prod logs now name which endpoint failed
- [ ] If only one side is failing, confirm partial live data is still being written to the wiki