### PR TITLE
fix(europapark): map live time-code 888 (queueing stopped) to Virtual Line FINISHED

### DIFF
--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -682,7 +682,9 @@ class EuropaParkBase extends Destination {
       let state: 'AVAILABLE' | 'TEMP_FULL' | 'FINISHED' = 'AVAILABLE';
       if (wait.time === 666) {
         state = 'TEMP_FULL';
-      } else if (wait.time === 777) {
+      } else if (wait.time === 777 || wait.time === 888) {
+        // 777 = Virtual Line ended; 888 = queueing stopped (no longer admitting
+        // guests). Both mean the Virtual Line no longer hands out return times.
         state = 'FINISHED';
       }
 


### PR DESCRIPTION
## Summary

The Europa-Park provider reads live queue states from the EP waiting-times API, which encodes special states as numeric sentinels in the `time` field. Code **`888` ("queueing stopped" — the Virtual Line no longer admits guests)** was not handled anywhere, so the Virtual-Line companion's return-time state stayed at the default `AVAILABLE` and the ride wrongly read as having an open Virtual Line.

It was not shown as an 888-minute wait — the standby guard `wait.time <= 91 ? wait.time : undefined` discards the sentinel as a wait value. The result was just a silently-wrong VQ state.

## Root cause

`buildLiveData` maps Virtual-Line sentinels in pass 1:

```ts
if (wait.time === 666) {
  state = 'TEMP_FULL';
} else if (wait.time === 777) {   // Virtual Line ended
  state = 'FINISHED';
}
// 888 fell through → state stayed 'AVAILABLE'
```

## Fix

Map `888` to `FINISHED` alongside the existing `777`, since both mean the Virtual Line no longer hands out return times:

```ts
} else if (wait.time === 777 || wait.time === 888) {
  // 777 = Virtual Line ended; 888 = queueing stopped (no longer admitting
  // guests). Both mean the Virtual Line no longer hands out return times.
  state = 'FINISHED';
}
```

## Verification (live API, 2026-06-19)

**Where the "888 = queueing stopped" mapping comes from:** the EP poi-group master data carries a `closingCode` field, and the POI that reports `time: 888` in waiting-times carries `closingCode: "888"` together with `queueingStopped: true`. So the sentinel's meaning is the API's own, not inferred.

Confirmed live:

| Code | Name | queueing | queueingStopped | queueingStoppedAt | closingCode |
|------|------|----------|-----------------|-------------------|-------------|
| 5005 | VirtualLine: Pirates in Batavia | `true` | `true` | `2026-06-17T14:39:21+02:00` | `"888"` |
| 550  | Pirates in Batavia (Standby) | `false` | `false` | `null` | `null` |

- 132 wait entries, exactly **one** with `time === 888` → code `5005`.
- `queueingStoppedAt` (`2026-06-17T14:39:21`) lines up with the waiting-times feed flipping `5005` to `888` — a reliable "stopped since" timestamp.
- The ride with `vQueue.code === 5005` is `Pirates in Batavia` (standby code `550`). After the fix its live `RETURN_TIME` state is **`FINISHED`**, while its standby queue stays **`OPERATING`** with its real wait time — the regular queue is correctly left untouched (`550` master data: `queueing: false`, `closingCode: null`).

Existing unit tests (`_isWaitsGlitch`) still pass; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)