### PR TITLE
feat: forward request headers, method & body through Scrapfly

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -136,6 +136,91 @@ describe('Per-Destination Proxy Injection', () => {
     expect(req.url).toBe('https://api.scrapfly.io/scrape?url=https%3A%2F%2Fexample.com%2Fapi%2Fdata&key=test-key');
   });
 
+  it('should forward request headers to Scrapfly as headers[] params', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    // Custom auth headers (fake values) — these must reach the target, or
+    // header-authenticated APIs (e.g. x-api-key) 401 through Scrapfly.
+    req.headers = {'x-api-key': 'fake-key-123', 'X-Custom-Auth': 'fake-token'};
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.url).toContain('headers%5Bx-api-key%5D=fake-key-123');
+    expect(req.url).toContain('headers%5BX-Custom-Auth%5D=fake-token');
+  });
+
+  it('should not forward hop-by-hop headers to Scrapfly', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    req.headers = {
+      host: 'example.com',
+      'content-length': '5',
+      connection: 'keep-alive',
+      'accept-encoding': 'gzip',
+      'x-api-key': 'keep-me',
+    };
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.url).not.toContain('headers%5Bhost%5D');
+    expect(req.url).not.toContain('headers%5Bcontent-length%5D');
+    expect(req.url).not.toContain('headers%5Bconnection%5D');
+    expect(req.url).not.toContain('headers%5Baccept-encoding%5D');
+    // Non-hop-by-hop headers still forwarded
+    expect(req.url).toContain('headers%5Bx-api-key%5D=keep-me');
+  });
+
+  it('should forward method and body for non-GET requests and call Scrapfly via GET', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    req.method = 'POST';
+    req.body = '{"foo":"bar"}';
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.url).toContain('method=POST');
+    expect(req.url).toContain('body=%7B%22foo%22%3A%22bar%22%7D');
+    // The request TO Scrapfly is itself a GET (Scrapfly performs the POST to the target)
+    expect(req.method).toBe('GET');
+    expect(req.body).toBeUndefined();
+  });
+
+  it('should JSON-encode object bodies when forwarding to Scrapfly', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    req.method = 'POST';
+    req.body = {foo: 'bar'};
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.url).toContain('body=%7B%22foo%22%3A%22bar%22%7D');
+  });
+
+  it('should leave GET requests without a method/body param', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.url).not.toContain('method=');
+    expect(req.url).not.toContain('body=');
+  });
+
   it('should set proxyUrl for basic proxy', async () => {
     process.env.PROXYTESTDESTINATION_BASICPROXY = JSON.stringify({proxy: 'http://myproxy.com:8080'});
 

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,7 +1,7 @@
 // Tests for proxy injection system
 import {loadProxyConfig, hasProxyConfig, type ProxyConfig} from '../proxy';
 import {Destination} from '../destination';
-import {HTTPObj} from '../http';
+import {HTTPObj, redactProxyUrlSecrets} from '../http';
 import {broadcast} from '../injector';
 import {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
 import config from '../config';
@@ -246,6 +246,38 @@ describe('Per-Destination Proxy Injection', () => {
     expect(req.url).toBe('https://api.scrapfly.io/scrape');
   });
 
+  it('should forward Content-Type/Accept for options.json requests', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    req.method = 'POST';
+    req.options = {json: true};
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.queryParams!['headers[Content-Type]']).toBe('application/json');
+    expect(req.queryParams!['headers[Accept]']).toBe('application/json');
+  });
+
+  it('should not duplicate Content-Type already set in request headers', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest();
+    req.method = 'POST';
+    req.options = {json: true};
+    req.headers = {'content-type': 'application/json'}; // lowercase, explicitly set
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    // The explicit lowercase header is forwarded; the capitalized json default is NOT added on top.
+    expect(req.queryParams!['headers[content-type]']).toBe('application/json');
+    expect(req.queryParams).not.toHaveProperty('headers[Content-Type]');
+  });
+
   it('should set proxyUrl for basic proxy', async () => {
     process.env.PROXYTESTDESTINATION_BASICPROXY = JSON.stringify({proxy: 'http://myproxy.com:8080'});
 
@@ -336,5 +368,35 @@ describe('Per-Destination Proxy Injection', () => {
 
     // Response should remain unchanged
     expect(req.response).toBe(originalResponse);
+  });
+});
+
+describe('redactProxyUrlSecrets', () => {
+  it('masks the Scrapfly key, forwarded headers and body', () => {
+    const url =
+      'https://api.scrapfly.io/scrape?url=https%3A%2F%2Fexample.com&key=fake-key&headers%5Bx-api-key%5D=fake-auth&body=secret-payload';
+    const redacted = redactProxyUrlSecrets(url);
+    expect(redacted).not.toContain('fake-key');
+    expect(redacted).not.toContain('fake-auth');
+    expect(redacted).not.toContain('secret-payload');
+    // The target url stays visible (not a secret, useful for debugging)
+    expect(redacted).toContain('url=https%3A%2F%2Fexample.com');
+    expect(redacted).toContain('key=***');
+  });
+
+  it('masks the CrawlBase token', () => {
+    const url = 'https://api.crawlbase.com/?url=https%3A%2F%2Fexample.com&token=fake-token';
+    const redacted = redactProxyUrlSecrets(url);
+    expect(redacted).not.toContain('fake-token');
+    expect(redacted).toContain('token=***');
+  });
+
+  it('leaves non-proxy URLs unchanged', () => {
+    const url = 'https://example.com/api/data?key=should-stay&foo=bar';
+    expect(redactProxyUrlSecrets(url)).toBe(url);
+  });
+
+  it('returns the input unchanged when not a valid URL', () => {
+    expect(redactProxyUrlSecrets('not a url')).toBe('not a url');
   });
 });

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -133,7 +133,10 @@ describe('Per-Destination Proxy Injection', () => {
     const req = createMockRequest();
     await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
 
-    expect(req.url).toBe('https://api.scrapfly.io/scrape?url=https%3A%2F%2Fexample.com%2Fapi%2Fdata&key=test-key');
+    // Scrapfly params live in queryParams (merged into the URL only at
+    // buildUrl() time) — req.url stays the bare endpoint so logs don't leak.
+    expect(req.url).toBe('https://api.scrapfly.io/scrape');
+    expect(req.queryParams).toMatchObject({url: 'https://example.com/api/data', key: 'test-key'});
   });
 
   it('should forward request headers to Scrapfly as headers[] params', async () => {
@@ -148,8 +151,12 @@ describe('Per-Destination Proxy Injection', () => {
     req.headers = {'x-api-key': 'fake-key-123', 'X-Custom-Auth': 'fake-token'};
     await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
 
-    expect(req.url).toContain('headers%5Bx-api-key%5D=fake-key-123');
-    expect(req.url).toContain('headers%5BX-Custom-Auth%5D=fake-token');
+    expect(req.queryParams!['headers[x-api-key]']).toBe('fake-key-123');
+    expect(req.queryParams!['headers[X-Custom-Auth]']).toBe('fake-token');
+    // Secrets must NOT be baked into req.url (logged verbatim on retry/trace),
+    // and the original request headers are cleared after forwarding.
+    expect(req.url).toBe('https://api.scrapfly.io/scrape');
+    expect(req.headers).toEqual({});
   });
 
   it('should not forward hop-by-hop headers to Scrapfly', async () => {
@@ -168,12 +175,12 @@ describe('Per-Destination Proxy Injection', () => {
     };
     await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
 
-    expect(req.url).not.toContain('headers%5Bhost%5D');
-    expect(req.url).not.toContain('headers%5Bcontent-length%5D');
-    expect(req.url).not.toContain('headers%5Bconnection%5D');
-    expect(req.url).not.toContain('headers%5Baccept-encoding%5D');
+    expect(req.queryParams).not.toHaveProperty('headers[host]');
+    expect(req.queryParams).not.toHaveProperty('headers[content-length]');
+    expect(req.queryParams).not.toHaveProperty('headers[connection]');
+    expect(req.queryParams).not.toHaveProperty('headers[accept-encoding]');
     // Non-hop-by-hop headers still forwarded
-    expect(req.url).toContain('headers%5Bx-api-key%5D=keep-me');
+    expect(req.queryParams!['headers[x-api-key]']).toBe('keep-me');
   });
 
   it('should forward method and body for non-GET requests and call Scrapfly via GET', async () => {
@@ -187,8 +194,8 @@ describe('Per-Destination Proxy Injection', () => {
     req.body = '{"foo":"bar"}';
     await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
 
-    expect(req.url).toContain('method=POST');
-    expect(req.url).toContain('body=%7B%22foo%22%3A%22bar%22%7D');
+    expect(req.queryParams!.method).toBe('POST');
+    expect(req.queryParams!.body).toBe('{"foo":"bar"}');
     // The request TO Scrapfly is itself a GET (Scrapfly performs the POST to the target)
     expect(req.method).toBe('GET');
     expect(req.body).toBeUndefined();
@@ -205,7 +212,7 @@ describe('Per-Destination Proxy Injection', () => {
     req.body = {foo: 'bar'};
     await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
 
-    expect(req.url).toContain('body=%7B%22foo%22%3A%22bar%22%7D');
+    expect(req.queryParams!.body).toBe('{"foo":"bar"}');
   });
 
   it('should leave GET requests without a method/body param', async () => {
@@ -217,8 +224,26 @@ describe('Per-Destination Proxy Injection', () => {
     const req = createMockRequest();
     await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
 
-    expect(req.url).not.toContain('method=');
-    expect(req.url).not.toContain('body=');
+    expect(req.queryParams).not.toHaveProperty('method');
+    expect(req.queryParams).not.toHaveProperty('body');
+  });
+
+  it('should fold the request queryParams into the Scrapfly target url param', async () => {
+    process.env.PROXYTESTDESTINATION_SCRAPFLY = JSON.stringify({apikey: 'test-key'});
+
+    const dest = new ProxyTestDestination();
+    dest.addConfigPrefix('PROXYTESTDESTINATION');
+
+    const req = createMockRequest('https://example.com/api/data');
+    // Target's own query params must survive proxying (Scrapfly fetches `url` verbatim).
+    req.queryParams = {region: 'jp', limit: '10'};
+    await broadcast(dest, {eventName: 'httpRequest', hostname: 'example.com', url: req.url, method: req.method, tags: req.tags}, req);
+
+    expect(req.queryParams!.url).toBe('https://example.com/api/data?region=jp&limit=10');
+    // The target params are NOT left as top-level params on the Scrapfly call.
+    expect(req.queryParams).not.toHaveProperty('region');
+    expect(req.queryParams).not.toHaveProperty('limit');
+    expect(req.url).toBe('https://api.scrapfly.io/scrape');
   });
 
   it('should set proxyUrl for basic proxy', async () => {

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -297,6 +297,16 @@ export abstract class Destination {
           sfParams[`headers[${name}]`] = String(value);
         }
       }
+      // buildHeaders() adds Content-Type/Accept for options.json requests; those
+      // are applied at send time and aren't in req.headers, so forward them too
+      // — otherwise a proxied JSON POST reaches the target without Content-Type.
+      // Skip if the request already set them explicitly (case-insensitive).
+      if (req.options?.json) {
+        const hasHeader = (h: string) =>
+          Object.keys(req.headers ?? {}).some((k) => k.toLowerCase() === h);
+        if (!hasHeader('content-type')) sfParams['headers[Content-Type]'] = 'application/json';
+        if (!hasHeader('accept')) sfParams['headers[Accept]'] = 'application/json';
+      }
       const method = (req.method || 'GET').toUpperCase();
       if (method !== 'GET') {
         sfParams.method = method;

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -113,6 +113,18 @@ export type EntityMapperConfig<T> = {
 };
 
 // Base class for all destinations
+// Hop-by-hop / transport-managed headers that must not be forwarded to a
+// target through Scrapfly — they describe the connection to the proxy, not the
+// target request, and forwarding them corrupts it.
+const SCRAPFLY_SKIP_HEADERS = new Set([
+  'host',
+  'content-length',
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'accept-encoding',
+]);
+
 export abstract class Destination {
   // Global proxy config — loaded once from GLOBAL_* env vars, shared across all destinations
   private static globalProxyConfig: ProxyConfig | null = null;
@@ -263,6 +275,31 @@ export abstract class Destination {
       const params = new URLSearchParams({url: req.url, key: sf.apikey});
       if (sf.params) {
         for (const [k, v] of Object.entries(sf.params)) params.set(k, v);
+      }
+      // Scrapfly's REST endpoint only sends headers/method/body to the TARGET
+      // when passed as explicit params — it does not forward the inbound
+      // request's own headers or body. Without this, APIs that authenticate via
+      // custom headers (e.g. an x-api-key header) fail with 401 through
+      // Scrapfly. Forward the request's headers (minus hop-by-hop), method, and
+      // body so authenticated requests behave the same as direct.
+      if (req.headers) {
+        for (const [name, value] of Object.entries(req.headers)) {
+          if (value == null) continue;
+          if (SCRAPFLY_SKIP_HEADERS.has(name.toLowerCase())) continue;
+          params.set(`headers[${name}]`, String(value));
+        }
+      }
+      const method = (req.method || 'GET').toUpperCase();
+      if (method !== 'GET') {
+        params.set('method', method);
+        if (req.body != null) {
+          params.set('body', typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
+        }
+        // The call TO Scrapfly is itself a GET; Scrapfly performs the
+        // method/body against the target. Clear them so the body isn't also
+        // sent to api.scrapfly.io.
+        req.method = 'GET';
+        req.body = undefined;
       }
       req.url = `https://api.scrapfly.io/scrape?${params.toString()}`;
       return;

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -272,10 +272,18 @@ export abstract class Destination {
 
     if (this.proxyConfig.scrapfly) {
       const sf = this.proxyConfig.scrapfly;
-      const params = new URLSearchParams({url: req.url, key: sf.apikey});
-      if (sf.params) {
-        for (const [k, v] of Object.entries(sf.params)) params.set(k, v);
+
+      // Fold the request's own query params into the target URL so they survive
+      // proxying — Scrapfly fetches the `url` param verbatim and would otherwise
+      // drop them (and they'd leak onto the Scrapfly call via buildUrl()).
+      const targetUrl = new URL(req.url);
+      if (req.queryParams) {
+        for (const [k, v] of Object.entries(req.queryParams)) targetUrl.searchParams.append(k, v);
       }
+
+      const sfParams: Record<string, string> = {url: targetUrl.toString(), key: sf.apikey};
+      if (sf.params) Object.assign(sfParams, sf.params);
+
       // Scrapfly's REST endpoint only sends headers/method/body to the TARGET
       // when passed as explicit params — it does not forward the inbound
       // request's own headers or body. Without this, APIs that authenticate via
@@ -286,22 +294,29 @@ export abstract class Destination {
         for (const [name, value] of Object.entries(req.headers)) {
           if (value == null) continue;
           if (SCRAPFLY_SKIP_HEADERS.has(name.toLowerCase())) continue;
-          params.set(`headers[${name}]`, String(value));
+          sfParams[`headers[${name}]`] = String(value);
         }
       }
       const method = (req.method || 'GET').toUpperCase();
       if (method !== 'GET') {
-        params.set('method', method);
+        sfParams.method = method;
         if (req.body != null) {
-          params.set('body', typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
+          sfParams.body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
         }
         // The call TO Scrapfly is itself a GET; Scrapfly performs the
-        // method/body against the target. Clear them so the body isn't also
-        // sent to api.scrapfly.io.
+        // method/body against the target.
         req.method = 'GET';
         req.body = undefined;
       }
-      req.url = `https://api.scrapfly.io/scrape?${params.toString()}`;
+
+      // Keep the Scrapfly key, forwarded auth headers and body in queryParams
+      // (merged into the final URL only at buildUrl() time) rather than baking
+      // them into req.url — trace/retry logging prints req.url verbatim, so this
+      // keeps secrets out of the logs. Auth now travels as params, so clear the
+      // request headers too (they'd otherwise be sent to api.scrapfly.io).
+      req.headers = {};
+      req.url = 'https://api.scrapfly.io/scrape';
+      req.queryParams = sfParams;
       return;
     }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -73,6 +73,36 @@ export type HTTPOptions = {
 };
 
 // Full HTTP object with response methods (for runtime use)
+/**
+ * Redact secret query params from a proxy URL before it appears in logs or
+ * error messages. Proxy services (Scrapfly/CrawlBase) carry the API key — and,
+ * for Scrapfly, forwarded auth headers and request bodies — in the URL's query
+ * string, which would otherwise leak into error/retry logs on failure. Only the
+ * known proxy hosts and their sensitive params are touched; all other URLs are
+ * returned unchanged.
+ */
+export function redactProxyUrlSecrets(rawUrl: string): string {
+  try {
+    const u = new URL(rawUrl);
+    if (u.hostname === 'api.scrapfly.io') {
+      for (const name of [...u.searchParams.keys()]) {
+        const lower = name.toLowerCase();
+        if (lower === 'key' || lower === 'body' || lower.startsWith('headers[')) {
+          u.searchParams.set(name, '***');
+        }
+      }
+      return u.toString();
+    }
+    if (u.hostname === 'api.crawlbase.com' && u.searchParams.has('token')) {
+      u.searchParams.set('token', '***');
+      return u.toString();
+    }
+    return rawUrl;
+  } catch {
+    return rawUrl;
+  }
+}
+
 export interface HTTPObj {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
   url: string;
@@ -487,7 +517,7 @@ class HTTPRequestImpl implements HTTPObj {
       } catch { /* ignore */ }
       throw new Error(
         `HTTP request not OK: ${response.status} ${response.statusText}\n` +
-        `  URL: ${this.method} ${urlToFetch}\n` +
+        `  URL: ${this.method} ${redactProxyUrlSecrets(urlToFetch)}\n` +
         (bodySnippet ? `  Body: ${bodySnippet}\n` : '')
       );
     }

--- a/src/http.ts
+++ b/src/http.ts
@@ -7,7 +7,8 @@ import {broadcast} from "./injector.js";
 import {tracing} from "./tracing.js";
 import Ajv, {type DefinedError} from "ajv";
 // Note: basic proxy URL is now set per-request via proxyUrl property (injected by Destination._injectProxy)
-import {makeHttpRequest} from "./httpProxy.js";
+import {makeHttpRequest, redactProxyUrlSecrets} from "./httpProxy.js";
+export {redactProxyUrlSecrets};
 const ajv = new Ajv.default();
 
 // OpenAPI-like parameter definition
@@ -73,36 +74,6 @@ export type HTTPOptions = {
 };
 
 // Full HTTP object with response methods (for runtime use)
-/**
- * Redact secret query params from a proxy URL before it appears in logs or
- * error messages. Proxy services (Scrapfly/CrawlBase) carry the API key — and,
- * for Scrapfly, forwarded auth headers and request bodies — in the URL's query
- * string, which would otherwise leak into error/retry logs on failure. Only the
- * known proxy hosts and their sensitive params are touched; all other URLs are
- * returned unchanged.
- */
-export function redactProxyUrlSecrets(rawUrl: string): string {
-  try {
-    const u = new URL(rawUrl);
-    if (u.hostname === 'api.scrapfly.io') {
-      for (const name of [...u.searchParams.keys()]) {
-        const lower = name.toLowerCase();
-        if (lower === 'key' || lower === 'body' || lower.startsWith('headers[')) {
-          u.searchParams.set(name, '***');
-        }
-      }
-      return u.toString();
-    }
-    if (u.hostname === 'api.crawlbase.com' && u.searchParams.has('token')) {
-      u.searchParams.set('token', '***');
-      return u.toString();
-    }
-    return rawUrl;
-  } catch {
-    return rawUrl;
-  }
-}
-
 export interface HTTPObj {
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
   url: string;

--- a/src/httpProxy.ts
+++ b/src/httpProxy.ts
@@ -29,6 +29,36 @@ import {
  * @param options Request options
  * @returns Standard fetch Response
  */
+/**
+ * Redact secret query params from a proxy URL before it appears in logs or
+ * error messages. Proxy services (Scrapfly/CrawlBase) carry the API key — and,
+ * for Scrapfly, forwarded auth headers and request bodies — in the URL's query
+ * string, which would otherwise leak into error/retry logs on failure. Only the
+ * known proxy hosts and their sensitive params are touched; all other URLs are
+ * returned unchanged.
+ */
+export function redactProxyUrlSecrets(rawUrl: string): string {
+  try {
+    const u = new URL(rawUrl);
+    if (u.hostname === 'api.scrapfly.io') {
+      for (const name of [...u.searchParams.keys()]) {
+        const lower = name.toLowerCase();
+        if (lower === 'key' || lower === 'body' || lower.startsWith('headers[')) {
+          u.searchParams.set(name, '***');
+        }
+      }
+      return u.toString();
+    }
+    if (u.hostname === 'api.crawlbase.com' && u.searchParams.has('token')) {
+      u.searchParams.set('token', '***');
+      return u.toString();
+    }
+    return rawUrl;
+  } catch {
+    return rawUrl;
+  }
+}
+
 export async function makeHttpRequest(options: {
   method: string;
   url: string;
@@ -94,7 +124,7 @@ export async function makeHttpRequest(options: {
     // Surface timeouts with the same message shape we used before so callers
     // (and log greps) don't need to change.
     if (err?.name === 'TimeoutError' || err?.code === 'UND_ERR_ABORTED' || err?.name === 'AbortError') {
-      throw new Error(`HTTP request timed out after ${timeoutMs}ms: ${method} ${url}`);
+      throw new Error(`HTTP request timed out after ${timeoutMs}ms: ${method} ${redactProxyUrlSecrets(url)}`);
     }
     throw err;
   }


### PR DESCRIPTION
## Problem

Scrapfly's REST scrape endpoint only sends headers/method/body to the **target** when they're passed as explicit params (`headers[Name]=Value`, `method`, `body`). It does **not** forward the inbound request's own headers or body.

So any destination that authenticates with custom headers (e.g. an `x-api-key` header set) gets a **401** when routed through Scrapfly — `_injectProxy` rewrote the URL to `api.scrapfly.io/scrape?...` but the auth headers were left on the request to Scrapfly, never reaching the target. This blocks using Scrapfly's residential pool to get past Akamai-style datacenter-IP blocks on header-authenticated APIs.

## Fix

`_injectProxy` (Scrapfly branch) now:
- copies `req.headers` (minus hop-by-hop: host, content-length, connection, keep-alive, transfer-encoding, accept-encoding) into `headers[Name]=Value` params, and
- for non-GET requests, forwards `method` + `body` as params and issues the Scrapfly call itself as a `GET` (Scrapfly performs the method/body against the target).

Header-authenticated APIs now work through Scrapfly the same as direct.

## Tests

Added to `proxy.test.ts` (all fake values, no secrets): header forwarding, hop-by-hop exclusion, method/body forwarding, object-body JSON encoding, GET passthrough. Full suite green (1196 tests), `tsc` clean.

Manually verified against a real Akamai-fronted, header-authenticated endpoint: residential pool + forwarded headers advances auth correctly where the un-forwarded request 401s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)