### PR TITLE
fix(universal): project show showtimes into park-local timezone

### DIFF
--- a/src/parks/universal/__tests__/places.test.ts
+++ b/src/parks/universal/__tests__/places.test.ts
@@ -201,6 +201,7 @@ describe('placeToEntity', () => {
 });
 
 describe('parseShowTimes', () => {
+  const UOR_TZ = 'America/New_York';
   const baseShow: UniversalShowListEntry = {
     show_id: 'uor.ioa.shows.frog_choir',
     resort_area_code: 'UOR',
@@ -212,7 +213,7 @@ describe('parseShowTimes', () => {
     show_times: [],
   };
 
-  test('emits one Performance Time per ENABLED show_time, future-only', () => {
+  test('emits one Performance Time per ENABLED show_time, future-only, in park-local timezone with offset', () => {
     const now = new Date('2026-05-22T17:00:00Z');
     const show: UniversalShowListEntry = {
       ...baseShow,
@@ -222,9 +223,10 @@ describe('parseShowTimes', () => {
         {show_time_id: 'c', status: 'ENABLED', start_time: '2026-05-22T19:00:00.000Z'},
       ],
     };
-    expect(parseShowTimes(show, now)).toEqual([
-      {type: 'Performance Time', startTime: '2026-05-22T18:00:00.000Z', endTime: '2026-05-22T18:00:00.000Z'},
-      {type: 'Performance Time', startTime: '2026-05-22T19:00:00.000Z', endTime: '2026-05-22T19:00:00.000Z'},
+    // 18:00 UTC + EDT (-04:00 in May) = 14:00 local. 19:00 UTC = 15:00 local.
+    expect(parseShowTimes(show, UOR_TZ, now)).toEqual([
+      {type: 'Performance Time', startTime: '2026-05-22T14:00:00-04:00', endTime: '2026-05-22T14:00:00-04:00'},
+      {type: 'Performance Time', startTime: '2026-05-22T15:00:00-04:00', endTime: '2026-05-22T15:00:00-04:00'},
     ]);
   });
 
@@ -237,13 +239,28 @@ describe('parseShowTimes', () => {
         {show_time_id: 'b', status: 'ENABLED',  start_time: '2026-05-22T15:00:00.000Z'},
       ],
     };
-    expect(parseShowTimes(show, now).map((t) => t.startTime)).toEqual([
-      '2026-05-22T15:00:00.000Z',
+    // 15:00 UTC + EDT (-04:00) = 11:00 local
+    expect(parseShowTimes(show, UOR_TZ, now).map((t) => t.startTime)).toEqual([
+      '2026-05-22T11:00:00-04:00',
+    ]);
+  });
+
+  test('Hollywood timezone (Pacific) projection', () => {
+    const now = new Date('2026-05-22T10:00:00Z');
+    const show: UniversalShowListEntry = {
+      ...baseShow,
+      show_times: [
+        {show_time_id: 'a', status: 'ENABLED', start_time: '2026-05-22T23:30:00.000Z'},
+      ],
+    };
+    // 23:30 UTC + PDT (-07:00 in May) = 16:30 Pacific local
+    expect(parseShowTimes(show, 'America/Los_Angeles', now).map((t) => t.startTime)).toEqual([
+      '2026-05-22T16:30:00-07:00',
     ]);
   });
 
   test('empty / missing show_times → []', () => {
-    expect(parseShowTimes({...baseShow, show_times: []}, new Date())).toEqual([]);
-    expect(parseShowTimes({...baseShow, show_times: undefined}, new Date())).toEqual([]);
+    expect(parseShowTimes({...baseShow, show_times: []}, UOR_TZ, new Date())).toEqual([]);
+    expect(parseShowTimes({...baseShow, show_times: undefined}, UOR_TZ, new Date())).toEqual([]);
   });
 });

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -193,9 +193,17 @@ export function placeToEntity(
  * Convert a show-list entry's show_times[] to wiki LiveData showtimes.
  * Filters to ENABLED slots in the future. Uses startTime === endTime
  * because the feed doesn't carry a duration — match USJ's convention.
+ *
+ * The CDN feed gives UTC ISO strings (e.g. `2026-05-25T20:30:00.000Z`).
+ * We re-project each into the park-local timezone so the emitted
+ * startTime / endTime carries the proper `+HH:MM` offset — matches the
+ * legacy emission behaviour from the pre-/places code path. Bare UTC was
+ * being misinterpreted as "after-park-close" by downstream displays that
+ * naively rendered the Z string in local time.
  */
 export function parseShowTimes(
   show: UniversalShowListEntry,
+  timezone: string,
   now: Date = new Date(),
 ): Array<{type: string; startTime: string; endTime: string}> {
   const out: Array<{type: string; startTime: string; endTime: string}> = [];
@@ -203,7 +211,8 @@ export function parseShowTimes(
     if (slot.status !== 'ENABLED') continue;
     const t = new Date(slot.start_time);
     if (!Number.isFinite(t.getTime()) || t < now) continue;
-    out.push({type: 'Performance Time', startTime: slot.start_time, endTime: slot.start_time});
+    const startIso = formatInTimezone(t, timezone, 'iso');
+    out.push({type: 'Performance Time', startTime: startIso, endTime: startIso});
   }
   return out;
 }
@@ -1028,7 +1037,7 @@ class Universal extends Destination {
       const showEntry = getOrCreateLiveData(showId);
       showEntry.status = show.status === 'OPEN' ? 'OPERATING' : 'CLOSED';
 
-      const times = parseShowTimes(show, now);
+      const times = parseShowTimes(show, this.timezone, now);
       if (times.length > 0) {
         showEntry.showtimes = times;
       }


### PR DESCRIPTION
## Summary

The CDN `/shows/show-list.json` feed (consumed since #191) emits UTC ISO strings like `2026-05-25T20:30:00.000Z`. The /places migration passed those through unchanged in `parseShowTimes`. Downstream displays were rendering the bare-UTC `Z` string in local time and showing all showtimes as after park close — e.g. Shrek's Swamp Meet (UOR USF) displaying as 8:30 PM instead of its real 4:30 PM EDT slot.

The pre-/places (legacy) code emitted park-local ISO with an offset via `constructDateTime(date, time, this.timezone)`. This PR restores that contract by re-projecting each ENABLED `show_time` through `formatInTimezone` in `parseShowTimes`.

## Was it always like this?

No — the legacy POI-based show-time code emitted park-local ISO strings with offsets (e.g. `2026-05-25T16:30:00-04:00`). The /places migration in #191 inadvertently changed this to bare UTC because the CDN feed already provides ISO-with-Z and I passed it straight through. This restores the legacy emission shape.

## Verification (live `/places` + CDN feeds)

| Show | Before | After |
|---|---|---|
| Shrek's Swamp Meet | `2026-05-25T20:30:00.000Z` | `2026-05-25T16:30:00-04:00` |
| Raptor Encounter (IOA) | `2026-05-25T21:40:00.000Z` | `2026-05-25T17:40:00-04:00` |
| Le Cirque Arcanus (EU) | `2026-05-25T22:00:00.000Z` | `2026-05-25T18:00:00-04:00` |

All landing in real-world plausible park-open windows.

## Changes

- `parseShowTimes(show, timezone, now?)` — added `timezone` parameter, projects each slot through `formatInTimezone(t, timezone, 'iso')`.
- `buildLiveData` call site now passes `this.timezone`.
- 1 new unit test (Pacific timezone projection for Hollywood) plus the existing tests updated to assert `-04:00` offsets.

## Test plan

- [x] `npm test` → 1106 / 1106 (1 new test for the Hollywood timezone path)
- [x] `npm run dev -- universalorlando` 4/4
- [x] `npm run dev -- universalstudios` 4/4
- [x] Verified live against the CDN feed for Shrek's Swamp Meet and others

🤖 Generated with [Claude Code](https://claude.com/claude-code)