### PR TITLE
fix(sixflags,enchantedparks): handle April 2026 divestments

### DIFF
--- a/src/__tests__/entityIdRegression.test.ts
+++ b/src/__tests__/entityIdRegression.test.ts
@@ -146,6 +146,38 @@ describe('Destination ID patterns', () => {
     expect(destinations[0]?.id).not.toBe('valleyfair');
   });
 
+  test('Worlds of Fun park class is registered under the Enchanted Parks umbrella', async () => {
+    const destinations = await getAllDestinations();
+    const ids = destinations.map(d => d.id);
+    expect(ids).toContain('worldsoffun');
+    const wof = destinations.find(d => d.id === 'worldsoffun');
+    expect(wof?.category).toEqual(['Enchanted Parks', 'Worlds of Fun']);
+  });
+
+  test('Worlds of Fun emits enchantedparks-namespaced DESTINATION entity id', async () => {
+    const {WorldsOfFun} = await import('../parks/enchantedparks/worldsoffun.js');
+    const dest = new WorldsOfFun({});
+    const destinations = await dest.getDestinations();
+    expect(destinations[0]?.id).toBe('enchantedparks_worldsoffun');
+    expect(destinations[0]?.id).not.toBe('worldsoffun');
+  });
+
+  test('Michigan\'s Adventure park class is registered under the Enchanted Parks umbrella', async () => {
+    const destinations = await getAllDestinations();
+    const ids = destinations.map(d => d.id);
+    expect(ids).toContain('michigansadventure');
+    const ma = destinations.find(d => d.id === 'michigansadventure');
+    expect(ma?.category).toEqual(['Enchanted Parks', 'Michigan\'s Adventure']);
+  });
+
+  test('Michigan\'s Adventure emits enchantedparks-namespaced DESTINATION entity id', async () => {
+    const {MichigansAdventure} = await import('../parks/enchantedparks/michigansadventure.js');
+    const dest = new MichigansAdventure({});
+    const destinations = await dest.getDestinations();
+    expect(destinations[0]?.id).toBe('enchantedparks_michigansadventure');
+    expect(destinations[0]?.id).not.toBe('michigansadventure');
+  });
+
   test('Attractions.io v1 Merlin parks are registered individually', async () => {
     const destinations = await getAllDestinations();
     const merlin = destinations.filter(d =>

--- a/src/parks/enchantedparks/michigansadventure.ts
+++ b/src/parks/enchantedparks/michigansadventure.ts
@@ -1,0 +1,35 @@
+import {EnchantedParks} from './enchantedparks.js';
+import {destinationController} from '../../destinationRegistry.js';
+import type {DestinationConstructor} from '../../destination.js';
+
+@destinationController({category: ['Enchanted Parks', "Michigan's Adventure"]})
+export class MichigansAdventure extends EnchantedParks {
+  constructor(options?: DestinationConstructor) {
+    super({
+      ...options,
+      config: {
+        destinationId: 'enchantedparks_michigansadventure',
+        destinationName: "Michigan's Adventure",
+        timezone: 'America/Detroit',
+        ...(options?.config ?? {}),
+      },
+    });
+    this.destinationLocation ??= {latitude: 43.3411, longitude: -86.2625};
+    this.themePark ??= {
+      id: 'enchantedparks_park_MA',
+      code: 'MA',
+      name: "Michigan's Adventure",
+      ridesPath: 'attractions',
+      scheduleCategory: 'Park Hours',
+      location: {latitude: 43.3411, longitude: -86.2625},
+    };
+    this.waterPark ??= {
+      id: 'enchantedparks_park_WWA',
+      code: 'WWA',
+      name: 'WildWater Adventure',
+      ridesPath: 'wildwater-adventure',
+      scheduleCategory: 'Waterpark Hours',
+      location: {latitude: 43.3411, longitude: -86.2625},
+    };
+  }
+}

--- a/src/parks/enchantedparks/michigansadventure.ts
+++ b/src/parks/enchantedparks/michigansadventure.ts
@@ -2,14 +2,14 @@ import {EnchantedParks} from './enchantedparks.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {DestinationConstructor} from '../../destination.js';
 
-@destinationController({category: ['Enchanted Parks', "Michigan's Adventure"]})
+@destinationController({category: ['Enchanted Parks', 'Michigan\'s Adventure']})
 export class MichigansAdventure extends EnchantedParks {
   constructor(options?: DestinationConstructor) {
     super({
       ...options,
       config: {
         destinationId: 'enchantedparks_michigansadventure',
-        destinationName: "Michigan's Adventure",
+        destinationName: 'Michigan\'s Adventure',
         timezone: 'America/Detroit',
         ...(options?.config ?? {}),
       },
@@ -18,7 +18,7 @@ export class MichigansAdventure extends EnchantedParks {
     this.themePark ??= {
       id: 'enchantedparks_park_MA',
       code: 'MA',
-      name: "Michigan's Adventure",
+      name: 'Michigan\'s Adventure',
       ridesPath: 'attractions',
       scheduleCategory: 'Park Hours',
       location: {latitude: 43.3411, longitude: -86.2625},

--- a/src/parks/enchantedparks/worldsoffun.ts
+++ b/src/parks/enchantedparks/worldsoffun.ts
@@ -1,0 +1,35 @@
+import {EnchantedParks} from './enchantedparks.js';
+import {destinationController} from '../../destinationRegistry.js';
+import type {DestinationConstructor} from '../../destination.js';
+
+@destinationController({category: ['Enchanted Parks', 'Worlds of Fun']})
+export class WorldsOfFun extends EnchantedParks {
+  constructor(options?: DestinationConstructor) {
+    super({
+      ...options,
+      config: {
+        destinationId: 'enchantedparks_worldsoffun',
+        destinationName: 'Worlds of Fun',
+        timezone: 'America/Chicago',
+        ...(options?.config ?? {}),
+      },
+    });
+    this.destinationLocation ??= {latitude: 39.1746, longitude: -94.4886};
+    this.themePark ??= {
+      id: 'enchantedparks_park_WOF',
+      code: 'WOF',
+      name: 'Worlds of Fun',
+      ridesPath: 'attractions',
+      scheduleCategory: 'Park Hours',
+      location: {latitude: 39.1746, longitude: -94.4886},
+    };
+    this.waterPark ??= {
+      id: 'enchantedparks_park_OOF',
+      code: 'OOF',
+      name: 'Oceans of Fun',
+      ridesPath: 'oceans-of-fun',
+      scheduleCategory: 'Waterpark Hours',
+      location: {latitude: 39.1746, longitude: -94.4886},
+    };
+  }
+}

--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -161,11 +161,12 @@ const PARKS_WITHOUT_WAIT_TIMES = new Set([942, 944, 947, 948, 959]);
  * feeds are no longer maintained, leaving the SixFlags class emitting all-
  * CLOSED garbage.
  *
- * On 2026-04-06 Six Flags sold a portfolio of six parks plus Valleyfair to
- * EPR Properties under 40-year operating leases. Five are operated by
- * Enchanted Parks; La Ronde is operated by La Ronde Operations under
- * Premier Parks LLC. The Enchanted Parks parks live under
- * `src/parks/enchantedparks/`. La Ronde currently has no replacement source.
+ * Between 2026-04-06 and 2026-05-14, Six Flags divested seven parks
+ * (including Valleyfair) to EPR Properties under 40-year operating
+ * leases. Six are operated by Enchanted Parks (WF, MA, VF, GV, SFSL,
+ * SFGE) and live under `src/parks/enchantedparks/`. La Ronde is operated
+ * by La Ronde Operations under Premier Parks LLC and currently has no
+ * replacement source.
  *
  * - 6   / WF:   Worlds of Fun         → enchantedparks/worldsoffun
  * - 12  / MA:   Michigan's Adventure  → enchantedparks/michigansadventure

--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -156,11 +156,26 @@ type SixFlagsOperatingHours = {
 const PARKS_WITHOUT_WAIT_TIMES = new Set([942, 944, 947, 948, 959]);
 
 /**
- * Park IDs to drop entirely — the destination is served by another module so
- * including it here would emit the destination twice.
- * - 14 / VF: Valleyfair (now under enchantedparks)
+ * Park IDs to drop entirely — the destination is served by another module
+ * or has been divested from Six Flags so its venue-status / wait-times
+ * feeds are no longer maintained, leaving the SixFlags class emitting all-
+ * CLOSED garbage.
+ *
+ * On 2026-04-06 Six Flags sold a portfolio of six parks plus Valleyfair to
+ * EPR Properties under 40-year operating leases. Five are operated by
+ * Enchanted Parks; La Ronde is operated by La Ronde Operations under
+ * Premier Parks LLC. The Enchanted Parks parks live under
+ * `src/parks/enchantedparks/`. La Ronde currently has no replacement source.
+ *
+ * - 6   / WF:   Worlds of Fun         → enchantedparks/worldsoffun
+ * - 12  / MA:   Michigan's Adventure  → enchantedparks/michigansadventure
+ * - 14  / VF:   Valleyfair            → enchantedparks/valleyfair
+ * - 27  / GV:   Schlitterbahn Galv.   → no source yet (subdomain not live)
+ * - 903 / SFSL: Six Flags St. Louis   → no source yet (subdomain not live)
+ * - 924 / SFGE: Six Flags Great Esc.  → no source yet (subdomain not live)
+ * - 969 / SFLR: La Ronde              → divested to La Ronde Operations
  */
-const EXCLUDED_PARK_IDS = new Set<number>([14]);
+const EXCLUDED_PARK_IDS = new Set<number>([6, 12, 14, 27, 903, 924, 969]);
 
 /** Default show duration in minutes when not otherwise specified */
 const DEFAULT_SHOW_DURATION_MINUTES = 30;
@@ -440,7 +455,7 @@ export class SixFlags extends Destination {
    * (new fields, new grouping rules like WATERPARK_PARENT_OVERRIDES, …).
    * Old entries become unreachable and expire on their TTL — no manual flush.
    */
-  @cache({ttlSeconds: 86400, cacheVersion: 3})
+  @cache({ttlSeconds: 86400, cacheVersion: 4})
   async getParkData(): Promise<SixFlagsParkData[]> {
     const entries = await this.getFirebaseConfig();
 

--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -164,9 +164,12 @@ const PARKS_WITHOUT_WAIT_TIMES = new Set([942, 944, 947, 948, 959]);
  * Between 2026-04-06 and 2026-05-14, Six Flags divested seven parks
  * (including Valleyfair) to EPR Properties under 40-year operating
  * leases. Six are operated by Enchanted Parks (WF, MA, VF, GV, SFSL,
- * SFGE) and live under `src/parks/enchantedparks/`. La Ronde is operated
- * by La Ronde Operations under Premier Parks LLC and currently has no
- * replacement source.
+ * SFGE); La Ronde is operated by La Ronde Operations under Premier Parks
+ * LLC. Replacement destination classes live under
+ * `src/parks/enchantedparks/` but only the three parks whose
+ * enchantedparks.com subdomains are live (WF, MA, VF) have subclasses
+ * today — the remaining three plus La Ronde are excluded with no source
+ * until their subdomains / a replacement become available.
  *
  * - 6   / WF:   Worlds of Fun         → enchantedparks/worldsoffun
  * - 12  / MA:   Michigan's Adventure  → enchantedparks/michigansadventure


### PR DESCRIPTION
## Background
On 2026-04-06 Six Flags sold seven parks (plus Valleyfair, already covered in #208) to EPR Properties under 40-year operating leases — Valleyfair, Worlds of Fun, Michigan's Adventure, Schlitterbahn Galveston, Six Flags St. Louis, and Six Flags Great Escape went to Enchanted Parks; La Ronde went to La Ronde Operations (Premier Parks LLC) on 2026-05-14.

Six Flags' venue-status / wait-times feeds for these parks have gone dark (all rides `Not Scheduled` 24/7) but Firebase Remote Config still lists them, so the SixFlags class was emitting all-CLOSED destinations with no live data — same shape as Valleyfair before #208.

## Changes

### Exclusions (sixflags.ts)
Add to `EXCLUDED_PARK_IDS`:
| parkId | Code | Park | New operator |
|---|---|---|---|
| 6 | WF | Worlds of Fun | Enchanted Parks |
| 12 | MA | Michigan's Adventure | Enchanted Parks |
| 27 | GV | Schlitterbahn Galveston | Enchanted Parks (subdomain not live yet) |
| 903 | SFSL | Six Flags St. Louis | Enchanted Parks (subdomain not live yet) |
| 924 | SFGE | Six Flags Great Escape | Enchanted Parks (subdomain not live yet) |
| 969 | SFLR | La Ronde | La Ronde Operations / Premier Parks |

Bump `getParkData()` cacheVersion 3 → 4 to invalidate stale snapshots.

Result: SixFlags `getParkData()` count drops 32 → 26.

### New EnchantedParks subclasses
Following the existing Valleyfair pattern:

**Worlds of Fun** (`worldsoffun.enchantedparks.com`):
- Themepark + Oceans of Fun waterpark
- `npm run dev -- worldsoffun`: 60 entities (1 dest, 2 parks, 57 attractions), 144 schedule days across both parks

**Michigan's Adventure** (`miadventure.enchantedparks.com`):
- Themepark + WildWater Adventure waterpark
- `npm run dev -- michigansadventure`: 57 entities (1 dest, 2 parks, 54 attractions), 162 schedule days

Both serve schedule + entities via the WordPress Tribe Events feed (verified `Park Hours` / `Waterpark Hours` categories match Valleyfair). No live wait times yet — the EnchantedParks base class still has `return []` in `buildLiveData()` ("No live wait-times source for Enchanted Parks until their app launches"). Coverage is on par with Valleyfair.

### Not in this PR
- **Schlitterbahn Galveston, Six Flags St. Louis, Six Flags Great Escape**: their `*.enchantedparks.com` subdomains return `000` (DNS not resolving) — they're excluded from SixFlags now, will add EnchantedParks subclasses when the subdomains go live.
- **La Ronde**: separate operator (La Ronde Operations / Premier Parks). Will need its own destination class once there's something to point at.

## Required env vars (collector)
```
WORLDSOFFUN_SUBDOMAIN=https://worldsoffun.enchantedparks.com
MICHIGANSADVENTURE_SUBDOMAIN=https://miadventure.enchantedparks.com
```

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 1183/1183 pass
- [x] `npm run dev -- worldsoffun` — 4/4 pass, 60 entities, 144 schedule days
- [x] `npm run dev -- michigansadventure` — 4/4 pass, 57 entities, 162 schedule days
- [x] Verified `SixFlags.getParkData()` count 32 → 26 with all 7 excluded parkIds (incl. existing Valleyfair) confirmed gone
- [ ] After deploy: re-run collector and confirm SixFlags pipeline stops emitting the 6 divested parks, EnchantedParks pipeline emits WoF + MA
- [ ] Wiki destination cleanup for the 6 SixFlags-side destinations (manual ID migration per established playbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)