### PR TITLE
feat(enchantedparks): add Mid-America Parks (former Six Flags St. Louis)

### DIFF
--- a/src/__tests__/entityIdRegression.test.ts
+++ b/src/__tests__/entityIdRegression.test.ts
@@ -178,6 +178,25 @@ describe('Destination ID patterns', () => {
     expect(destinations[0]?.id).not.toBe('michigansadventure');
   });
 
+  test('Mid-America Parks class is registered under the Enchanted Parks umbrella', async () => {
+    const destinations = await getAllDestinations();
+    const ids = destinations.map(d => d.id);
+    expect(ids).toContain('midamericaparks');
+    const map = destinations.find(d => d.id === 'midamericaparks');
+    expect(map?.category).toEqual(['Enchanted Parks', 'Mid-America Parks']);
+  });
+
+  test('Mid-America Parks emits enchantedparks-namespaced DESTINATION entity id', async () => {
+    // Migrated from sixflags_destination_SFSL → enchantedparks_midamericaparks
+    // when EPR/Enchanted Parks took over for the 2026 season. Wiki externalId
+    // will be renamed to match.
+    const {MidAmericaParks} = await import('../parks/enchantedparks/midamericaparks.js');
+    const dest = new MidAmericaParks({});
+    const destinations = await dest.getDestinations();
+    expect(destinations[0]?.id).toBe('enchantedparks_midamericaparks');
+    expect(destinations[0]?.id).not.toBe('midamericaparks');
+  });
+
   test('Attractions.io v1 Merlin parks are registered individually', async () => {
     const destinations = await getAllDestinations();
     const merlin = destinations.filter(d =>

--- a/src/parks/enchantedparks/midamericaparks.ts
+++ b/src/parks/enchantedparks/midamericaparks.ts
@@ -1,0 +1,35 @@
+import {EnchantedParks} from './enchantedparks.js';
+import {destinationController} from '../../destinationRegistry.js';
+import type {DestinationConstructor} from '../../destination.js';
+
+@destinationController({category: ['Enchanted Parks', 'Mid-America Parks']})
+export class MidAmericaParks extends EnchantedParks {
+  constructor(options?: DestinationConstructor) {
+    super({
+      ...options,
+      config: {
+        destinationId: 'enchantedparks_midamericaparks',
+        destinationName: 'Mid-America Parks',
+        timezone: 'America/Chicago',
+        ...(options?.config ?? {}),
+      },
+    });
+    this.destinationLocation ??= {latitude: 38.5128, longitude: -90.6724};
+    this.themePark ??= {
+      id: 'enchantedparks_park_MAP',
+      code: 'MAP',
+      name: 'Mid-America Parks',
+      ridesPath: 'attractions',
+      scheduleCategory: 'Park Hours',
+      location: {latitude: 38.5128, longitude: -90.6724},
+    };
+    this.waterPark ??= {
+      id: 'enchantedparks_park_HH',
+      code: 'HH',
+      name: 'Hurricane Harbor',
+      ridesPath: 'hurricane-harbor-water-park',
+      scheduleCategory: 'Waterpark Hours',
+      location: {latitude: 38.5128, longitude: -90.6724},
+    };
+  }
+}

--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -161,23 +161,23 @@ const PARKS_WITHOUT_WAIT_TIMES = new Set([942, 944, 947, 948, 959]);
  * feeds are no longer maintained, leaving the SixFlags class emitting all-
  * CLOSED garbage.
  *
- * Between 2026-04-06 and 2026-05-14, Six Flags divested seven parks
- * (including Valleyfair) to EPR Properties under 40-year operating
- * leases. Six are operated by Enchanted Parks (WF, MA, VF, GV, SFSL,
- * SFGE); La Ronde is operated by La Ronde Operations under Premier Parks
- * LLC. Replacement destination classes live under
- * `src/parks/enchantedparks/` but only the three parks whose
- * enchantedparks.com subdomains are live (WF, MA, VF) have subclasses
- * today — the remaining three plus La Ronde are excluded with no source
- * until their subdomains / a replacement become available.
+ * Between 2026-04-06 and 2026-05-14, Six Flags divested seven parks to
+ * EPR Properties under 40-year operating leases. Six are operated by
+ * Enchanted Parks (WF, MA, VF, GV, SFSL, SFGE); La Ronde is operated by
+ * La Ronde Operations Inc., a Premier Parks LLC subsidiary that also
+ * runs Calypso and Valcartier. Replacement destination classes live
+ * under `src/parks/enchantedparks/`.
  *
  * - 6   / WF:   Worlds of Fun         → enchantedparks/worldsoffun
  * - 12  / MA:   Michigan's Adventure  → enchantedparks/michigansadventure
  * - 14  / VF:   Valleyfair            → enchantedparks/valleyfair
  * - 27  / GV:   Schlitterbahn Galv.   → no source yet (subdomain not live)
- * - 903 / SFSL: Six Flags St. Louis   → no source yet (subdomain not live)
+ * - 903 / SFSL: Six Flags St. Louis   → enchantedparks/midamericaparks
  * - 924 / SFGE: Six Flags Great Esc.  → no source yet (subdomain not live)
- * - 969 / SFLR: La Ronde              → divested to La Ronde Operations
+ * - 969 / SFLR: La Ronde              → no primary source distinct from
+ *                                       the Six Flags app; Premier Parks
+ *                                       has no shared guest-experience
+ *                                       platform with wait times
  */
 const EXCLUDED_PARK_IDS = new Set<number>([6, 12, 14, 27, 903, 924, 969]);
 


### PR DESCRIPTION
## Summary

Six Flags St. Louis (parkId 903) was sold to EPR Properties on 2026-04-06 in the same April divestment wave as Worlds of Fun and Michigan's Adventure. The park is operated by Enchanted Parks under the lease; its WordPress/Tribe Events site at **mid-americaparks.enchantedparks.com** is already live and matches the stack used by the existing EP subclasses.

- Add `MidAmericaParks` subclass under `src/parks/enchantedparks/midamericaparks.ts`, mirroring `worldsoffun.ts` (theme park + water park structure)
  - destinationId `enchantedparks_midamericaparks`, theme park code `MAP`, water park code `HH` (Hurricane Harbor)
- Update the SixFlags `EXCLUDED_PARK_IDS` comment block:
  - parkId 903 → points at the new module
  - parkId 969 (La Ronde) → corrected from the speculative "divested to La Ronde Operations" placeholder to "no usable primary source distinct from the Six Flags app" (Premier Parks LLC has no shared guest-experience platform)

## Verification

Ran `MIDAMERICAPARKS_SUBDOMAIN=https://mid-americaparks.enchantedparks.com npm run dev -- midamericaparks` against the live site:

- Found 1 destination, 2 parks, **41 attractions** parsed via existing `parseAttractionsPage()`
- **129 schedule days** returned via Tribe Events (Park Hours + Waterpark Hours categories match siblings exactly)
- 0 live data — parity with WoF/MA/Valleyfair (EP source has no wait-time surface)
- Missing locations on all 41 attractions — same gap as siblings; will bundle a static `midamericaparks.json` snapshot in a follow-up PR once the wiki migration shakes out

## Post-merge ops (collector + wiki)

1. Bump parksapi in the collector (`npm run bump`)
2. Set `ENCHANTEDPARKS_SUBDOMAIN` / `MIDAMERICAPARKS_SUBDOMAIN` in collector env
3. Rename wiki destination externalId: `sixflags_destination_SFSL` → `enchantedparks_midamericaparks` (admin PUT, same playbook as WoF/MA)
4. Purge orphan LiveData rows: SFSL (39), GV (21), SFGE (55), La Ronde (40) — all frozen at 2026-06-09T19:55, none will be replaced
5. Run migration tool for the new park IDs

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/parks/enchantedparks src/parks/sixflags` — 25/25 pass
- [x] Live harness run against `mid-americaparks.enchantedparks.com` — entities + schedules confirmed
- [ ] Post-merge: confirm collector picks up the new module and wiki receives fresh entities
- [ ] Follow-up PR for `locations/midamericaparks.json` snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)