### PR TITLE
fix(europapark): fall back to analyticsName for empty-name shows

### DIFF
--- a/src/parks/europapark/__tests__/europapark.test.ts
+++ b/src/parks/europapark/__tests__/europapark.test.ts
@@ -269,3 +269,56 @@ describe('_isWaitsGlitch', () => {
     expect(probe.probe(waits, entities)).toBe(true);
   });
 });
+
+// ── Show name resolution ────────────────────────────────────────────────────
+// Some upstream shows (e.g. Rulantica show 133 "TALENT ACADEMY on Stage")
+// arrive with an empty public `name` while the title sits in `analyticsName`.
+// Without a fallback they are dropped by the `if (!name) return` guard and
+// never reach the entity list / moderation queue.
+class EntityProbe extends EuropaPark {
+  private readonly _pois: any[];
+  constructor(pois: any[]) {
+    super();
+    this._pois = pois;
+  }
+  override async getPOIs(): Promise<any> {
+    return this._pois;
+  }
+}
+
+describe('getParkEntities show name fallback', () => {
+  const pois = [
+    {
+      id: 747,
+      type: 'showlocation',
+      name: 'Stage at Skip Strand',
+      scopes: ['rulantica'],
+      latitude: 48.26,
+      longitude: 7.74,
+      shows: [
+        {id: 133, name: '', analyticsName: 'TALENT ACADEMY on Stage'},
+        {id: 134, name: 'The secret of the vikings', analyticsName: 'internal label'},
+        {id: 135, name: '', analyticsName: ''},
+      ],
+    },
+  ];
+
+  test('falls back to analyticsName when a show has an empty name', async () => {
+    const entities = await new EntityProbe(pois).getParkEntities();
+    const show133 = entities.find((e) => e.id === 'shows_133');
+    expect(show133).toBeDefined();
+    expect(show133!.name).toBe('TALENT ACADEMY on Stage');
+    expect(show133!.entityType).toBe('SHOW');
+  });
+
+  test('keeps the public name when one is present', async () => {
+    const entities = await new EntityProbe(pois).getParkEntities();
+    const show134 = entities.find((e) => e.id === 'shows_134');
+    expect(show134!.name).toBe('The secret of the vikings');
+  });
+
+  test('still skips a show with neither name nor analyticsName', async () => {
+    const entities = await new EntityProbe(pois).getParkEntities();
+    expect(entities.find((e) => e.id === 'shows_135')).toBeUndefined();
+  });
+});

--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -19,6 +19,9 @@ import {TagBuilder} from '../../tags/index.js';
 type EuropaParkPOI = {
   id: number;
   name: string;
+  // Internal label; sometimes the only place a not-yet-published show's title
+  // lives while its public `name` is still empty (e.g. Rulantica show 133).
+  analyticsName?: string;
   type: string;
   subtype?: string;
   queueing?: boolean;
@@ -38,6 +41,7 @@ type EuropaParkPOI = {
 type EuropaParkShow = {
   id: number;
   name: string;
+  analyticsName?: string;
   duration?: number;
   code?: number;
   latitude?: number;
@@ -351,7 +355,11 @@ class EuropaParkBase extends Destination {
     const entities: EuropaParkEntity[] = [];
 
     const addPoiData = (poi: EuropaParkPOI & {entityType?: string}): void => {
-      if (!poi.name) return;
+      // Some shows (e.g. Rulantica 133 "TALENT ACADEMY on Stage") publish an
+      // empty public `name` with the title only in `analyticsName`. Fall back
+      // to it so the entity still surfaces; skip only when both are empty.
+      const name = poi.name || poi.analyticsName;
+      if (!name) return;
 
       const poiEntityTypes = ['attraction', 'showlocation', 'shows', 'pois'];
       const entityType = poi.entityType ?? poi.type;
@@ -380,7 +388,7 @@ class EuropaParkBase extends Destination {
       if (poi.queueing) return;
 
       // Skip queue map pointers
-      if (poi.name.indexOf('Queue - ') === 0) return;
+      if (name.indexOf('Queue - ') === 0) return;
 
       // Map old vs new entity type strings to id prefix
       let idPrefix: string;
@@ -396,14 +404,14 @@ class EuropaParkBase extends Destination {
         (entityType === 'shows' || entityType === 'showlocation') ? 'SHOW' : 'ATTRACTION';
 
       // Look for a virtual-queue companion (queueing:true, name contains this ride's name)
-      const nameLower = poi.name.toLowerCase();
+      const nameLower = name.toLowerCase();
       const vQueueData = poiData.find((x) => {
         return x.queueing === true && x.name.toLowerCase().indexOf(nameLower) > 0;
       });
 
       entities.push({
         id: `${idPrefix}_${poi.id}`,
-        name: poi.name,
+        name,
         entityType: finalEntityType,
         scopes: poi.scopes || [],
         code: poi.code,


### PR DESCRIPTION
## Problem

Rulantica show **133 "TALENT ACADEMY on Stage"** wasn't reaching the collector's moderation queue. In the live `poi-group` feed it arrives with an empty public `name`; the title only exists in `analyticsName` (status `preview`).

`getParkEntities()` opens with `if (!poi.name) return`, so the show was dropped before it ever became an entity — never built, never pushed, never queued.

## Investigation

Probed the live feed (677 POIs, 102 nested shows):
- Status is **not** the gate. parksapi already ingests `preview` and `draft` shows that have a name (e.g. "TALENT ACADEMY No Borders" = preview, "Test Show" = draft). 74 live / 20 preview / 8 draft.
- Show 133 is the **only** show in the entire feed with an empty `name`. The empty name was the sole blocker.

## Fix

Resolve an effective name as `poi.name || poi.analyticsName` and skip only when **both** are empty. Used consistently for the queue-pointer check, vQueue matching, and the emitted entity name.

- Blast radius today: **1 entity** (133 → "TALENT ACADEMY on Stage", Rulantica). When Europa-Park later populates a real `name`, the entity (stable id `shows_133`) just updates its name.

## Tests

New `getParkEntities show name fallback` block:
- falls back to analyticsName when name is empty
- keeps the public name when present
- still skips when both name and analyticsName are empty

`tsc` clean, full suite **1233 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)