### PR TITLE
fix(nigloland): gate liveness on park calendar, decouple waitTime from status

### DIFF
--- a/src/parks/nigloland/nigloland.ts
+++ b/src/parks/nigloland/nigloland.ts
@@ -11,8 +11,16 @@ import {TagBuilder} from '../../tags/index.js';
 
 const DESTINATION_ID = 'niglolandresort';
 const PARK_ID = 'nigloland';
-/** Indéterminé rides only count as live when upstream updatedAt is recent. */
-const FRESHNESS_WINDOW_MS = 30 * 60 * 1000;
+/** Live waitTime values older than this are considered stale and dropped. */
+const WAITTIME_FRESHNESS_MS = 30 * 60 * 1000;
+/**
+ * Indéterminé rides with `updatedAt` older than this are treated as retired
+ * catalogue entries (we have seen ones still pointing at 2024) and forced to
+ * CLOSED. Within this window an Indéterminé ride trusts the park calendar's
+ * open signal instead of demanding a recent waitTime refresh — upstream is
+ * slow to re-poll some rides whose value is stable.
+ */
+const RIDE_RETIREMENT_MS = 24 * 60 * 60 * 1000;
 /** Months of forward calendar to pull. Mirrors what the mobile app fetches. */
 const SCHEDULE_MONTHS_AHEAD = 4;
 /** Safety stop for /calendar_dates pagination. App responses fit in <=3 pages. */
@@ -234,24 +242,36 @@ export class Nigloland extends Destination {
     return {open: tokens[0], close: tokens[tokens.length - 1]};
   }
 
-  private isRideDataFresh(ride: NiglolandRide): boolean {
-    if (!ride.updatedAt) return false;
+  private rideAgeMs(ride: NiglolandRide): number {
+    if (!ride.updatedAt) return Infinity;
     const ts = Date.parse(ride.updatedAt);
-    if (!Number.isFinite(ts)) return false;
-    return Date.now() - ts < FRESHNESS_WINDOW_MS;
+    if (!Number.isFinite(ts)) return Infinity;
+    return Date.now() - ts;
+  }
+
+  private hasFreshWaitTime(ride: NiglolandRide): boolean {
+    return this.rideAgeMs(ride) < WAITTIME_FRESHNESS_MS;
+  }
+
+  private isRideRetired(ride: NiglolandRide): boolean {
+    return this.rideAgeMs(ride) > RIDE_RETIREMENT_MS;
   }
 
   /**
-   * Indéterminé never flips to Fermé after close — gate on updatedAt freshness
-   * so extended weather/crowd sessions stay OPERATING while retired catalog rides
-   * (years-old updatedAt) do not emit stale waits.
+   * The park calendar drives the OPERATING/CLOSED axis — `Indéterminé` is the
+   * upstream's idle state and never flips to `Fermé` after hours, so trusting
+   * `statusName` alone always over-emits OPERATING. waitTime freshness is
+   * handled separately at emission time so a long-stable ride does not get
+   * incorrectly closed mid-day. Retired catalogue rides (years-old updatedAt)
+   * are filtered out via `isRideRetired` so they don't leak in on open days.
    */
-  private rideLiveStatus(ride: NiglolandRide): string {
+  private rideLiveStatus(ride: NiglolandRide, parkClosedToday: boolean): string {
+    if (parkClosedToday) return 'CLOSED';
     const name = ride.statusName;
     if (name === 'Fermé') return 'CLOSED';
     if (name === 'En maintenance') return 'REFURBISHMENT';
-    if (name === 'Indéterminé') return this.isRideDataFresh(ride) ? 'OPERATING' : 'CLOSED';
     if (name === 'Ouvert') return 'OPERATING';
+    if (name === 'Indéterminé') return this.isRideRetired(ride) ? 'CLOSED' : 'OPERATING';
     return 'CLOSED';
   }
 
@@ -360,18 +380,33 @@ export class Nigloland extends Destination {
   // ── Live data ──────────────────────────────────────────────────
 
   protected async buildLiveData(): Promise<LiveData[]> {
-    const {rides, shows} = await this.getPointsOfInterest();
+    const [{rides, shows}, calendar] = await Promise.all([
+      this.getPointsOfInterest(),
+      this.getCalendarDates(),
+    ]);
+    const todayParis = formatDate(new Date(), this.timezone);
+    const todayEntry = calendar.find(
+      (e) => typeof e.date === 'string' && e.date.slice(0, 10) === todayParis,
+    );
+    // Shows have no per-day live signal (their `updatedAt` tracks the show
+    // definition, not whether they're running). When the calendar marks today
+    // as Fermé, the upstream still leaves showTimes populated for cancelled
+    // performances — gate on the calendar instead.
+    const parkClosedToday =
+      this.parseCalendarHours(todayEntry?.calendarType?.hoursPark) === 'closed';
     const liveData: LiveData[] = [];
 
     for (const ride of rides) {
       const id = this.entityId(ride.idNiglo);
       if (!id) continue;
 
-      const status = this.rideLiveStatus(ride);
+      const status = this.rideLiveStatus(ride, parkClosedToday);
       const ld: LiveData = {id, status} as LiveData;
 
-      // Fermé and stale Indéterminé rides may still carry frozen waitingTime values.
-      if (status === 'OPERATING') {
+      // waitTime emission is independently gated on freshness — never push a
+      // value the upstream hasn't touched in the last WAITTIME_FRESHNESS_MS,
+      // even if we believe the ride is OPERATING per the calendar.
+      if (status === 'OPERATING' && this.hasFreshWaitTime(ride)) {
         const waitTime = Number(ride.waitingTime);
         if (Number.isFinite(waitTime)) {
           ld.queue = {STANDBY: {waitTime}};
@@ -387,12 +422,16 @@ export class Nigloland extends Destination {
       if (!id) continue;
 
       const times = Array.isArray(show.showTimes) ? show.showTimes : [];
-      const ld: LiveData = {
-        id,
-        status: mapStatus(show.statusName ?? ''),
-      } as LiveData;
+      // Two-tier gate: a show is OPERATING only when the park calendar says
+      // we are open today AND the upstream still lists showtimes. Either
+      // signal failing emits CLOSED — and CLOSED entries drop the showtimes
+      // array so the wiki doesn't echo cancelled performances.
+      const status = !parkClosedToday && times.length > 0
+        ? mapStatus(show.statusName ?? '')
+        : 'CLOSED';
+      const ld: LiveData = {id, status} as LiveData;
 
-      if (times.length > 0) {
+      if (status === 'OPERATING') {
         ld.showtimes = times.map((startTime) => ({
           type: 'PERFORMANCE_TIME',
           startTime,

--- a/src/parks/nigloland/nigloland.ts
+++ b/src/parks/nigloland/nigloland.ts
@@ -269,10 +269,10 @@ export class Nigloland extends Destination {
   private isOpenNow(
     calendar: NiglolandCalendarDate[],
     hoursField: 'hoursPark' | 'hoursRides',
+    now: Date,
   ): boolean {
-    // Single `now` snapshot so the date lookup and the time comparison can
-    // never straddle a Paris-time midnight rollover.
-    const now = new Date();
+    // Caller passes `now` so the parkOpenNow / ridesOpenNow pair in
+    // buildLiveData() can't straddle a Paris-time midnight rollover.
     const todayParis = formatDate(now, this.timezone);
     const entry = calendar.find(
       (e) => typeof e.date === 'string' && e.date.slice(0, 10) === todayParis,
@@ -419,9 +419,12 @@ export class Nigloland extends Destination {
       this.getCalendarDates(),
     ]);
     // Rides and shows have different end-of-day windows on fireworks/special
-    // days — rides wind down before the late programme. Gate them separately.
-    const parkOpenNow = this.isOpenNow(calendar, 'hoursPark');
-    const ridesOpenNow = this.isOpenNow(calendar, 'hoursRides');
+    // days — rides wind down before the late programme. Gate them separately
+    // against a single `now` snapshot so the two checks can't disagree on
+    // which day it is.
+    const now = new Date();
+    const parkOpenNow = this.isOpenNow(calendar, 'hoursPark', now);
+    const ridesOpenNow = this.isOpenNow(calendar, 'hoursRides', now);
     const liveData: LiveData[] = [];
 
     for (const ride of rides) {

--- a/src/parks/nigloland/nigloland.ts
+++ b/src/parks/nigloland/nigloland.ts
@@ -15,11 +15,11 @@ const PARK_ID = 'nigloland';
 const WAITTIME_FRESHNESS_MS = 30 * 60 * 1000;
 /**
  * Indéterminé rides with `updatedAt` older than this are treated as retired
- * catalogue entries (real ones still point at 2024) and forced to CLOSED.
- * The window is wide because Nigloland operates on a weekends-only schedule
- * for chunks of the year, so an active ride can legitimately sit untouched
- * for several days between operating days. The actual retired entries we've
- * observed are 14+ months stale, well past the threshold.
+ * catalogue entries and forced to CLOSED. The window is wide because
+ * Nigloland operates on a weekends-only schedule for chunks of the year, so
+ * an active ride can legitimately sit untouched for several days between
+ * operating days. Observed retired entries sit at 2024 timestamps — 14+
+ * months stale, well past the threshold.
  */
 const RIDE_RETIREMENT_MS = 30 * 24 * 60 * 60 * 1000;
 /** Months of forward calendar to pull. Mirrors what the mobile app fetches. */
@@ -260,16 +260,34 @@ export class Nigloland extends Destination {
 
   /**
    * True iff the park calendar says today is operating AND the current
-   * Paris-time clock is within today's open/close window. Used as the
-   * primary OPERATING signal — `Indéterminé` is the upstream's idle state
-   * and never flips after hours, so `statusName` alone always over-emits.
+   * Paris-time clock is within today's open/close window for the given
+   * hours field. Used as the primary OPERATING signal — `Indéterminé` is
+   * the upstream's idle state and never flips after hours, so `statusName`
+   * alone always over-emits.
+   *
+   * `hoursPark` and `hoursRides` can differ on fireworks/special days: the
+   * park can stay open for a late programme while rides progressively wind
+   * down. Callers pass the field that matches what they're gating —
+   * `hoursPark` for shows (which run during the late programme), `hoursRides`
+   * for attractions. Missing/unparseable `hoursRides` falls back to
+   * `hoursPark` so normal days (where the two are identical) behave the
+   * same regardless of which field the upstream populates.
    */
-  private isParkOpenNow(calendar: NiglolandCalendarDate[]): boolean {
+  private isOpenNow(
+    calendar: NiglolandCalendarDate[],
+    hoursField: 'hoursPark' | 'hoursRides',
+  ): boolean {
     const todayParis = formatDate(new Date(), this.timezone);
     const entry = calendar.find(
       (e) => typeof e.date === 'string' && e.date.slice(0, 10) === todayParis,
     );
-    const hours = this.parseCalendarHours(entry?.calendarType?.hoursPark);
+    if (!entry) return false;
+    const primary = this.parseCalendarHours(entry.calendarType?.[hoursField]);
+    const fallback =
+      hoursField === 'hoursRides'
+        ? this.parseCalendarHours(entry.calendarType?.hoursPark)
+        : null;
+    const hours = primary ?? fallback;
     if (!hours || hours === 'closed') return false;
     // formatInTimezone iso = "YYYY-MM-DDTHH:mm:ss+ZZ:ZZ"; slice 11..16 = "HH:mm"
     const nowHHMM = formatInTimezone(new Date(), this.timezone, 'iso').slice(11, 16);
@@ -404,14 +422,17 @@ export class Nigloland extends Destination {
       this.getPointsOfInterest(),
       this.getCalendarDates(),
     ]);
-    const parkOpenNow = this.isParkOpenNow(calendar);
+    // Rides and shows have different end-of-day windows on fireworks/special
+    // days — rides wind down before the late programme. Gate them separately.
+    const parkOpenNow = this.isOpenNow(calendar, 'hoursPark');
+    const ridesOpenNow = this.isOpenNow(calendar, 'hoursRides');
     const liveData: LiveData[] = [];
 
     for (const ride of rides) {
       const id = this.entityId(ride.idNiglo);
       if (!id) continue;
 
-      const status = this.rideLiveStatus(ride, parkOpenNow);
+      const status = this.rideLiveStatus(ride, ridesOpenNow);
       const ld: LiveData = {id, status} as LiveData;
 
       // waitTime emission is independently gated on freshness — never push a

--- a/src/parks/nigloland/nigloland.ts
+++ b/src/parks/nigloland/nigloland.ts
@@ -291,20 +291,23 @@ export class Nigloland extends Destination {
   }
 
   /**
-   * Indéterminé inside the calendar's open window → OPERATING. Outside the
+   * Indéterminé inside the gated open window → OPERATING. Outside the
    * window we still grant OPERATING when upstream is actively polling the
    * ride (fresh waitTime), so weather/crowd extensions past the advertised
    * close don't get prematurely closed. Retired catalogue entries are
    * filtered out separately via `isRideRetired`.
+   *
+   * `openNow` is the boolean for whichever window is relevant to the
+   * caller — `ridesOpenNow` for attractions, `parkOpenNow` for shows.
    */
-  private rideLiveStatus(ride: NiglolandRide, parkOpenNow: boolean): string {
+  private rideLiveStatus(ride: NiglolandRide, openNow: boolean): string {
     const name = ride.statusName;
     if (name === 'Fermé') return 'CLOSED';
     if (name === 'En maintenance') return 'REFURBISHMENT';
     if (name === 'Ouvert') return 'OPERATING';
     if (name === 'Indéterminé') {
       if (this.isRideRetired(ride)) return 'CLOSED';
-      return parkOpenNow || this.hasFreshWaitTime(ride) ? 'OPERATING' : 'CLOSED';
+      return openNow || this.hasFreshWaitTime(ride) ? 'OPERATING' : 'CLOSED';
     }
     return 'CLOSED';
   }
@@ -414,9 +417,20 @@ export class Nigloland extends Destination {
   // ── Live data ──────────────────────────────────────────────────
 
   protected async buildLiveData(): Promise<LiveData[]> {
+    // Live data must not be held up by a calendar outage. If /calendar_dates
+    // fails (WAF glitch, transient 5xx, etc.) we fall back to an empty
+    // calendar — rides keep the `hasFreshWaitTime` extension fallback, shows
+    // emit CLOSED until the calendar recovers. The @cache layer makes this
+    // path rare in practice (6h TTL).
     const [{rides, shows}, calendar] = await Promise.all([
       this.getPointsOfInterest(),
-      this.getCalendarDates(),
+      this.getCalendarDates().catch((err) => {
+        console.warn(
+          'Nigloland: /calendar_dates fetch failed, status gate degraded for this tick',
+          err,
+        );
+        return [] as NiglolandCalendarDate[];
+      }),
     ]);
     // Rides and shows have different end-of-day windows on fireworks/special
     // days — rides wind down before the late programme. Gate them separately

--- a/src/parks/nigloland/nigloland.ts
+++ b/src/parks/nigloland/nigloland.ts
@@ -5,7 +5,7 @@ import {inject} from '../../injector.js';
 import config from '../../config.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule, ScheduleEntry, TagData} from '@themeparks/typelib';
-import {constructDateTime, formatDate, hostnameFromUrl} from '../../datetime.js';
+import {constructDateTime, formatDate, formatInTimezone, hostnameFromUrl} from '../../datetime.js';
 import {createStatusMap} from '../../statusMap.js';
 import {TagBuilder} from '../../tags/index.js';
 
@@ -15,12 +15,13 @@ const PARK_ID = 'nigloland';
 const WAITTIME_FRESHNESS_MS = 30 * 60 * 1000;
 /**
  * Indéterminé rides with `updatedAt` older than this are treated as retired
- * catalogue entries (we have seen ones still pointing at 2024) and forced to
- * CLOSED. Within this window an Indéterminé ride trusts the park calendar's
- * open signal instead of demanding a recent waitTime refresh — upstream is
- * slow to re-poll some rides whose value is stable.
+ * catalogue entries (real ones still point at 2024) and forced to CLOSED.
+ * The window is wide because Nigloland operates on a weekends-only schedule
+ * for chunks of the year, so an active ride can legitimately sit untouched
+ * for several days between operating days. The actual retired entries we've
+ * observed are 14+ months stale, well past the threshold.
  */
-const RIDE_RETIREMENT_MS = 24 * 60 * 60 * 1000;
+const RIDE_RETIREMENT_MS = 30 * 24 * 60 * 60 * 1000;
 /** Months of forward calendar to pull. Mirrors what the mobile app fetches. */
 const SCHEDULE_MONTHS_AHEAD = 4;
 /** Safety stop for /calendar_dates pagination. App responses fit in <=3 pages. */
@@ -258,20 +259,39 @@ export class Nigloland extends Destination {
   }
 
   /**
-   * The park calendar drives the OPERATING/CLOSED axis — `Indéterminé` is the
-   * upstream's idle state and never flips to `Fermé` after hours, so trusting
-   * `statusName` alone always over-emits OPERATING. waitTime freshness is
-   * handled separately at emission time so a long-stable ride does not get
-   * incorrectly closed mid-day. Retired catalogue rides (years-old updatedAt)
-   * are filtered out via `isRideRetired` so they don't leak in on open days.
+   * True iff the park calendar says today is operating AND the current
+   * Paris-time clock is within today's open/close window. Used as the
+   * primary OPERATING signal — `Indéterminé` is the upstream's idle state
+   * and never flips after hours, so `statusName` alone always over-emits.
    */
-  private rideLiveStatus(ride: NiglolandRide, parkClosedToday: boolean): string {
-    if (parkClosedToday) return 'CLOSED';
+  private isParkOpenNow(calendar: NiglolandCalendarDate[]): boolean {
+    const todayParis = formatDate(new Date(), this.timezone);
+    const entry = calendar.find(
+      (e) => typeof e.date === 'string' && e.date.slice(0, 10) === todayParis,
+    );
+    const hours = this.parseCalendarHours(entry?.calendarType?.hoursPark);
+    if (!hours || hours === 'closed') return false;
+    // formatInTimezone iso = "YYYY-MM-DDTHH:mm:ss+ZZ:ZZ"; slice 11..16 = "HH:mm"
+    const nowHHMM = formatInTimezone(new Date(), this.timezone, 'iso').slice(11, 16);
+    return nowHHMM >= hours.open && nowHHMM <= hours.close;
+  }
+
+  /**
+   * Indéterminé inside the calendar's open window → OPERATING. Outside the
+   * window we still grant OPERATING when upstream is actively polling the
+   * ride (fresh waitTime), so weather/crowd extensions past the advertised
+   * close don't get prematurely closed. Retired catalogue entries are
+   * filtered out separately via `isRideRetired`.
+   */
+  private rideLiveStatus(ride: NiglolandRide, parkOpenNow: boolean): string {
     const name = ride.statusName;
     if (name === 'Fermé') return 'CLOSED';
     if (name === 'En maintenance') return 'REFURBISHMENT';
     if (name === 'Ouvert') return 'OPERATING';
-    if (name === 'Indéterminé') return this.isRideRetired(ride) ? 'CLOSED' : 'OPERATING';
+    if (name === 'Indéterminé') {
+      if (this.isRideRetired(ride)) return 'CLOSED';
+      return parkOpenNow || this.hasFreshWaitTime(ride) ? 'OPERATING' : 'CLOSED';
+    }
     return 'CLOSED';
   }
 
@@ -384,23 +404,14 @@ export class Nigloland extends Destination {
       this.getPointsOfInterest(),
       this.getCalendarDates(),
     ]);
-    const todayParis = formatDate(new Date(), this.timezone);
-    const todayEntry = calendar.find(
-      (e) => typeof e.date === 'string' && e.date.slice(0, 10) === todayParis,
-    );
-    // Shows have no per-day live signal (their `updatedAt` tracks the show
-    // definition, not whether they're running). When the calendar marks today
-    // as Fermé, the upstream still leaves showTimes populated for cancelled
-    // performances — gate on the calendar instead.
-    const parkClosedToday =
-      this.parseCalendarHours(todayEntry?.calendarType?.hoursPark) === 'closed';
+    const parkOpenNow = this.isParkOpenNow(calendar);
     const liveData: LiveData[] = [];
 
     for (const ride of rides) {
       const id = this.entityId(ride.idNiglo);
       if (!id) continue;
 
-      const status = this.rideLiveStatus(ride, parkClosedToday);
+      const status = this.rideLiveStatus(ride, parkOpenNow);
       const ld: LiveData = {id, status} as LiveData;
 
       // waitTime emission is independently gated on freshness — never push a
@@ -422,11 +433,11 @@ export class Nigloland extends Destination {
       if (!id) continue;
 
       const times = Array.isArray(show.showTimes) ? show.showTimes : [];
-      // Two-tier gate: a show is OPERATING only when the park calendar says
-      // we are open today AND the upstream still lists showtimes. Either
-      // signal failing emits CLOSED — and CLOSED entries drop the showtimes
-      // array so the wiki doesn't echo cancelled performances.
-      const status = !parkClosedToday && times.length > 0
+      // Two-tier gate: a show is OPERATING only when the park is open right
+      // now (calendar + clock) AND the upstream still lists showtimes.
+      // Either signal failing emits CLOSED — and CLOSED entries drop the
+      // showtimes array so the wiki doesn't echo cancelled performances.
+      const status = parkOpenNow && times.length > 0
         ? mapStatus(show.statusName ?? '')
         : 'CLOSED';
       const ld: LiveData = {id, status} as LiveData;

--- a/src/parks/nigloland/nigloland.ts
+++ b/src/parks/nigloland/nigloland.ts
@@ -6,7 +6,6 @@ import config from '../../config.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule, ScheduleEntry, TagData} from '@themeparks/typelib';
 import {constructDateTime, formatDate, formatInTimezone, hostnameFromUrl} from '../../datetime.js';
-import {createStatusMap} from '../../statusMap.js';
 import {TagBuilder} from '../../tags/index.js';
 
 const DESTINATION_ID = 'niglolandresort';
@@ -26,12 +25,6 @@ const RIDE_RETIREMENT_MS = 30 * 24 * 60 * 60 * 1000;
 const SCHEDULE_MONTHS_AHEAD = 4;
 /** Safety stop for /calendar_dates pagination. App responses fit in <=3 pages. */
 const CALENDAR_PAGE_LIMIT = 10;
-
-const mapStatus = createStatusMap({
-  OPERATING: ['Ouvert', 'Indéterminé'],
-  CLOSED: ['Fermé'],
-  REFURBISHMENT: ['En maintenance'],
-}, {parkName: 'Nigloland', defaultStatus: 'CLOSED'});
 
 interface NiglolandSizeReference {
   minSize?: number | null;
@@ -277,7 +270,10 @@ export class Nigloland extends Destination {
     calendar: NiglolandCalendarDate[],
     hoursField: 'hoursPark' | 'hoursRides',
   ): boolean {
-    const todayParis = formatDate(new Date(), this.timezone);
+    // Single `now` snapshot so the date lookup and the time comparison can
+    // never straddle a Paris-time midnight rollover.
+    const now = new Date();
+    const todayParis = formatDate(now, this.timezone);
     const entry = calendar.find(
       (e) => typeof e.date === 'string' && e.date.slice(0, 10) === todayParis,
     );
@@ -290,7 +286,7 @@ export class Nigloland extends Destination {
     const hours = primary ?? fallback;
     if (!hours || hours === 'closed') return false;
     // formatInTimezone iso = "YYYY-MM-DDTHH:mm:ss+ZZ:ZZ"; slice 11..16 = "HH:mm"
-    const nowHHMM = formatInTimezone(new Date(), this.timezone, 'iso').slice(11, 16);
+    const nowHHMM = formatInTimezone(now, this.timezone, 'iso').slice(11, 16);
     return nowHHMM >= hours.open && nowHHMM <= hours.close;
   }
 
@@ -437,8 +433,14 @@ export class Nigloland extends Destination {
 
       // waitTime emission is independently gated on freshness — never push a
       // value the upstream hasn't touched in the last WAITTIME_FRESHNESS_MS,
-      // even if we believe the ride is OPERATING per the calendar.
-      if (status === 'OPERATING' && this.hasFreshWaitTime(ride)) {
+      // even if we believe the ride is OPERATING per the calendar. Guard on
+      // `!= null` first so a null upstream value doesn't get coerced to a
+      // bogus 0-minute standby via `Number(null)`.
+      if (
+        status === 'OPERATING' &&
+        this.hasFreshWaitTime(ride) &&
+        ride.waitingTime != null
+      ) {
         const waitTime = Number(ride.waitingTime);
         if (Number.isFinite(waitTime)) {
           ld.queue = {STANDBY: {waitTime}};
@@ -454,13 +456,13 @@ export class Nigloland extends Destination {
       if (!id) continue;
 
       const times = Array.isArray(show.showTimes) ? show.showTimes : [];
-      // Two-tier gate: a show is OPERATING only when the park is open right
-      // now (calendar + clock) AND the upstream still lists showtimes.
-      // Either signal failing emits CLOSED — and CLOSED entries drop the
-      // showtimes array so the wiki doesn't echo cancelled performances.
-      const status = parkOpenNow && times.length > 0
-        ? mapStatus(show.statusName ?? '')
-        : 'CLOSED';
+      // Drive show status directly from the calendar+showtimes gate, not
+      // `statusName`. The upstream uses `Indéterminé` as its idle state for
+      // shows regardless of whether they're running, and we have not observed
+      // any other value carry useful information here. CLOSED entries drop
+      // the showtimes array so the wiki doesn't echo cancelled performances.
+      const status: 'OPERATING' | 'CLOSED' =
+        parkOpenNow && times.length > 0 ? 'OPERATING' : 'CLOSED';
       const ld: LiveData = {id, status} as LiveData;
 
       if (status === 'OPERATING') {


### PR DESCRIPTION
## Summary
Two related bugs surfaced after #207 landed:

1. **Shows on closed days emit OPERATING with stale showtimes.** `Niglo Show` was visible on the wiki today (a `Fermé` Tuesday) with 4 showtimes that won't actually happen.
2. **Rides can incorrectly close mid-day if upstream doesn't re-poll.** The previous 30-minute `updatedAt` freshness window assumes the upstream touches every ride at least that often. The data so far suggests it usually does, but the assumption is fragile — a stable-wait ride could legitimately go untouched for >30 minutes and incorrectly flip CLOSED.

Root cause for both: status was inferred from per-ride `updatedAt`, which is a poor proxy for "is the park open right now."

## Fix
The park calendar (already pulled for `buildSchedules` in #207) is now the primary OPERATING/CLOSED signal. `updatedAt` only filters two specific failure modes: retired catalogue rides, and stale `waitTime` values.

| Layer | Old | New |
|---|---|---|
| **Ride status** | `Indéterminé + fresh<30m` → OPERATING else CLOSED | `ridesOpenNow` (calendar `hoursRides` + clock) → OPERATING; outside window with stale `updatedAt` → CLOSED; `age > 30d` → CLOSED (retirement filter) |
| **Ride waitTime** | emitted whenever status=OPERATING | independently gated by `age<30m` |
| **Show status** | raw `mapStatus(statusName)` | `parkOpenNow` (calendar `hoursPark` + clock) + `times>0` → OPERATING else CLOSED |
| **Show showtimes** | always echoed | only emitted on OPERATING entries |

Two-window constants:
- `WAITTIME_FRESHNESS_MS = 30 min` — gates waitTime emission
- `RIDE_RETIREMENT_MS = 30 days` — catches catalogue rides with `updatedAt` from 2024 without false-positiving normal multi-day gaps in Nigloland's weekends-only schedule

Rides and shows use different "open now" windows: `hoursRides` vs `hoursPark`. They diverge on fireworks/special days where the park stays open for a late programme while rides progressively wind down.

## Verification
Today's park calendar is `Fermé`:
```
2026-06-09  hoursPark=Fermé
```
Live data on PR branch:
```
status: { CLOSED: 41 }
withQueue: 0  withShowtimes: 0
shows: [{id:5, status:CLOSED, showtimes:0}, {id:73, status:CLOSED, showtimes:0}]
```

`isOpenNow()` unit-style probe:
```
normal "10h00 à 18h00":          park=true   rides=true
fireworks (late park, 17h30 rides): park=true   rides=true (at 12:14 — before 17h30)
Fermé:                            park=false  rides=false
missing hoursRides:               rides=true (falls back to hoursPark) ✓
```

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 1183/1183 pass
- [x] `npm run dev -- nigloland` — 4/4 pass on a `Fermé` calendar day
- [x] Manual probe: rides on Fermé day → 41 CLOSED, 0 queue, 0 showtimes
- [ ] Re-verify on next operating day (calendar shows 2026-06-13 / 2026-06-14 open) that real rides + Niglo Show flip back to OPERATING with showtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)