### PR TITLE
feat(europapark): defensive filter for upstream waits-coverage glitch

### DIFF
--- a/src/parks/europapark/__tests__/europapark.test.ts
+++ b/src/parks/europapark/__tests__/europapark.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for Europa-Park pure helpers.
+ *
+ * The class itself is integration-tested via `npm run dev -- europapark`.
+ * Pure logic is exercised here without network access.
+ */
+import {describe, test, expect} from 'vitest';
+import {EuropaPark} from '../europapark.js';
+
+const mkWait = (code: number, time = 0) => ({code, time});
+const mkAttraction = (id: number, code: number) =>
+  ({id: `pois_${id}`, name: `Attraction ${id}`, entityType: 'ATTRACTION', scopes: ['europapark'], code} as any);
+
+// Sub-class to expose the protected glitch detector for testing.
+class Probe extends EuropaPark {
+  public probe(waits: any[], entities: any[]): boolean {
+    return this._isWaitsGlitch(waits, entities);
+  }
+}
+
+describe('_isWaitsGlitch', () => {
+  const probe = new Probe();
+
+  test('returns false when no coded attractions exist', () => {
+    // Defensive: avoid divide-by-zero when the entity build returned nothing.
+    expect(probe.probe([mkWait(1)], [])).toBe(false);
+  });
+
+  test('returns false on a typical operating-day mix (~45% of attractions in waits)', () => {
+    const entities = Array.from({length: 100}, (_, i) => mkAttraction(i, i));
+    const waits = Array.from({length: 45}, (_, i) => mkWait(i, 5 + (i % 30)));
+    expect(probe.probe(waits, entities)).toBe(false);
+  });
+
+  test('returns false at the boundary (exactly 85%)', () => {
+    // Strict > 0.85 — equal-to is treated as non-glitch.
+    const entities = Array.from({length: 100}, (_, i) => mkAttraction(i, i));
+    const waits = Array.from({length: 85}, (_, i) => mkWait(i, 0));
+    expect(probe.probe(waits, entities)).toBe(false);
+  });
+
+  test('returns true just above the boundary (86%)', () => {
+    const entities = Array.from({length: 100}, (_, i) => mkAttraction(i, i));
+    const waits = Array.from({length: 86}, (_, i) => mkWait(i, 0));
+    expect(probe.probe(waits, entities)).toBe(true);
+  });
+
+  test('returns true for the observed glitch fingerprint (~94% of catalogue)', () => {
+    // 2026-04-20 shape: ~129 of ~137 coded attractions present.
+    const entities = Array.from({length: 137}, (_, i) => mkAttraction(i, i));
+    const waits = Array.from({length: 129}, (_, i) => mkWait(i, 0));
+    expect(probe.probe(waits, entities)).toBe(true);
+  });
+
+  test('returns true even when wait values look plausible (different time shape)', () => {
+    // Detector is agnostic to time values — a future glitch with all entries
+    // showing e.g. waitTime=1 would still match if it covered the whole
+    // catalogue. This is the headline reason we picked this signal.
+    const entities = Array.from({length: 100}, (_, i) => mkAttraction(i, i));
+    const waits = Array.from({length: 95}, (_, i) => mkWait(i, 1));
+    expect(probe.probe(waits, entities)).toBe(true);
+  });
+
+  test('ignores SHOW entities in the denominator', () => {
+    // Shows have codes and appear in the entities list but should not count
+    // toward the attraction catalogue.
+    const entities = [
+      ...Array.from({length: 50}, (_, i) => mkAttraction(i, i)),
+      ...Array.from({length: 30}, (_, i) =>
+        ({id: `shows_${i}`, name: `Show ${i}`, entityType: 'SHOW', scopes: ['europapark'], code: 9000 + i} as any),
+      ),
+    ];
+    const waits = Array.from({length: 46}, (_, i) => mkWait(i, 0));
+    // 46/50 attractions = 92% → glitch, even though 46/80 entities is only 58%.
+    expect(probe.probe(waits, entities)).toBe(true);
+  });
+
+  test('ignores attractions without a code (cannot appear in waits)', () => {
+    // No-code attractions (walk-around trails, saunas) can never appear in
+    // waits, so they must be excluded from the denominator.
+    const entities = [
+      ...Array.from({length: 50}, (_, i) => mkAttraction(i, i)),
+      ...Array.from({length: 10}, (_, i) => mkAttraction(2000 + i, undefined as any)),
+    ];
+    const waits = Array.from({length: 46}, (_, i) => mkWait(i, 0));
+    // 46/50 coded attractions = 92%. With the 10 no-code attractions counted,
+    // the ratio would be 46/60 = 77% and we'd miss the glitch.
+    expect(probe.probe(waits, entities)).toBe(true);
+  });
+
+  test('ignores attractions with NaN/Infinity codes', () => {
+    // Non-finite codes from malformed upstream JSON would inflate the
+    // denominator without ever matching a wait; mirrors the Number.isFinite
+    // gate already applied to waits.
+    const entities = [
+      ...Array.from({length: 50}, (_, i) => mkAttraction(i, i)),
+      mkAttraction(9001, NaN),
+      mkAttraction(9002, Infinity),
+    ];
+    const waits = Array.from({length: 46}, (_, i) => mkWait(i, 0));
+    expect(probe.probe(waits, entities)).toBe(true);
+  });
+});

--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -616,7 +616,7 @@ class EuropaParkBase extends Destination {
     // proxy fails; downstream also uses strict-equality switches and `<= 91`
     // comparisons that silently misbehave on non-numbers — so require both a
     // finite numeric `code` and a finite numeric `time`.
-    const waits = waitsRaw.filter(
+    let waits = waitsRaw.filter(
       (w): w is EuropaParkWaitTime => {
         if (!w || typeof w !== 'object') return false;
         const code = (w as any).code;
@@ -625,6 +625,19 @@ class EuropaParkBase extends Destination {
             && typeof time === 'number' && Number.isFinite(time);
       },
     );
+
+    // Defensive: detect the upstream glitch first observed at 2026-04-20T20:11:59Z,
+    // which briefly returned wait entries for ~94% of the attraction catalogue
+    // (vs ~45% on a normal day). The fingerprint is purely "implausibly large
+    // fraction of attractions reporting", agnostic to time-value shape, so it
+    // also catches future glitches with different time signatures.
+    if (this._isWaitsGlitch(waits, entities)) {
+      console.warn(
+        `Europa-Park waits sanity-check: suspected upstream glitch, skipping ` +
+        `wait-time emission this tick`,
+      );
+      waits = [];
+    }
 
     // Build code → entityId map from attraction/show entities
     const codeToEntityId = new Map<number, string>();
@@ -911,6 +924,39 @@ class EuropaParkBase extends Destination {
       id: `park_${parkConfig.id}`,
       schedule: times,
     } as EntitySchedule;
+  }
+
+  /**
+   * Returns true when waits is reporting an implausibly large fraction of the
+   * attraction catalogue. Normal Europa-Park days see roughly 45% of coded
+   * attractions in the waits response; the 2026-04-20 glitch jumped that to
+   * ~94%. Threshold of >85% sits comfortably in the gap.
+   *
+   * The denominator is derived from the already-built entity list rather than
+   * raw POI data: getParkEntities owns the skip rules (nameless, VQ dummies,
+   * "Queue - …" map pointers, etc.) and we want the detector to track those
+   * rules automatically instead of duplicating them.
+   */
+  protected _isWaitsGlitch(waits: EuropaParkWaitTime[], entities: EuropaParkEntity[]): boolean {
+    const attractionCodes = new Set<number>();
+    for (const e of entities) {
+      if (e.entityType !== 'ATTRACTION') continue;
+      // Mirror the Number.isFinite gate used for waits — a NaN/Infinity code
+      // (possible from malformed upstream JSON) would inflate the denominator
+      // without ever matching a wait.
+      if (typeof e.code === 'number' && Number.isFinite(e.code)) {
+        attractionCodes.add(e.code);
+      }
+    }
+    if (attractionCodes.size === 0) return false;
+
+    const waitCodes = new Set<number>(waits.map((w) => w.code));
+    let inWaitsCount = 0;
+    for (const code of attractionCodes) {
+      if (waitCodes.has(code)) inWaitsCount++;
+    }
+
+    return inWaitsCount / attractionCodes.size > 0.85;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `_isWaitsGlitch(waits, poiData)` to Europa-Park's `buildLiveData`: flags the upstream `/api/v2/waiting-times` response as suspect when more than 85% of the coded attraction catalogue is reporting wait data.
- When triggered, wait-time emission is skipped for that tick. Showtimes still process unaffected.

## Why

On 2026-04-20T20:11:59Z, upstream briefly returned wait entries for the entire attraction catalogue rather than just the operating ones, writing `OPERATING + waitTime: 0` rows to ~67 entities that don't normally appear in the feed (kid play areas, restaurants, scenic transit POIs, the VR overlay of Alpenexpress, etc.). Those rows then sat in the wiki's last-write-wins live data store with no source ever overwriting them.

Normal day on this endpoint shows ~45% of the coded attraction catalogue present in waits. The April event jumped to ~94%. 85% sits comfortably in the gap with safety margin in both directions.

The check is **agnostic to time values** — it just measures catalogue coverage — so it also catches future glitches with different time signatures (all-`time:1`, mixed numerics, etc.).

## Test plan

- [x] 8 unit tests covering: empty catalogue, normal mix (~45%), exact boundary (85% → false, 86% → true), observed glitch shape (~94%), agnostic-to-time-value variant, non-attraction POIs excluded from denominator, no-code attractions excluded from denominator
- [x] `npm run dev -- europapark` — 4/4 integration tests pass, 150 live data entries emitted with 48 wait times (normal-shape response, detector did not trigger)
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)