### PR TITLE
fix(europapark): guard live data against poisoned wait-times array

### DIFF
--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -599,12 +599,21 @@ class EuropaParkBase extends Destination {
   @reusable()
   protected async buildLiveData(): Promise<LiveData[]> {
     // Parallelise — these four are independent network calls.
-    const [entities, poiData, waits, showTimes] = await Promise.all([
+    const [entities, poiData, waitsRaw, showTimes] = await Promise.all([
       this.getParkEntities(),
       this.getPOIs(),
       this.getWaitingTimes(),
       this.getShowTimes(),
     ]);
+
+    // Upstream occasionally injects a literal PHP cURL error string as the
+    // first array element when its internal /waittimes/ proxy fails. Drop any
+    // entry that isn't a proper {code, time, ...} object so a missing `code`
+    // doesn't accidentally match `e.vQueue?.code === undefined`.
+    const waits = (Array.isArray(waitsRaw) ? waitsRaw : []).filter(
+      (w): w is EuropaParkWaitTime =>
+        !!w && typeof w === 'object' && typeof (w as any).code === 'string',
+    );
 
     // Build code → entityId map from attraction/show entities
     const codeToEntityId = new Map<string, string>();

--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -607,12 +607,17 @@ class EuropaParkBase extends Destination {
     ]);
 
     // Upstream occasionally injects a literal PHP cURL error string as the
-    // first array element when its internal /waittimes/ proxy fails. Drop any
-    // entry that isn't a proper {code, time, ...} object so a missing `code`
-    // doesn't accidentally match `e.vQueue?.code === undefined`.
+    // first array element when its internal /waittimes/ proxy fails. Require a
+    // string `code` (so a missing code can't match `e.vQueue?.code === undefined`)
+    // AND a finite numeric `time` (downstream uses strict-equality switches and
+    // `<= 91` comparisons that silently misbehave on non-numbers).
     const waits = (Array.isArray(waitsRaw) ? waitsRaw : []).filter(
-      (w): w is EuropaParkWaitTime =>
-        !!w && typeof w === 'object' && typeof (w as any).code === 'string',
+      (w): w is EuropaParkWaitTime => {
+        if (!w || typeof w !== 'object') return false;
+        const code = (w as any).code;
+        const time = (w as any).time;
+        return typeof code === 'string' && typeof time === 'number' && Number.isFinite(time);
+      },
     );
 
     // Build code → entityId map from attraction/show entities


### PR DESCRIPTION
## Summary

Europa-Park's `/api/v2/waiting-times` endpoint internally proxies a private upstream (`io.europapark.de/waittimes/`) via PHP cURL. When that inner call fails, the cURL error message gets serialised as the **first element of the JSON array** instead of a proper error response, e.g.:

```json
["cURL error 35: Recv failure: Connection reset by peer ... for https://io.europapark.de/waittimes/",
 {"code":5002,"time":222,...},
 ...]
```

Our existing code didn't crash on this, but the poison string's `wait.code` is `undefined`, which in the vQueue first pass matches *any* entity whose `vQueue?.code` is also undefined — leading to a bogus `RETURN_TIME` queue being attached to the first vQueue-less entity that happens to also have a valid wait entry.

This PR filters the response to well-formed `{code: string, ...}` entries before either pass runs, so malformed elements are dropped at the boundary.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run dev -- europapark` — 4/4 passes; same 30 live data entries as before the change (no valid data dropped, only the poison entry is skipped)
- [ ] When upstream recovers, wait times return automatically; the filter becomes a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)