### PR TITLE
fix(universal): restore CHILD_SWAP + MINIMUM_HEIGHT attraction tags

### DIFF
--- a/src/parks/universal/__tests__/places.test.ts
+++ b/src/parks/universal/__tests__/places.test.ts
@@ -127,7 +127,7 @@ describe('placeToEntity', () => {
     expect(e?.tags).toEqual([expect.objectContaining({tag: 'CHILD_SWAP'})]);
   });
 
-  test('Ride with both attributes → emits both tags', () => {
+  test('Ride with both attributes → emits both tags; unrelated attributes ignored', () => {
     const both: UniversalPlace = {
       ...ridePlace,
       place_type: {
@@ -135,12 +135,21 @@ describe('placeToEntity', () => {
         attributes: [
           {name: 'has_child_swap', value: 'true'},
           {name: 'minimum_rider_height_inches', value: '48'},
-          {name: 'express_pass', value: 'true'}, // ignored — not in legacy surface
+          {name: 'express_pass', value: 'true'},        // not in legacy surface — must NOT emit a tag
+          {name: 'mfdo_enabled', value: 'true'},        // ditto
         ],
       },
     };
     const tags = placeToEntity(both, DESTINATION, TZ)?.tags ?? [];
-    expect(tags.length).toBe(2);
+    expect(tags).toHaveLength(2);
+    expect(tags).toEqual(expect.arrayContaining([
+      expect.objectContaining({tag: 'CHILD_SWAP'}),
+      expect.objectContaining({tag: 'MINIMUM_HEIGHT', value: expect.objectContaining({height: 48, unit: 'in'})}),
+    ]));
+    // Defensive: ensure neither express_pass nor mfdo_enabled snuck in.
+    const tagNames = tags.map((t: any) => t.tag);
+    expect(tagNames).not.toContain('EXPRESS_PASS');
+    expect(tagNames).not.toContain('MFDO_ENABLED');
   });
 
   test('has_child_swap="false" or missing → no childSwap tag', () => {
@@ -168,9 +177,26 @@ describe('placeToEntity', () => {
   test('Non-Ride entities (Show / Dining) do NOT receive height/child-swap tags', () => {
     const showWithAttrs: UniversalPlace = {
       ...showPlace,
-      place_type: {type: 'Show', attributes: [{name: 'minimum_rider_height_inches', value: '36'}]},
+      place_type: {
+        type: 'Show',
+        attributes: [
+          {name: 'minimum_rider_height_inches', value: '36'},
+          {name: 'has_child_swap', value: 'true'},
+        ],
+      },
+    };
+    const diningWithAttrs: UniversalPlace = {
+      ...diningPlace,
+      place_type: {
+        type: 'Dining',
+        attributes: [
+          {name: 'minimum_rider_height_inches', value: '36'},
+          {name: 'has_child_swap', value: 'true'},
+        ],
+      },
     };
     expect(placeToEntity(showWithAttrs, DESTINATION, TZ)?.tags ?? []).toEqual([]);
+    expect(placeToEntity(diningWithAttrs, DESTINATION, TZ)?.tags ?? []).toEqual([]);
   });
 });
 

--- a/src/parks/universal/__tests__/places.test.ts
+++ b/src/parks/universal/__tests__/places.test.ts
@@ -100,6 +100,78 @@ describe('placeToEntity', () => {
     const weird: UniversalPlace = {...ridePlace, place_id: 'uor.usf.rides:weird*name'};
     expect(placeToEntity(weird, DESTINATION, TZ)?.id).toBe('uor.usf.rides_weird_name');
   });
+
+  test('Ride with minimum_rider_height_inches attribute → emits minimumHeight tag', () => {
+    const withHeight: UniversalPlace = {
+      ...ridePlace,
+      place_type: {
+        type: 'Ride',
+        attributes: [{name: 'minimum_rider_height_inches', value: '40'}],
+      },
+    };
+    const e = placeToEntity(withHeight, DESTINATION, TZ);
+    expect(e?.tags).toEqual([
+      expect.objectContaining({tag: 'MINIMUM_HEIGHT', value: expect.objectContaining({height: 40, unit: 'in'})}),
+    ]);
+  });
+
+  test('Ride with has_child_swap="true" attribute → emits childSwap tag', () => {
+    const withSwap: UniversalPlace = {
+      ...ridePlace,
+      place_type: {
+        type: 'Ride',
+        attributes: [{name: 'has_child_swap', value: 'true'}],
+      },
+    };
+    const e = placeToEntity(withSwap, DESTINATION, TZ);
+    expect(e?.tags).toEqual([expect.objectContaining({tag: 'CHILD_SWAP'})]);
+  });
+
+  test('Ride with both attributes → emits both tags', () => {
+    const both: UniversalPlace = {
+      ...ridePlace,
+      place_type: {
+        type: 'Ride',
+        attributes: [
+          {name: 'has_child_swap', value: 'true'},
+          {name: 'minimum_rider_height_inches', value: '48'},
+          {name: 'express_pass', value: 'true'}, // ignored — not in legacy surface
+        ],
+      },
+    };
+    const tags = placeToEntity(both, DESTINATION, TZ)?.tags ?? [];
+    expect(tags.length).toBe(2);
+  });
+
+  test('has_child_swap="false" or missing → no childSwap tag', () => {
+    const falsy: UniversalPlace = {
+      ...ridePlace,
+      place_type: {type: 'Ride', attributes: [{name: 'has_child_swap', value: 'false'}]},
+    };
+    const e = placeToEntity(falsy, DESTINATION, TZ);
+    expect((e?.tags ?? []).some(t => (t as any).tag === 'CHILD_SWAP')).toBe(false);
+  });
+
+  test('minimum_rider_height_inches="0" or non-finite → no minimumHeight tag', () => {
+    const zero: UniversalPlace = {
+      ...ridePlace,
+      place_type: {type: 'Ride', attributes: [{name: 'minimum_rider_height_inches', value: '0'}]},
+    };
+    const garbage: UniversalPlace = {
+      ...ridePlace,
+      place_type: {type: 'Ride', attributes: [{name: 'minimum_rider_height_inches', value: 'tall'}]},
+    };
+    expect(placeToEntity(zero, DESTINATION, TZ)?.tags ?? []).toEqual([]);
+    expect(placeToEntity(garbage, DESTINATION, TZ)?.tags ?? []).toEqual([]);
+  });
+
+  test('Non-Ride entities (Show / Dining) do NOT receive height/child-swap tags', () => {
+    const showWithAttrs: UniversalPlace = {
+      ...showPlace,
+      place_type: {type: 'Show', attributes: [{name: 'minimum_rider_height_inches', value: '36'}]},
+    };
+    expect(placeToEntity(showWithAttrs, DESTINATION, TZ)?.tags ?? []).toEqual([]);
+  });
 });
 
 describe('parseShowTimes', () => {

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -132,6 +132,11 @@ const PARK_PLACE_ID_TO_LEGACY_VENUE_ID: Record<string, string> = {
   'ush.ush': '13825',
 };
 
+/** Read a single attribute value from a place's place_type.attributes[]. */
+function attr(place: UniversalPlace, name: string): string | undefined {
+  return place.place_type.attributes?.find((a) => a.name === name)?.value;
+}
+
 /**
  * Map a UniversalPlace to a wiki Entity. Returns null for place types we
  * don't expose (Park is emitted separately by buildEntityList; Shop /
@@ -160,6 +165,25 @@ export function placeToEntity(
   const mapLoc = place.geometry?.locations?.find((l) => l.location_type === 'map');
   if (mapLoc?.lat_lng) {
     entity.location = {latitude: mapLoc.lat_lng.lat, longitude: mapLoc.lat_lng.lng};
+  }
+
+  // Attraction-only attribute tags. Matches the surface the legacy
+  // POI-based build emitted: HasChildSwap → CHILD_SWAP, MinHeightInInches
+  // → MINIMUM_HEIGHT. The new feed exposes these under
+  // place_type.attributes[].
+  if (entityType === 'ATTRACTION') {
+    const tags: NonNullable<Entity['tags']> = [];
+    if (attr(place, 'has_child_swap') === 'true') {
+      tags.push(TagBuilder.childSwap());
+    }
+    const heightStr = attr(place, 'minimum_rider_height_inches');
+    if (heightStr) {
+      const inches = Number(heightStr);
+      if (Number.isFinite(inches) && inches > 0) {
+        tags.push(TagBuilder.minimumHeight(inches, 'in'));
+      }
+    }
+    if (tags.length > 0) entity.tags = tags;
   }
 
   return entity;


### PR DESCRIPTION
## Summary

Follow-up to #191. The `/places` migration silently dropped the attraction tags the legacy POI build emitted (`HasChildSwap → CHILD_SWAP`, `MinHeightInInches → MINIMUM_HEIGHT`). Reporter noticed Harry Potter and the Forbidden Journey losing its 48" minimum height in Orlando during the migration tool run.

The new feed exposes the same data under `place_type.attributes[]`:

```json
"attributes": [
  {"name": "has_child_swap", "value": "true"},
  {"name": "minimum_rider_height_inches", "value": "40"}
]
```

`placeToEntity` now reads both and emits the matching `TagBuilder` outputs, scoped to ATTRACTION-type entities only (matches the legacy surface — only rides carried these).

## Verification (live `/places` feed)

| Attraction | Tag(s) emitted |
|---|---|
| Harry Potter and the Forbidden Journey (IOA) | `CHILD_SWAP`, `MINIMUM_HEIGHT` 48 in |
| Despicable Me Minion Mayhem (USF) | `CHILD_SWAP`, `MINIMUM_HEIGHT` 40 in |

## Test plan

- [x] 6 new unit tests in `places.test.ts` covering: height-tag emitted, child-swap-tag emitted, both-together, non-Ride types do NOT pick up the tags, `has_child_swap="false"` doesn't emit, `minimum_rider_height_inches="0"` and non-numeric values don't emit.
- [x] `npm test -- src/parks/universal` → 30 / 30 pass.
- [x] `npm run dev -- universalorlando` → 4/4.
- [x] `npm run dev -- universalstudios` → 4/4.

## Scope guard

Intentionally NOT adding tags for other attributes the new feed exposes (`express_pass`, `mfdo_enabled`, `is_kid_friendly`, etc.). This PR restores the legacy surface only — broader tag coverage is a separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)