### PR TITLE
feat(dlp): surface 'Live Your Story' Castle Stage show

### DIFF
--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -1,0 +1,52 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES). Entities
+ * listed in VISIBILITY_EXCEPTIONS bypass that. P1GS93 ("Live Your Story") is a
+ * real Castle Stage show Disney flags "Hide from the Service", so it must be
+ * force-surfaced while other hidden shows stay filtered.
+ */
+function stubbedPark(): DisneylandParis {
+  const park = new DisneylandParis();
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Entertainment: [
+      {
+        id: 'P1GS93',
+        name: 'Live Your Story – a Disney Princess Celebration',
+        type: 'Entertainment',
+        subType: 'Stage Show',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from the Service',
+      },
+      {
+        // Control: hidden Stage Show NOT in VISIBILITY_EXCEPTIONS — must stay dropped.
+        id: 'P1G107',
+        name: 'Disney Music Hits Concert',
+        type: 'Entertainment',
+        subType: 'Stage Show',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+    ],
+  });
+  return park;
+}
+
+describe('DLP visibility exceptions', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('surfaces P1GS93 (Live Your Story) despite its "Hide from the Service" flag', async () => {
+    const entities = await stubbedPark().getEntities();
+    const lys = entities.find((e) => e.id === 'P1GS93');
+    expect(lys).toBeDefined();
+    expect(lys?.entityType).toBe('SHOW');
+    expect((lys as any)?.parkId).toBe('P1');
+  });
+
+  it('still drops other hidden shows not in the exception set', async () => {
+    const entities = await stubbedPark().getEntities();
+    expect(entities.find((e) => e.id === 'P1G107')).toBeUndefined();
+  });
+});

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -34,6 +34,7 @@ const IGNORE_ENTITIES = new Set([
 const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
+  'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
 ]);
 
 /** Hide rules that exclude entities from the POI list */


### PR DESCRIPTION
## What
Adds `P1GS93` — **Live Your Story – a Disney Princess Celebration** (Disneyland Park Castle Stage) — to `VISIBILITY_EXCEPTIONS` in `disneylandparis.ts`.

## Why
Disney flags this show `Hide from the Service`, which `HIDE_RULES` filters out, so it never reached the API despite being a real, running show. This uses the same override already applied to Frozen Ever After and Tangled Spin.

## Verification
- New offline regression test (`src/parks/dlp/__tests__/visibility.test.ts`): asserts P1GS93 surfaces as a `SHOW` under P1, and that a control hidden show (`P1G107`, not in the set) stays dropped.
- Confirmed against the live DLP API: fresh `getEntities()` now emits `P1GS93` as `SHOW` / parkId `P1`.
- Full suite: 1248 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)