### PR TITLE
feat(enchantedparks): add Great Escape Parks + Galveston Island Waterpark

### DIFF
--- a/src/__tests__/entityIdRegression.test.ts
+++ b/src/__tests__/entityIdRegression.test.ts
@@ -197,6 +197,42 @@ describe('Destination ID patterns', () => {
     expect(destinations[0]?.id).not.toBe('midamericaparks');
   });
 
+  test('Great Escape Parks class is registered under the Enchanted Parks umbrella', async () => {
+    const destinations = await getAllDestinations();
+    const ids = destinations.map(d => d.id);
+    expect(ids).toContain('greatescapeparks');
+    const ge = destinations.find(d => d.id === 'greatescapeparks');
+    expect(ge?.category).toEqual(['Enchanted Parks', 'Great Escape Parks']);
+  });
+
+  test('Great Escape Parks emits enchantedparks-namespaced DESTINATION entity id', async () => {
+    // Migrated from sixflags_destination_SFGE → enchantedparks_greatescapeparks
+    // when EPR/Enchanted Parks took over for the 2026 season.
+    const {GreatEscapeParks} = await import('../parks/enchantedparks/greatescapeparks.js');
+    const dest = new GreatEscapeParks({});
+    const destinations = await dest.getDestinations();
+    expect(destinations[0]?.id).toBe('enchantedparks_greatescapeparks');
+    expect(destinations[0]?.id).not.toBe('greatescapeparks');
+  });
+
+  test('Galveston Island Waterpark class is registered under the Enchanted Parks umbrella', async () => {
+    const destinations = await getAllDestinations();
+    const ids = destinations.map(d => d.id);
+    expect(ids).toContain('galvestonislandwaterpark');
+    const giwp = destinations.find(d => d.id === 'galvestonislandwaterpark');
+    expect(giwp?.category).toEqual(['Enchanted Parks', 'Galveston Island Waterpark']);
+  });
+
+  test('Galveston Island Waterpark emits enchantedparks-namespaced DESTINATION entity id', async () => {
+    // Migrated from sixflags_destination_GV → enchantedparks_galvestonislandwaterpark
+    // when EPR/Enchanted Parks took over for the 2026 season.
+    const {GalvestonIslandWaterpark} = await import('../parks/enchantedparks/galvestonislandwaterpark.js');
+    const dest = new GalvestonIslandWaterpark({});
+    const destinations = await dest.getDestinations();
+    expect(destinations[0]?.id).toBe('enchantedparks_galvestonislandwaterpark');
+    expect(destinations[0]?.id).not.toBe('galvestonislandwaterpark');
+  });
+
   test('Attractions.io v1 Merlin parks are registered individually', async () => {
     const destinations = await getAllDestinations();
     const merlin = destinations.filter(d =>

--- a/src/parks/enchantedparks/galvestonislandwaterpark.ts
+++ b/src/parks/enchantedparks/galvestonislandwaterpark.ts
@@ -1,6 +1,7 @@
 import {EnchantedParks} from './enchantedparks.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {DestinationConstructor} from '../../destination.js';
+import locations from './locations/galvestonislandwaterpark.json' with {type: 'json'};
 
 @destinationController({category: ['Enchanted Parks', 'Galveston Island Waterpark']})
 export class GalvestonIslandWaterpark extends EnchantedParks {
@@ -14,6 +15,7 @@ export class GalvestonIslandWaterpark extends EnchantedParks {
         ...(options?.config ?? {}),
       },
     });
+    this.attractionLocations = locations;
     this.destinationLocation ??= {latitude: 29.2767, longitude: -94.8231};
     // Water-park-only destination: the upstream site exposes a single
     // `/rides-and-experiences/attractions/` list under the "Waterpark Hours"

--- a/src/parks/enchantedparks/galvestonislandwaterpark.ts
+++ b/src/parks/enchantedparks/galvestonislandwaterpark.ts
@@ -1,0 +1,31 @@
+import {EnchantedParks} from './enchantedparks.js';
+import {destinationController} from '../../destinationRegistry.js';
+import type {DestinationConstructor} from '../../destination.js';
+
+@destinationController({category: ['Enchanted Parks', 'Galveston Island Waterpark']})
+export class GalvestonIslandWaterpark extends EnchantedParks {
+  constructor(options?: DestinationConstructor) {
+    super({
+      ...options,
+      config: {
+        destinationId: 'enchantedparks_galvestonislandwaterpark',
+        destinationName: 'Galveston Island Waterpark',
+        timezone: 'America/Chicago',
+        ...(options?.config ?? {}),
+      },
+    });
+    this.destinationLocation ??= {latitude: 29.2767, longitude: -94.8231};
+    // Water-park-only destination: the upstream site exposes a single
+    // `/rides-and-experiences/attractions/` list under the "Waterpark Hours"
+    // schedule category, with no separate theme-park surface. We register it
+    // as the only park rather than splitting into theme/water.
+    this.waterPark ??= {
+      id: 'enchantedparks_park_GIWP',
+      code: 'GIWP',
+      name: 'Galveston Island Waterpark',
+      ridesPath: 'attractions',
+      scheduleCategory: 'Waterpark Hours',
+      location: {latitude: 29.2767, longitude: -94.8231},
+    };
+  }
+}

--- a/src/parks/enchantedparks/greatescapeparks.ts
+++ b/src/parks/enchantedparks/greatescapeparks.ts
@@ -1,0 +1,35 @@
+import {EnchantedParks} from './enchantedparks.js';
+import {destinationController} from '../../destinationRegistry.js';
+import type {DestinationConstructor} from '../../destination.js';
+
+@destinationController({category: ['Enchanted Parks', 'Great Escape Parks']})
+export class GreatEscapeParks extends EnchantedParks {
+  constructor(options?: DestinationConstructor) {
+    super({
+      ...options,
+      config: {
+        destinationId: 'enchantedparks_greatescapeparks',
+        destinationName: 'Great Escape Parks',
+        timezone: 'America/New_York',
+        ...(options?.config ?? {}),
+      },
+    });
+    this.destinationLocation ??= {latitude: 43.3506, longitude: -73.6889};
+    this.themePark ??= {
+      id: 'enchantedparks_park_GE',
+      code: 'GE',
+      name: 'The Great Escape',
+      ridesPath: 'attractions',
+      scheduleCategory: 'Park Hours',
+      location: {latitude: 43.3506, longitude: -73.6889},
+    };
+    this.waterPark ??= {
+      id: 'enchantedparks_park_HHGE',
+      code: 'HHGE',
+      name: 'Hurricane Harbor',
+      ridesPath: 'hurricane-harbor-water-park',
+      scheduleCategory: 'Waterpark Hours',
+      location: {latitude: 43.3506, longitude: -73.6889},
+    };
+  }
+}

--- a/src/parks/enchantedparks/greatescapeparks.ts
+++ b/src/parks/enchantedparks/greatescapeparks.ts
@@ -1,6 +1,7 @@
 import {EnchantedParks} from './enchantedparks.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {DestinationConstructor} from '../../destination.js';
+import locations from './locations/greatescapeparks.json' with {type: 'json'};
 
 @destinationController({category: ['Enchanted Parks', 'Great Escape Parks']})
 export class GreatEscapeParks extends EnchantedParks {
@@ -14,6 +15,7 @@ export class GreatEscapeParks extends EnchantedParks {
         ...(options?.config ?? {}),
       },
     });
+    this.attractionLocations = locations;
     this.destinationLocation ??= {latitude: 43.3506, longitude: -73.6889};
     this.themePark ??= {
       id: 'enchantedparks_park_GE',

--- a/src/parks/enchantedparks/locations/galvestonislandwaterpark.json
+++ b/src/parks/enchantedparks/locations/galvestonislandwaterpark.json
@@ -1,0 +1,86 @@
+{
+  "AquaVeyer": {
+    "latitude": 29.270818,
+    "longitude": -94.85136
+  },
+  "Bahnzai Pipeline": {
+    "latitude": 29.271073,
+    "longitude": -94.851887
+  },
+  "Boogie Bahn": {
+    "latitude": 29.270903,
+    "longitude": -94.85183
+  },
+  "Dragon Blaster": {
+    "latitude": 29.27142,
+    "longitude": -94.852288
+  },
+  "Infinity Racers": {
+    "latitude": 29.270696,
+    "longitude": -94.850548
+  },
+  "Infinity Swim-Up Bar": {
+    "latitude": 29.271432,
+    "longitude": -94.850571
+  },
+  "Kristal River": {
+    "latitude": 29.271465,
+    "longitude": -94.852076
+  },
+  "Loopy Luge": {
+    "latitude": 29.269987,
+    "longitude": -94.852039
+  },
+  "MASSIV Monster Blaster": {
+    "latitude": 29.271256,
+    "longitude": -94.850191
+  },
+  "Rohr!": {
+    "latitude": 29.269473,
+    "longitude": -94.852028
+  },
+  "Screaming Serpents": {
+    "latitude": 29.270204,
+    "longitude": -94.850568
+  },
+  "Shipwreck Harbor": {
+    "latitude": 29.271606,
+    "longitude": -94.85109
+  },
+  "Thunder Tub": {
+    "latitude": 29.27132,
+    "longitude": -94.851903
+  },
+  "Tiki Tikes": {
+    "latitude": 29.271436,
+    "longitude": -94.851785
+  },
+  "Torrent Beach Kids Area": {
+    "latitude": 29.269815,
+    "longitude": -94.85206
+  },
+  "Torrent River": {
+    "latitude": 29.269732,
+    "longitude": -94.852016
+  },
+  "Treasure Island Kids Pool": {
+    "latitude": 29.271336,
+    "longitude": -94.850475
+  },
+  "Wasserfest Kids Area": {
+    "latitude": 29.269949,
+    "longitude": -94.85135
+  },
+  "Wasserfest Swim-Up Bar": {
+    "latitude": 29.269831,
+    "longitude": -94.851547
+  },
+  "Wave Lagoon": {
+    "latitude": 29.270478,
+    "longitude": -94.852144
+  },
+  "Whitewater River": {
+    "latitude": 29.270652,
+    "longitude": -94.851071
+  }
+}

--- a/src/parks/enchantedparks/locations/greatescapeparks.json
+++ b/src/parks/enchantedparks/locations/greatescapeparks.json
@@ -1,0 +1,198 @@
+{
+  "Adirondack Outlaw": {
+    "latitude": 43.351357,
+    "longitude": -73.6922
+  },
+  "Adventure River": {
+    "latitude": 43.350319,
+    "longitude": -73.685219
+  },
+  "Alice in Wonderland": {
+    "latitude": 43.350386,
+    "longitude": -73.688909
+  },
+  "Balloon Race": {
+    "latitude": 43.350258,
+    "longitude": -73.687714
+  },
+  "Bamboo Shoots": {
+    "latitude": 43.350548,
+    "longitude": -73.685257
+  },
+  "Big Kahuna": {
+    "latitude": 43.349846,
+    "longitude": -73.685913
+  },
+  "Blizzard": {
+    "latitude": 43.349606,
+    "longitude": -73.689003
+  },
+  "Bonzai Pipelines": {
+    "latitude": 43.3521,
+    "longitude": -73.68663
+  },
+  "Buccaneer Beach": {
+    "latitude": 43.350319,
+    "longitude": -73.686127
+  },
+  "Bucket Blasters": {
+    "latitude": 43.350544,
+    "longitude": -73.68705
+  },
+  "Cannonball Express": {
+    "latitude": 43.350029,
+    "longitude": -73.688118
+  },
+  "Canyon Blaster": {
+    "latitude": 43.351715,
+    "longitude": -73.691521
+  },
+  "Comet": {
+    "latitude": 43.351292,
+    "longitude": -73.685181
+  },
+  "Condor": {
+    "latitude": 43.351231,
+    "longitude": -73.691711
+  },
+  "Convoy": {
+    "latitude": 43.350067,
+    "longitude": -73.687897
+  },
+  "Dare Devil Dive": {
+    "latitude": 43.350224,
+    "longitude": -73.6875
+  },
+  "Desperado Plunge": {
+    "latitude": 43.351704,
+    "longitude": -73.692108
+  },
+  "Extreme Supernova": {
+    "latitude": 43.35128,
+    "longitude": -73.685402
+  },
+  "Flashback": {
+    "latitude": 43.349335,
+    "longitude": -73.690643
+  },
+  "Frankie’s Mine Train": {
+    "latitude": 43.350842,
+    "longitude": -73.689476
+  },
+  "Grand Carousel": {
+    "latitude": 43.350346,
+    "longitude": -73.690498
+  },
+  "Greezed Lightnin'": {
+    "latitude": 43.349541,
+    "longitude": -73.691002
+  },
+  "Hootie’s Treehouse": {
+    "latitude": 43.350571,
+    "longitude": -73.689629
+  },
+  "Hurricane Bay": {
+    "latitude": 43.351601,
+    "longitude": -73.686852
+  },
+  "Island Air Adventures": {
+    "latitude": 43.350269,
+    "longitude": -73.68718
+  },
+  "Marshal's Stampede Indoor Bumper Cars": {
+    "latitude": 43.351524,
+    "longitude": -73.691757
+  },
+  "Oakley’s Honey Swings": {
+    "latitude": 43.350632,
+    "longitude": -73.689514
+  },
+  "Olympiad Grand Prix Go-Karts": {
+    "latitude": 43.351265,
+    "longitude": -73.686913
+  },
+  "Pandemonium": {
+    "latitude": 43.350143,
+    "longitude": -73.689026
+  },
+  "Paradise Plunge": {
+    "latitude": 43.352093,
+    "longitude": -73.686569
+  },
+  "Raging River": {
+    "latitude": 43.350983,
+    "longitude": -73.688278
+  },
+  "Ranger Randy's Scenic Railway": {
+    "latitude": 43.350814,
+    "longitude": -73.689949
+  },
+  "Sasquatch Drop": {
+    "latitude": 43.349949,
+    "longitude": -73.691711
+  },
+  "Sasquatch Launch": {
+    "latitude": 43.349949,
+    "longitude": -73.691711
+  },
+  "Screamin' Eagles": {
+    "latitude": 43.350365,
+    "longitude": -73.688957
+  },
+  "Sheldon's Speedway": {
+    "latitude": 43.3507,
+    "longitude": -73.689903
+  },
+  "Shipwreck Cove": {
+    "latitude": 43.350341,
+    "longitude": -73.686848
+  },
+  "Sky Ride": {
+    "latitude": 43.34959,
+    "longitude": -73.689392
+  },
+  "Splashwater Island": {
+    "latitude": 43.351521,
+    "longitude": -73.686295
+  },
+  "Spruce’s Wilderness Bus Tours": {
+    "latitude": 43.35041,
+    "longitude": -73.689613
+  },
+  "Steamin’ Demon": {
+    "latitude": 43.351448,
+    "longitude": -73.692322
+  },
+  "Storytown Houses": {
+    "latitude": 43.350007,
+    "longitude": -73.690722
+  },
+  "Storytown Train": {
+    "latitude": 43.349583,
+    "longitude": -73.690193
+  },
+  "Swan Boats": {
+    "latitude": 43.349876,
+    "longitude": -73.691544
+  },
+  "The Bobcat": {
+    "latitude": 43.35051,
+    "longitude": -73.687912
+  },
+  "Thunder Alley": {
+    "latitude": 43.349487,
+    "longitude": -73.691208
+  },
+  "Tornado": {
+    "latitude": 43.350281,
+    "longitude": -73.685402
+  },
+  "Typhoon Twister": {
+    "latitude": 43.350648,
+    "longitude": -73.686055
+  },
+  "Wahoo Racer": {
+    "latitude": 43.352058,
+    "longitude": -73.68647
+  }
+}

--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -171,9 +171,9 @@ const PARKS_WITHOUT_WAIT_TIMES = new Set([942, 944, 947, 948, 959]);
  * - 6   / WF:   Worlds of Fun         → enchantedparks/worldsoffun
  * - 12  / MA:   Michigan's Adventure  → enchantedparks/michigansadventure
  * - 14  / VF:   Valleyfair            → enchantedparks/valleyfair
- * - 27  / GV:   Schlitterbahn Galv.   → no source yet (subdomain not live)
+ * - 27  / GV:   Schlitterbahn Galv.   → enchantedparks/galvestonislandwaterpark
  * - 903 / SFSL: Six Flags St. Louis   → enchantedparks/midamericaparks
- * - 924 / SFGE: Six Flags Great Esc.  → no source yet (subdomain not live)
+ * - 924 / SFGE: Six Flags Great Esc.  → enchantedparks/greatescapeparks
  * - 969 / SFLR: La Ronde              → no primary source distinct from
  *                                       the Six Flags app; Premier Parks
  *                                       has no shared guest-experience


### PR DESCRIPTION
## Summary

The remaining two divested-park subdomains went live:

- **`greatescapeparks.enchantedparks.com`** — former Six Flags Great Escape (parkId 924). Dual-park destination (theme park + Hurricane Harbor water park), mirroring the WoF / Mid-America pattern.
- **`galvestonislandwaterpark.enchantedparks.com`** — former Schlitterbahn Galveston (parkId 27). Water-park-only — upstream exposes a single `/rides-and-experiences/attractions/` list under the "Waterpark Hours" schedule category with no separate theme-park surface, so we register it as `waterPark` only (`themePark` left undefined).

Updates the SixFlags `EXCLUDED_PARK_IDS` comment block to point parkIds 27 and 924 at their new modules. This completes the EP coverage for the six EPR-divested parks — only La Ronde (969) remains without a primary source distinct from the Six Flags app.

## Verification

| Park | Attractions | Schedule days | Notes |
|---|---|---|---|
| Great Escape Parks | 49 | 154 | Dual-park, locations missing on all 49 |
| Galveston Island Waterpark | 21 | 63 | Water-only, locations missing on all 21 |

Locations gap will be addressed in a follow-up via static JSON snapshots, same as WoF / MA / Mid-America.

## Post-merge ops

1. Bump parksapi in the collector
2. Set `GREATESCAPEPARKS_SUBDOMAIN=https://greatescapeparks.enchantedparks.com` and `GALVESTONISLANDWATERPARK_SUBDOMAIN=https://galvestonislandwaterpark.enchantedparks.com`
3. Rename wiki destination + park externalIds (LiveData for both was already purged in the previous round)
4. Run migration tool for attraction-level remappings

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 1225/1225 pass (4 new regression tests across the two new classes)
- [x] Live harness runs against both subdomains — entities + schedules confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)