### PR TITLE
docs(sponsors): add Pocket'Park

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ This library powers the free API at [ThemeParks.wiki](https://themeparks.wiki).
   </span>
 </div>
 
+<div style="display: flex; align-items: center;">
+  <a href="https://pocketpark.fr/">
+    <img src="https://themeparks.wiki/sponsors/pocketpark.png" alt="Pocket'Park" width="40" style="margin-right: 10px;"/>
+  </a>
+  <span>
+    <a href="https://pocketpark.fr/">Pocket'Park</a>
+  </span>
+</div>
+
 ## Quick Start
 
 **Requirements:** Node.js 24+, npm 11+


### PR DESCRIPTION
## Summary
- Adds Pocket'Park (pocketpark.fr) as a third entry under "Sponsored By" in the README, mirroring the existing TouringPlans / Queue Times blocks
- Logo references `https://themeparks.wiki/sponsors/pocketpark.png` — resolves once the matching web change ([ThemeParks/web#1](https://github.com/ThemeParks/web/pull/1)) deploys

## Test plan
- [ ] Preview README on GitHub — Pocket'Park block renders with logo + link
- [ ] Confirm web PR merged & deployed so the image URL resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)