### PR TITLE
feat(enchantedparks): bundle attraction locations for Mid-America Parks

### DIFF
--- a/src/parks/enchantedparks/locations/midamericaparks.json
+++ b/src/parks/enchantedparks/locations/midamericaparks.json
@@ -1,0 +1,170 @@
+{
+  "Adventure Cove": {
+    "latitude": 38.51201,
+    "longitude": -90.672694
+  },
+  "American Thunder": {
+    "latitude": 38.513214,
+    "longitude": -90.676857
+  },
+  "BATMAN™: The Ride": {
+    "latitude": 38.5137,
+    "longitude": -90.674035
+  },
+  "Big Kahuna": {
+    "latitude": 38.51304,
+    "longitude": -90.672013
+  },
+  "Boomerang": {
+    "latitude": 38.516319,
+    "longitude": -90.675162
+  },
+  "Bugs Bunny Fort Fun": {
+    "latitude": 38.516005,
+    "longitude": -90.676348
+  },
+  "Bugs Bunny Ranger Pilots": {
+    "latitude": 38.515935,
+    "longitude": -90.67598
+  },
+  "CATWOMAN™ Whip": {
+    "latitude": 38.516798,
+    "longitude": -90.675671
+  },
+  "Colossus": {
+    "latitude": 38.514666,
+    "longitude": -90.676175
+  },
+  "Daffy Duck Stars on Parade": {
+    "latitude": 38.516228,
+    "longitude": -90.675647
+  },
+  "Elmer Fudd Weather Balloons": {
+    "latitude": 38.51591,
+    "longitude": -90.675895
+  },
+  "Fireball": {
+    "latitude": 38.516206,
+    "longitude": -90.675062
+  },
+  "Foghorn Leghorn National Park Railway": {
+    "latitude": 38.516088,
+    "longitude": -90.67616
+  },
+  "Grand Ole Carousel": {
+    "latitude": 38.516029,
+    "longitude": -90.677191
+  },
+  "Gulley Washer Creek": {
+    "latitude": 38.512322,
+    "longitude": -90.672
+  },
+  "Hurricane Bay": {
+    "latitude": 38.512192,
+    "longitude": -90.673637
+  },
+  "JUSTICE LEAGUE™": {
+    "latitude": 38.513974,
+    "longitude": -90.676861
+  },
+  "JUSTICE LEAGUE™: Battle for METROPOLIS": {
+    "latitude": 38.513974,
+    "longitude": -90.676861
+  },
+  "Log Flume": {
+    "latitude": 38.513397,
+    "longitude": -90.677093
+  },
+  "MR. FREEZE™: Reverse Blast": {
+    "latitude": 38.514287,
+    "longitude": -90.67689
+  },
+  "Marvin the Martian Camp Invasion": {
+    "latitude": 38.516284,
+    "longitude": -90.6756
+  },
+  "Ninja": {
+    "latitude": 38.514408,
+    "longitude": -90.673478
+  },
+  "Pandemonium": {
+    "latitude": 38.515564,
+    "longitude": -90.676775
+  },
+  "River King Mine Train": {
+    "latitude": 38.515758,
+    "longitude": -90.675056
+  },
+  "Rookie Racer": {
+    "latitude": 38.516026,
+    "longitude": -90.678012
+  },
+  "SHAZAM!™": {
+    "latitude": 38.513919,
+    "longitude": -90.677409
+  },
+  "SUPERGIRL™ Sky Flyer": {
+    "latitude": 38.515867,
+    "longitude": -90.677485
+  },
+  "Screamin’ Eagle": {
+    "latitude": 38.516963,
+    "longitude": -90.675968
+  },
+  "SkyScreamer": {
+    "latitude": 38.516042,
+    "longitude": -90.674626
+  },
+  "Spinsanity": {
+    "latitude": 38.514678,
+    "longitude": -90.674579
+  },
+  "THE JOKER™: Carnival of Chaos": {
+    "latitude": 38.515899,
+    "longitude": -90.677936
+  },
+  "Taz Twisters": {
+    "latitude": 38.515886,
+    "longitude": -90.676026
+  },
+  "The Boss": {
+    "latitude": 38.516073,
+    "longitude": -90.677575
+  },
+  "The Buccaneer": {
+    "latitude": 38.514137,
+    "longitude": -90.673248
+  },
+  "Thunder River": {
+    "latitude": 38.514951,
+    "longitude": -90.676509
+  },
+  "Tommy G. Robertson Railroad": {
+    "latitude": 38.514919,
+    "longitude": -90.675552
+  },
+  "Tornado": {
+    "latitude": 38.511698,
+    "longitude": -90.67199
+  },
+  "Tube Slides": {
+    "latitude": 38.513053,
+    "longitude": -90.672119
+  },
+  "Tweety Twee House": {
+    "latitude": 38.516629,
+    "longitude": -90.675864
+  },
+  "Typhoon Twister": {
+    "latitude": 38.511759,
+    "longitude": -90.671837
+  },
+  "Wahoo Racer": {
+    "latitude": 38.511994,
+    "longitude": -90.671549
+  },
+  "Yosemite Sam Tugboat Tailspin": {
+    "latitude": 38.515972,
+    "longitude": -90.676255
+  }
+}

--- a/src/parks/enchantedparks/midamericaparks.ts
+++ b/src/parks/enchantedparks/midamericaparks.ts
@@ -1,6 +1,7 @@
 import {EnchantedParks} from './enchantedparks.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {DestinationConstructor} from '../../destination.js';
+import locations from './locations/midamericaparks.json' with {type: 'json'};
 
 @destinationController({category: ['Enchanted Parks', 'Mid-America Parks']})
 export class MidAmericaParks extends EnchantedParks {
@@ -14,6 +15,7 @@ export class MidAmericaParks extends EnchantedParks {
         ...(options?.config ?? {}),
       },
     });
+    this.attractionLocations = locations;
     this.destinationLocation ??= {latitude: 38.5128, longitude: -90.6724};
     this.themePark ??= {
       id: 'enchantedparks_park_MAP',


### PR DESCRIPTION
## Summary

Final missing snapshot for the EPR-divested EP destinations — closes out the same "delete location" churn risk that bundled snapshots resolved for WoF, MA, Great Escape, and Galveston.

Snapshot taken from the wiki post-migration: all 41 attractions had locations carried over from the SFSL data, so no manual hand-coordinating needed. One entry needs an alias:

- WP scraper emits `JUSTICE LEAGUE™`
- Wiki has the longer `JUSTICE LEAGUE™: Battle for METROPOLIS`

Added the shorter name as a second key pointing at the same coordinates so the lookup hits without changing the base-class matcher.

## Verification

```
Testing: Mid America Parks
   ✓ Found 44 entities  (DEST + 2 PARK + 41 ATTRACTION)
   ✓ Found 0 live data entries
   ✓ Found 2 schedule(s) with 129 total days
```

No "Missing location" warnings. All 41/41 attractions resolve via the existing `attractionLocations` / `lookupAttractionLocation()` machinery.

Full vitest suite 1225/1225 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)