### PR TITLE
fix(dlp): drop "Entry to World of Frozen" from POI list

### DIFF
--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -27,13 +27,13 @@ const IGNORE_ENTITIES = new Set([
   'P2AC00-REMOVED',
   'P2AC00',
   'armageddon',
+  'P2EA02', // Entry to World of Frozen (land-entry pass, not a ride)
 ]);
 
 /** Entities that bypass visibility/hide rules */
 const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
-  'P2EA02', // Entry to World of Frozen
 ]);
 
 /** Hide rules that exclude entities from the POI list */


### PR DESCRIPTION
## Summary

- `P2EA02` (Entry to World of Frozen) is a land-entry Premier Access pass, not a ride. Move it from `VISIBILITY_EXCEPTIONS` to `IGNORE_ENTITIES` so it's dropped from entities, live data, and schedules in one pass.
- It was kept around for parity with the legacy collector during migration. That window has closed.

## Test plan

- [x] `npm test` — 58/58 files, 1246/1246 tests
- [x] `npm run dev -- disneylandparis` — 4/4. 126 entities (was 127), 67 live entries (was 68); P2EA02 dropped from all three pipelines