### PR TITLE
feat(destination): shared appwatch version fetcher

### DIFF
--- a/src/__tests__/getAppwatchVersion.test.ts
+++ b/src/__tests__/getAppwatchVersion.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for Destination.getAppwatchVersion — the shared helper that pulls
+ * the latest Play Store version string for a mobile app via the
+ * themeparks.wiki appwatch mirror. Used by parks whose APIs gate on the
+ * App-Version header so we ride the live app's version automatically.
+ */
+
+import {describe, test, expect, afterAll} from 'vitest';
+import {Destination} from '../destination.js';
+import {stopHttpQueue} from '../http.js';
+import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
+
+afterAll(() => {
+  stopHttpQueue();
+});
+
+type StubResponse = {json(): Promise<unknown>};
+
+function makeStubDestination(stub: () => Promise<StubResponse>) {
+  class StubDestination extends Destination {
+    // Override the @http-decorated fetcher with a plain stub. The outer
+    // getAppwatchVersion (which has @cache) still runs.
+    protected async fetchAppwatchVersion(_packageId: string): Promise<any> {
+      return stub();
+    }
+    async getDestinations(): Promise<Entity[]> { return []; }
+    protected async buildEntityList(): Promise<Entity[]> { return []; }
+    protected async buildLiveData(): Promise<LiveData[]> { return []; }
+    protected async buildSchedules(): Promise<EntitySchedule[]> { return []; }
+  }
+  return new StubDestination();
+}
+
+describe('Destination.getAppwatchVersion', () => {
+  test('returns the live version when appwatch responds with one', async () => {
+    const dest = makeStubDestination(async () => ({
+      json: async () => ({version: '13.8.0'}),
+    }));
+    const v = await dest.getAppwatchVersion('appwatch.test.happy', 'fallback');
+    expect(v).toBe('13.8.0');
+  });
+
+  test('returns the fallback when the response is missing the version field', async () => {
+    const dest = makeStubDestination(async () => ({
+      json: async () => ({name: 'Some App'}),
+    }));
+    const v = await dest.getAppwatchVersion('appwatch.test.missing-field', 'fallback-version');
+    expect(v).toBe('fallback-version');
+  });
+
+  test('returns the fallback when the fetcher throws', async () => {
+    const dest = makeStubDestination(async () => {
+      throw new Error('network down');
+    });
+    const v = await dest.getAppwatchVersion('appwatch.test.throws', '9.9.9');
+    expect(v).toBe('9.9.9');
+  });
+
+  test('returns the empty default fallback when none provided and appwatch fails', async () => {
+    const dest = makeStubDestination(async () => {
+      throw new Error('network down');
+    });
+    const v = await dest.getAppwatchVersion('appwatch.test.empty-fallback');
+    expect(v).toBe('');
+  });
+
+  test('caches per package id so different packages get isolated entries', async () => {
+    let callCount = 0;
+    const dest = makeStubDestination(async () => {
+      callCount += 1;
+      return {json: async () => ({version: `v${callCount}`})};
+    });
+
+    const a1 = await dest.getAppwatchVersion('appwatch.test.cache.pkgA', 'fb');
+    const a2 = await dest.getAppwatchVersion('appwatch.test.cache.pkgA', 'fb');
+    const b1 = await dest.getAppwatchVersion('appwatch.test.cache.pkgB', 'fb');
+
+    expect(a1).toBe('v1');
+    expect(a2).toBe('v1'); // cached, no second call
+    expect(b1).toBe('v2'); // different package id → new cache entry
+    expect(callCount).toBe(2);
+  });
+});

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -3,7 +3,8 @@ import {trace} from "./tracing.js";
 import {reusable} from "./promiseReuse.js";
 import {loadProxyConfig, hasProxyConfig, type ProxyConfig} from "./proxy.js";
 import {inject} from "./injector.js";
-import {type HTTPObj, HttpQueue} from "./http.js";
+import {type HTTPObj, HttpQueue, http} from "./http.js";
+import {cache} from "./cache.js";
 import {VQueueBuilder} from "./virtualQueue/builder.js";
 import {calculateReturnWindow} from "./virtualQueue/timeWindows.js";
 import {formatInTimezone} from "./datetime.js";
@@ -787,6 +788,44 @@ export abstract class Destination {
       return formatInTimezone(new Date(date), this.timezone, 'iso');
     }
     return formatInTimezone(date, this.timezone, 'iso');
+  }
+
+  /**
+   * Fetch the latest version of an app from the themeparks.wiki appwatch
+   * mirror (Play Store metadata). Used by `getAppwatchVersion()`; subclasses
+   * shouldn't call this directly.
+   */
+  @http({cacheSeconds: 60 * 60 * 12})
+  protected async fetchAppwatchVersion(packageId: string): Promise<HTTPObj> {
+    return {
+      method: 'GET',
+      url: `https://api.themeparks.wiki/appwatch/latest/${encodeURIComponent(packageId)}`,
+      options: {json: true},
+    } as HTTPObj;
+  }
+
+  /**
+   * Get the latest published version string of a mobile app, via appwatch.
+   * Returns `fallback` when appwatch is unreachable or doesn't have the
+   * version field. Cached 12h per (subclass, packageId) — invalidate the
+   * cache entry from a response-error handler if the upstream API ever
+   * starts gating on version.
+   *
+   * @example
+   * ```typescript
+   * const v = await this.getAppwatchVersion('com.example.app', this.appVersion);
+   * headers['App-Version'] = v;
+   * ```
+   */
+  @cache({ttlSeconds: 60 * 60 * 12})
+  async getAppwatchVersion(packageId: string, fallback: string = ''): Promise<string> {
+    try {
+      const resp = await this.fetchAppwatchVersion(packageId);
+      const data = await resp.json();
+      return data?.version || fallback;
+    } catch {
+      return fallback;
+    }
   }
 
   /**

--- a/src/parks/shdr/shanghaidisneyresort.ts
+++ b/src/parks/shdr/shanghaidisneyresort.ts
@@ -102,6 +102,10 @@ export class ShanghaiDisneylandResort extends Destination {
   @config
   timezone: string = 'Asia/Shanghai';
 
+  /** Fallback App-Version header. The live value is fetched from appwatch and overrides this. */
+  @config
+  appVersion: string = '';
+
   constructor(options?: DestinationConstructor) {
     super(options);
     this.addConfigPrefix('SHDR');
@@ -120,11 +124,12 @@ export class ShanghaiDisneylandResort extends Destination {
     },
   })
   async injectAPIHeaders(requestObj: HTTPObj): Promise<void> {
+    const appVersion = await this.getAppwatchVersion('com.disney.shanghaidisneyland_goo', this.appVersion);
     requestObj.headers = {
       ...requestObj.headers,
       'Accept-Language': 'en',
       'Accept': 'application/json',
-      'App-Version': '13.5.0',
+      'App-Version': appVersion,
       'Content-Type': 'application/json',
       'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 16; FP4 Build/BP4A.251205.006)',
     };

--- a/src/parks/tdr/tokyodisneyresort.ts
+++ b/src/parks/tdr/tokyodisneyresort.ts
@@ -181,7 +181,7 @@ export class TokyoDisneyResort extends Destination {
     tags: {$nin: ['deviceRegistration']},
   })
   async injectAPIHeaders(requestObj: HTTPObj): Promise<void> {
-    const appVersion = await this.getAppVersion();
+    const appVersion = await this.getAppwatchVersion('jp.tokyodisneyresort.portalapp', this.apiVersion);
     const deviceId = await this.getDeviceId();
 
     requestObj.headers = {
@@ -212,7 +212,7 @@ export class TokyoDisneyResort extends Destination {
     tags: {$in: ['deviceRegistration']},
   })
   async injectDeviceRegistrationHeaders(requestObj: HTTPObj): Promise<void> {
-    const appVersion = await this.getAppVersion();
+    const appVersion = await this.getAppwatchVersion('jp.tokyodisneyresort.portalapp', this.apiVersion);
 
     requestObj.headers = {
       ...requestObj.headers,
@@ -243,7 +243,7 @@ export class TokyoDisneyResort extends Destination {
   async handleAPIResponse(requestObj: HTTPObj): Promise<void> {
     if (requestObj.status === 400) {
       console.log('[TDR] API returned 400, clearing cached app version...');
-      CacheLib.delete('TokyoDisneyResort:getAppVersion:[]');
+      CacheLib.delete('TokyoDisneyResort:getAppwatchVersion:["jp.tokyodisneyresort.portalapp"]');
     }
 
     if (requestObj.status === 503) {
@@ -260,32 +260,6 @@ export class TokyoDisneyResort extends Destination {
   }
 
   // ===== HTTP Fetch Methods =====
-
-  /**
-   * Fetch the latest app version from appwatch API
-   */
-  @http({cacheSeconds: 60 * 60 * 12})
-  async fetchAppVersion(): Promise<HTTPObj> {
-    return {
-      method: 'GET',
-      url: 'https://api.themeparks.wiki/appwatch/latest/jp.tokyodisneyresort.portalapp',
-      options: {json: true},
-    } as HTTPObj;
-  }
-
-  /**
-   * Get the current app version (cached 12h, falls back to apiVersion config)
-   */
-  @cache({ttlSeconds: 60 * 60 * 12})
-  async getAppVersion(): Promise<string> {
-    try {
-      const resp = await this.fetchAppVersion();
-      const data = await resp.json();
-      return data?.version || this.apiVersion || '3.11.7';
-    } catch {
-      return this.apiVersion || '3.11.7';
-    }
-  }
 
   /**
    * Register a device with the TDR API


### PR DESCRIPTION
## Summary

- Extract Tokyo Disney's appwatch-based App-Version fetcher into the `Destination` base class as `getAppwatchVersion(packageId, fallback)`. Any park can now ride the live Play Store version without per-park boilerplate.
- Wire Shanghai Disney Resort to it. Disney's live app sends App-Version `13.8.0`; we were hardcoded to `13.5.0`. Not enforced today, but trivial to keep in sync now that the helper exists.
- Refactor Tokyo Disney Resort onto the shared helper. Its `400 → clear cached app version` recovery path is preserved; the cache key was updated to match the new method name.

## Ops note

The fallback chain for Shanghai is: appwatch → `SHDR_APPVERSION` env → `''`. Production collector env should add `SHDR_APPVERSION=13.8.0` so the fallback is meaningful if appwatch ever stalls. Appwatch is reachable today (returning `13.7.0`), so the live path is what's in use.

## Test plan

- [x] `npm test` — 58/58 files, 1238/1238 tests (was 57/1233 on main; +1 file, +5 new tests for the shared helper)
- [x] `npm run dev -- tokyodisneyresort` — 4/4 (live App-Version still pulled, all entity/live/schedule contracts pass)
- [x] `npm run dev -- shanghaidisneylandresort` — 3/4: 80 live entries (26 with wait times), 77 schedules / 812 days. The 4th failure is the pre-existing `ID_CHARSET` harness check that rejects Shanghai's semicolon-delimited IDs (introduced in `fec57568`, unrelated to this PR).