### PR TITLE
fix(europapark): waiting-times `code` field is a number, not a string

### DIFF
--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -309,10 +309,15 @@ class EuropaParkBase extends Destination {
     return list as EuropaParkPOI[];
   }
 
+  // Return the raw array unparsed — upstream occasionally injects non-object
+  // poison entries (a PHP cURL error string as the first element when the
+  // internal /waittimes/ proxy fails), so callers must narrow to
+  // `EuropaParkWaitTime` via runtime validation.
   @reusable()
-  async getWaitingTimes(): Promise<EuropaParkWaitTime[]> {
+  async getWaitingTimes(): Promise<unknown[]> {
     const resp = await this.fetchWaitingTimes();
-    return (await resp.json()) as EuropaParkWaitTime[];
+    const data = await resp.json();
+    return Array.isArray(data) ? data : [];
   }
 
   @reusable()
@@ -606,12 +611,12 @@ class EuropaParkBase extends Destination {
       this.getShowTimes(),
     ]);
 
-    // Upstream occasionally injects a literal PHP cURL error string as the
-    // first array element when its internal /waittimes/ proxy fails. Require a
-    // numeric `code` (so a missing code can't match `e.vQueue?.code === undefined`)
-    // AND a finite numeric `time` (downstream uses strict-equality switches and
-    // `<= 91` comparisons that silently misbehave on non-numbers).
-    const waits = (Array.isArray(waitsRaw) ? waitsRaw : []).filter(
+    // Narrow the raw wait-times array. Upstream occasionally injects a literal
+    // PHP cURL error string as the first element when its internal /waittimes/
+    // proxy fails; downstream also uses strict-equality switches and `<= 91`
+    // comparisons that silently misbehave on non-numbers — so require both a
+    // finite numeric `code` and a finite numeric `time`.
+    const waits = waitsRaw.filter(
       (w): w is EuropaParkWaitTime => {
         if (!w || typeof w !== 'object') return false;
         const code = (w as any).code;

--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -27,7 +27,7 @@ type EuropaParkPOI = {
   longitude?: number;
   minHeight?: number;
   maxHeight?: number;
-  code?: string;
+  code?: number;
   // showlocation sub-entities
   shows?: EuropaParkShow[];
   // virtual-queue companion data (injected during entity build)
@@ -39,14 +39,14 @@ type EuropaParkShow = {
   id: number;
   name: string;
   duration?: number;
-  code?: string;
+  code?: number;
   latitude?: number;
   longitude?: number;
 };
 
 /** Waiting-times API response item */
 type EuropaParkWaitTime = {
-  code: string;
+  code: number;
   time: number;
   startAt?: string | null;
   endAt?: string | null;
@@ -92,7 +92,7 @@ type EuropaParkEntity = {
   name: string;
   entityType: 'ATTRACTION' | 'SHOW';
   scopes: string[];
-  code?: string;
+  code?: number;
   vQueue?: EuropaParkPOI;
   duration?: number;
   latitude?: number;
@@ -608,7 +608,7 @@ class EuropaParkBase extends Destination {
 
     // Upstream occasionally injects a literal PHP cURL error string as the
     // first array element when its internal /waittimes/ proxy fails. Require a
-    // string `code` (so a missing code can't match `e.vQueue?.code === undefined`)
+    // numeric `code` (so a missing code can't match `e.vQueue?.code === undefined`)
     // AND a finite numeric `time` (downstream uses strict-equality switches and
     // `<= 91` comparisons that silently misbehave on non-numbers).
     const waits = (Array.isArray(waitsRaw) ? waitsRaw : []).filter(
@@ -616,12 +616,13 @@ class EuropaParkBase extends Destination {
         if (!w || typeof w !== 'object') return false;
         const code = (w as any).code;
         const time = (w as any).time;
-        return typeof code === 'string' && typeof time === 'number' && Number.isFinite(time);
+        return typeof code === 'number' && Number.isFinite(code)
+            && typeof time === 'number' && Number.isFinite(time);
       },
     );
 
     // Build code → entityId map from attraction/show entities
-    const codeToEntityId = new Map<string, string>();
+    const codeToEntityId = new Map<number, string>();
     for (const entity of entities) {
       if (entity.code) {
         codeToEntityId.set(entity.code, entity.id);
@@ -647,7 +648,7 @@ class EuropaParkBase extends Destination {
     // ── First pass: extract virtual-queue data ─────────────────────────────
     type VQueueEntry = {
       entityId: string;
-      ignoreCode: string;
+      ignoreCode: number;
       returnStart: string | null;
       returnEnd: string | null;
       state: 'AVAILABLE' | 'TEMP_FULL' | 'FINISHED';


### PR DESCRIPTION
## Summary
Follow-up to #187. The `code` field in the `/api/v2/waiting-times` response has always been a `number` at runtime, but four type declarations (`EuropaParkPOI`, `EuropaParkShow`, `EuropaParkWaitTime`, `EuropaParkEntity`) declared it as `string`. PR #187's defensive filter (`typeof code === 'string' && typeof time === 'number' && Number.isFinite(time)`) trusted that lying type and consequently rejected **every** wait-time entry. Result: `getLiveData()` succeeded, but reported zero wait times across the entire destination.

## Changes
- Correct the four `code` field type declarations from `string` → `number`.
- Retype `codeToEntityId` to `Map<number, string>` (`Map.set/get` was working only because JS doesn't enforce the lying TS generics).
- Retype `VQueueEntry.ignoreCode` to `number`.
- Update the filter to require `typeof code === 'number' && Number.isFinite(code)`. Still defends against the PHP cURL error string the upstream `/waittimes/` proxy occasionally injects as the first array element.

## Verification
- Before: `npm run dev -- europapark` → 31 live entries, **0** with wait times.
- After: `npm run dev -- europapark` → 149 live entries, **48** with wait times.
- `npm test` → 1088 / 1088 pass.

## Test plan
- [x] `npm run build` clean (catches the type-mismatch if Map/VQueueEntry retypes were inconsistent).
- [x] `npm run dev -- europapark` — all 4 phases pass with wait times present.
- [x] `npm test` — full vitest suite green.
- [ ] No other parks affected — change is confined to `src/parks/europapark/europapark.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)