### PR TITLE
fix(genting): gate live data by operating-hours window

### DIFF
--- a/src/parks/genting/gentingskyworlds.ts
+++ b/src/parks/genting/gentingskyworlds.ts
@@ -342,6 +342,13 @@ export class GentingSkyworlds extends Destination {
     const vqByRide = new Map<string, GentingDesireItineraryEntry>();
     for (const v of desire) vqByRide.set(String(v.id), v);
 
+    // The upstream API freezes the last wait-time snapshot when the park
+    // closes — so polling at 2am gets yesterday's 6pm state back. Gate every
+    // live-data emission on the operationHour window: when `now` falls outside
+    // the window, force CLOSED and suppress queue + VQ data. When we don't
+    // have operationHour, fall through to upstream-as-truth.
+    const parkOpenNow = this.isParkCurrentlyOpen(wait.operationHour);
+
     const out: LiveData[] = [];
 
     for (const ride of data.rides ?? []) {
@@ -350,6 +357,12 @@ export class GentingSkyworlds extends Destination {
         id: String(ride.id),
         status: 'CLOSED',
       } as LiveData;
+
+      if (parkOpenNow === false) {
+        // Outside hours — closed, no queue. Don't trust the frozen snapshot.
+        out.push(ld);
+        continue;
+      }
 
       const queue: Record<string, any> = {};
 
@@ -386,9 +399,10 @@ export class GentingSkyworlds extends Destination {
     }
 
     // Shows — emit OPERATING / CLOSED based on operationStatus; showtimes not
-    // currently populated by the API (showTimes is always []).
+    // currently populated by the API (showTimes is always []). When the park
+    // is closed, the upstream show status is also frozen, so force CLOSED.
     for (const show of data.shows ?? []) {
-      const open = show.operationStatus?.title === 'OPEN';
+      const open = parkOpenNow !== false && show.operationStatus?.title === 'OPEN';
       out.push({
         id: String(show.id),
         status: open ? 'OPERATING' : 'CLOSED',
@@ -396,6 +410,24 @@ export class GentingSkyworlds extends Destination {
     }
 
     return out;
+  }
+
+  /**
+   * Decide whether the park is currently within its operating hours.
+   * Returns `true`/`false` when we have an upstream operationHour window
+   * to compare against, or `null` when we don't — callers should treat
+   * `null` as "no data, fall through to upstream-as-truth" rather than
+   * blanket-closing the park.
+   */
+  private isParkCurrentlyOpen(
+    operationHour: GentingWaitTimeResponse['result']['operationHour'],
+  ): boolean | null {
+    if (!operationHour?.startTime || !operationHour?.endTime) return null;
+    const start = new Date(operationHour.startTime).getTime();
+    const end = new Date(operationHour.endTime).getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+    const now = Date.now();
+    return now >= start && now < end;
   }
 
   // ── Schedules ────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The Genting upstream API freezes its wait-time response at the last published state when the park closes — so polling at, say, 02:30 KL gets yesterday's 18:00 snapshot back unchanged for 16 hours overnight. We were faithfully emitting that, so the wiki was publishing 13 rides as currently **OPERATING** with stale wait times in the middle of the night, with no \`lastUpdated\` movement for hours.

Observed at 02:30 KL on 2026-06-01:
- 13 rides OPERATING with non-zero wait times
- 4 DOWN, 1 COMINGSOON
- Park actually closed since 18:00 the previous evening

## Fix

Add an \`isParkCurrentlyOpen()\` check in \`buildLiveData()\` using \`operationHour.startTime\` / \`endTime\` from the wait-time payload. When \`now\` is outside the window:
- **Rides** → CLOSED, no STANDBY queue, no RETURN_TIME state
- **Shows** → CLOSED regardless of upstream operationStatus

When \`operationHour\` is missing or unparseable, fall through to upstream-as-truth (don't blanket-close on missing data — that would hide real-state outages).

## Verified

Locally at 02:33 KL — every emission is now CLOSED with no queue payload, instead of the stale 13×OPERATING + wait times that were going out.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run dev -- gentingskyworlds\` 4/4 still passes
- [x] Confirmed gate fires at 02:33 KL (all 36 entries CLOSED, zero queue)
- [ ] Will re-verify after merge during park-open hours (10am-6pm KL) that live data flows normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)