### PR TITLE
fix(europapark): roll post-midnight closing time to the next day

### DIFF
--- a/src/parks/europapark/__tests__/europapark.test.ts
+++ b/src/parks/europapark/__tests__/europapark.test.ts
@@ -6,6 +6,174 @@
  */
 import {describe, test, expect} from 'vitest';
 import {EuropaPark} from '../europapark.js';
+import {addDays, formatInTimezone} from '../../../datetime.js';
+
+const TZ = 'Europe/Berlin';
+
+/** Date offset from now as a YYYY-MM-DD string in the park timezone. */
+const isoDay = (offsetDays: number): string => {
+  const [mm, dd, yyyy] = formatInTimezone(addDays(new Date(), offsetDays), TZ, 'date').split('/');
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+/**
+ * Subclass that stubs the two network-backed getters so buildSchedules() can be
+ * exercised offline. buildSchedules() is protected; expose it for assertions.
+ */
+class ScheduleProbe extends EuropaPark {
+  private readonly _seasons: any[];
+  private readonly _live: any;
+  constructor(seasons: any[], live: any = {}) {
+    super();
+    this._seasons = seasons;
+    this._live = live;
+  }
+  override async getSeasons(): Promise<any> {
+    return this._seasons;
+  }
+  override async getLiveCalendar(): Promise<any> {
+    return this._live;
+  }
+  public schedules(): Promise<any[]> {
+    return this.buildSchedules();
+  }
+  /** Find the OPERATING entry for a given date in the main Europa-Park schedule. */
+  async operatingEntry(date: string): Promise<any> {
+    const scheds = await this.schedules();
+    const main = scheds.find((s) => s.id === 'park_493');
+    return main?.schedule.find((e: any) => e.date === date && e.type === 'OPERATING');
+  }
+}
+
+describe('Europa-Park schedule: post-midnight closing time', () => {
+  test('special-day 00:00 close (Sommernächte) rolls to the next calendar day', async () => {
+    const special = isoDay(30);
+    const next = isoDay(31);
+    const probe = new ScheduleProbe([
+      {
+        startAt: `${isoDay(-10)}T09:00:00+02:00`,
+        endAt: `${isoDay(60)}T18:00:00+02:00`,
+        scopes: ['europapark'],
+        status: 'live',
+        closed: false,
+        specialOpenTimes: [
+          {
+            dateAt: `${special}T00:00:00+02:00`,
+            startAt: `${special}T09:00:00+02:00`,
+            endAt: `${special}T00:00:00+02:00`, // closing BEFORE opening in upstream feed
+          },
+        ],
+      },
+    ]);
+
+    const entry = await probe.operatingEntry(special);
+    expect(entry).toBeDefined();
+    expect(entry.openingTime.startsWith(`${special}T09:00`)).toBe(true);
+    // Closing rolled forward to 00:00 of the following day.
+    expect(entry.closingTime.startsWith(`${next}T00:00`)).toBe(true);
+    // Core invariant: the operating window is positive.
+    expect(new Date(entry.closingTime).getTime()).toBeGreaterThan(
+      new Date(entry.openingTime).getTime(),
+    );
+  });
+
+  test('regular-day 00:00 close also rolls forward (both branches covered)', async () => {
+    const regular = isoDay(5);
+    const next = isoDay(6);
+    const probe = new ScheduleProbe([
+      {
+        startAt: `${isoDay(-10)}T10:00:00+02:00`,
+        endAt: `${isoDay(60)}T00:00:00+02:00`, // daily close component = midnight
+        scopes: ['europapark'],
+        status: 'live',
+        closed: false,
+      },
+    ]);
+
+    const entry = await probe.operatingEntry(regular);
+    expect(entry).toBeDefined();
+    expect(entry.closingTime.startsWith(`${next}T00:00`)).toBe(true);
+    expect(new Date(entry.closingTime).getTime()).toBeGreaterThan(
+      new Date(entry.openingTime).getTime(),
+    );
+  });
+
+  test('normal 18:00 close is left unchanged (no regression)', async () => {
+    const regular = isoDay(5);
+    const probe = new ScheduleProbe([
+      {
+        startAt: `${isoDay(-10)}T09:00:00+02:00`,
+        endAt: `${isoDay(60)}T18:00:00+02:00`,
+        scopes: ['europapark'],
+        status: 'live',
+        closed: false,
+      },
+    ]);
+
+    const entry = await probe.operatingEntry(regular);
+    expect(entry).toBeDefined();
+    expect(entry.closingTime.startsWith(`${regular}T18:00`)).toBe(true);
+    expect(entry.closingTime.substring(0, 10)).toBe(regular); // not rolled
+  });
+
+  test('special day with startAt set but endAt null does not crash (regression)', async () => {
+    // The seasons type allows endAt === null independently of startAt. Such an
+    // entry reaches the roll helper with a null closingTime; it must pass through
+    // untouched rather than throw on substring().
+    const special = isoDay(20);
+    const probe = new ScheduleProbe([
+      {
+        startAt: `${isoDay(-10)}T09:00:00+02:00`,
+        endAt: `${isoDay(60)}T18:00:00+02:00`,
+        scopes: ['europapark'],
+        status: 'live',
+        closed: false,
+        specialOpenTimes: [
+          {
+            dateAt: `${special}T00:00:00+02:00`,
+            startAt: `${special}T09:00:00+02:00`,
+            endAt: null,
+          },
+        ],
+      },
+    ]);
+
+    await expect(probe.schedules()).resolves.toBeDefined();
+    const entry = await probe.operatingEntry(special);
+    expect(entry).toBeDefined();
+    expect(entry.closingTime).toBeNull(); // preserved, not rolled, not crashed
+  });
+
+  test('live "today" overlay with a 00:00 end rolls forward too', async () => {
+    const today = isoDay(0);
+    const next = isoDay(1);
+    const probe = new ScheduleProbe(
+      [
+        {
+          startAt: `${isoDay(-10)}T09:00:00+02:00`,
+          endAt: `${isoDay(60)}T18:00:00+02:00`,
+          scopes: ['europapark'],
+          status: 'live',
+          closed: false,
+        },
+      ],
+      {
+        today: {
+          date: `${today}T00:00:00+02:00`,
+          start: `${today}T09:00:00+02:00`,
+          end: `${today}T00:00:00+02:00`, // live feed reports midnight close
+        },
+      },
+    );
+
+    const entry = await probe.operatingEntry(today);
+    expect(entry).toBeDefined();
+    expect(entry.closingTime.startsWith(`${next}T00:00`)).toBe(true);
+    expect(new Date(entry.closingTime).getTime()).toBeGreaterThan(
+      new Date(entry.openingTime).getTime(),
+    );
+  });
+});
 
 const mkWait = (code: number, time = 0) => ({code, time});
 const mkAttraction = (id: number, code: number) =>

--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -878,6 +878,11 @@ class EuropaParkBase extends Destination {
           closingTime = this._applyDateToTime(season.endAt, isoDate);
         }
 
+        // A closing time at/before the opening (typically a 00:00 close on a
+        // past-midnight event day) belongs to the following calendar day.
+        // Covers both the special-day and the regular branch above.
+        closingTime = this._rollClosingPastMidnight(openingTime, closingTime);
+
         times.push({date: isoDate, openingTime, closingTime, type: 'OPERATING'});
 
         // Hotel extra hours
@@ -914,7 +919,12 @@ class EuropaParkBase extends Destination {
           const entry = times.find((t) => t.date === date && t.type === 'OPERATING');
           if (entry) {
             entry.openingTime = liveData.today.start;
-            entry.closingTime = liveData.today.end;
+            // Live "today" overlay can also report a 00:00 close on past-midnight
+            // event days — apply the same next-day roll as the seasons branch.
+            entry.closingTime = this._rollClosingPastMidnight(
+              liveData.today.start,
+              liveData.today.end,
+            );
           }
         }
       }
@@ -972,6 +982,39 @@ class EuropaParkBase extends Destination {
     const match = datetimeStr.match(/T(\d{2}:\d{2}(?::\d{2})?)/);
     const timePart = match ? match[1] : '00:00:00';
     return constructDateTime(targetDate, timePart, TIMEZONE);
+  }
+
+  /**
+   * Europa-Park reports a 00:00 closing time on the SAME calendar day for days
+   * that run past midnight (the "Sommernächte" summer-night events): the
+   * upstream seasons feed carries `endAt` at 00:00 of the opening day, which is
+   * *before* `startAt` and yields a negative operating window. A midnight close
+   * belongs to the END of the operating day, so when the resolved closing time
+   * is not strictly after the opening time we roll it onto the following
+   * calendar day. Invalid/unparseable inputs are returned unchanged so this is
+   * a safe no-op for the normal same-day case.
+   */
+  private _rollClosingPastMidnight(openingTime: string, closingTime: string): string {
+    // A special day may carry endAt === null (startAt set, endAt null) — the `!`
+    // at the call site is compile-time only, so closingTime can be null here.
+    // Pass non-string values through untouched (new Date(null) is epoch 0, which
+    // is finite, so the check below would not catch it and the substring would
+    // throw). This preserves the original behaviour of emitting a null close.
+    if (typeof openingTime !== 'string' || typeof closingTime !== 'string') {
+      return closingTime;
+    }
+    const close = new Date(closingTime).getTime();
+    const open = new Date(openingTime).getTime();
+    if (!Number.isFinite(close) || !Number.isFinite(open) || close > open) {
+      return closingTime;
+    }
+    // Re-stamp the closing wall-clock time on the day after its current date.
+    // Date-only arithmetic in UTC keeps a DST transition from shifting the day
+    // boundary; _applyDateToTime re-derives the correct offset for the new day.
+    const closingDate = new Date(`${closingTime.substring(0, 10)}T00:00:00Z`);
+    closingDate.setUTCDate(closingDate.getUTCDate() + 1);
+    const nextDay = closingDate.toISOString().substring(0, 10);
+    return this._applyDateToTime(closingTime, nextDay);
   }
 }
 


### PR DESCRIPTION
## Summary

Europa-Park's "Sommernächte" summer-night events keep the park open past
midnight. On those days the public `/schedule` output contained an `OPERATING`
entry whose `closingTime` was dated to 00:00 of the **same** calendar day
instead of 00:00 of the **next** day — so the close landed *before* the open
and the operating window was negative.

## Root cause

The schedule is built from the EP `seasons` endpoint. For past-midnight event
days the upstream `specialOpenTimes` entry already reports the close on the same
day at 00:00:

```jsonc
// GET /api/v2/seasons -> seasons[id=45].specialOpenTimes[dateAt=2026-07-18]
{
  "dateAt":  "2026-07-18T00:00:00+02:00",
  "startAt": "2026-07-18T09:00:00+02:00",
  "endAt":   "2026-07-18T00:00:00+02:00"   // closing, BEFORE startAt
}
```

`_buildScheduleForPark` passed `endAt` through unchanged, producing a
`closingTime` of `2026-07-18T00:00:00+02:00`. Confirmed still present upstream
on 2026-06-19 (two days report `endAt <= startAt`: 2026-07-18 and 2026-02-07).

## Fix

New helper `_rollClosingPastMidnight(openingTime, closingTime)`: when the
resolved close is not strictly after the open, re-stamp the closing wall-clock
time onto the following calendar day. Applied in the special-day branch, the
regular branch (one shared call before the `OPERATING` push), and the live
"today" overlay.

- **DST-safe** — date-only arithmetic in UTC; `constructDateTime` re-derives the
  correct Europe/Berlin offset for the rolled day.
- **No-op for normal days** — a normal close (close > open) is returned unchanged.
- **Null-safe** — `special.endAt` may be `null`; non-string closes pass through
  untouched rather than crashing.

After the fix, 2026-07-18 → `closingTime: 2026-07-19T00:00:00+02:00` (verified
against the live API).

## Testing

- 5 new unit tests (special/regular midnight roll, normal close unchanged,
  null-`endAt` no-crash, live overlay). EP test file: 14/14 pass.
- Full suite green except one unrelated pre-existing Windows-only failure in
  `cache.test.ts` (hardcoded `/tmp/` path).
- `npm run dev -- europapark`: 4/4 green; targeted real-data check confirms the
  corrected window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)