### PR TITLE
fix(uss): tolerate malformed 24h+meridiem showtimes

### DIFF
--- a/src/parks/uss/universalsingapore.ts
+++ b/src/parks/uss/universalsingapore.ts
@@ -171,8 +171,15 @@ function parseOperatingHours(raw: string | undefined, date: string): string[] {
     let hour = parseInt(m[1], 10);
     const minute = m[2];
     const meridiem = m[3].toUpperCase();
-    if (meridiem === 'PM' && hour !== 12) hour += 12;
-    if (meridiem === 'AM' && hour === 12) hour = 0;
+    // The API occasionally emits entries like "17:30 PM" — a 24-hour value
+    // with a redundant meridiem. Treat hours 13–23 as already-24h and ignore
+    // the meridiem rather than crashing the whole live-data fetch on the
+    // resulting invalid clock time.
+    if (hour < 0 || hour > 23) continue;
+    if (hour <= 12) {
+      if (meridiem === 'PM' && hour !== 12) hour += 12;
+      if (meridiem === 'AM' && hour === 12) hour = 0;
+    }
     const hh = String(hour).padStart(2, '0');
     out.push(constructDateTime(date, `${hh}:${minute}:00`, TIMEZONE));
   }


### PR DESCRIPTION
## Summary
- Universal Singapore live data was returning stale values because every `getLiveData()` call was throwing `RangeError: Invalid time value`.
- Root cause: the USS API emits entries like `"17:30 PM"` (24-hour value with a redundant meridiem). The old `parseOperatingHours` added 12 unconditionally, producing hour `29`, which `constructDateTime` rejected. The throw bubbled up through `buildLiveData` and killed the entire fetch — wait times were frozen on whatever cache snapshot consumers held.
- Fix: treat hours 13–23 as already-24h and ignore the meridiem; only reject values truly outside 0–23. Live data is restored and the previously-crashing showtime parses correctly (`17:30 PM` → `17:30` local).

## Test plan
- [x] `npm run build`
- [x] `npm run dev -- universalsingapore` — all 4 phases pass (was 3/4 before)
- [x] Verified Illumination's Minions (id 341) now emits all four showtimes including the previously-crashing 17:30 slot
- [ ] No other parks affected — change is confined to USS's local helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)