### PR TITLE
feat(plopsa): add per-POI coordinates for Plopsaland De Panne

### DIFF
--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -8,7 +8,7 @@
  * disagrees between instances.
  */
 import {describe, test, expect} from 'vitest';
-import {plopsaDecideOperating} from '../plopsa.js';
+import {plopsaDecideOperating, Plopsaland} from '../plopsa.js';
 
 describe('plopsaDecideOperating', () => {
   test('park closed → ride always CLOSED regardless of other inputs', () => {
@@ -34,5 +34,46 @@ describe('plopsaDecideOperating', () => {
 
   test('park open + POI says temp-closed + no wait → CLOSED (the hint is authoritative when no live signal)', () => {
     expect(plopsaDecideOperating(true, true, false)).toBe(false);
+  });
+});
+
+describe('De Panne POI location lookup', () => {
+  // Expose the protected lookup + allow overriding the snapshot for the
+  // normalization tests, without a full destination lifecycle.
+  class Probe extends Plopsaland {
+    public withLocations(
+      m: Record<string, {latitude: number; longitude: number}>,
+    ): this {
+      (this as any).poiLocations = m;
+      (this as any).normalizedPoiLocations = undefined; // force lazy rebuild
+      return this;
+    }
+    public lookup(title: string) {
+      return (this as any).lookupPoiLocation(title) as
+        | {latitude: number; longitude: number}
+        | undefined;
+    }
+  }
+
+  test('resolves a known ride from the bundled snapshot', () => {
+    // The real snapshot is assigned in the constructor; Anubis is hand-pinned.
+    const loc = new Probe().lookup('Anubis The Ride');
+    expect(loc).toBeDefined();
+    expect(typeof loc!.latitude).toBe('number');
+    expect(typeof loc!.longitude).toBe('number');
+  });
+
+  test('folds curly/straight apostrophes and is case-insensitive', () => {
+    const p = new Probe().withLocations({
+      "Vic's Whirlwind": {latitude: 51.08, longitude: 2.59},
+    });
+    // Feed emits a curly apostrophe; snapshot key uses a straight one.
+    expect(p.lookup('Vic’s Whirlwind')).toEqual({latitude: 51.08, longitude: 2.59});
+    // Case differences still match.
+    expect(p.lookup("vic's whirlwind")).toEqual({latitude: 51.08, longitude: 2.59});
+  });
+
+  test('returns undefined for an unknown title', () => {
+    expect(new Probe().lookup('Nonexistent Ride')).toBeUndefined();
   });
 });

--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -8,6 +8,7 @@
  * disagrees between instances.
  */
 import {describe, test, expect} from 'vitest';
+import type {Entity} from '@themeparks/typelib';
 import {plopsaDecideOperating, Plopsaland} from '../plopsa.js';
 
 describe('plopsaDecideOperating', () => {
@@ -37,43 +38,99 @@ describe('plopsaDecideOperating', () => {
   });
 });
 
-describe('De Panne POI location lookup', () => {
-  // Expose the protected lookup + allow overriding the snapshot for the
-  // normalization tests, without a full destination lifecycle.
+describe('De Panne POI location wiring', () => {
+  const fallbackLocation = {latitude: 1, longitude: 2};
+
   class Probe extends Plopsaland {
-    public withLocations(
-      m: Record<string, {latitude: number; longitude: number}>,
-    ): this {
-      (this as any).poiLocations = m;
-      (this as any).normalizedPoiLocations = undefined; // force lazy rebuild
-      return this;
+    protected override mapCoordinates(
+      coords: {x: number; y: number} | undefined,
+    ): {latitude: number; longitude: number} | undefined {
+      return coords ? fallbackLocation : undefined;
     }
-    public lookup(title: string) {
-      return (this as any).lookupPoiLocation(title) as
-        | {latitude: number; longitude: number}
-        | undefined;
+
+    public buildEntitiesForTest(): Promise<Entity[]> {
+      return this.buildEntityList();
     }
   }
 
-  test('resolves a known ride from the bundled snapshot', () => {
-    // The real snapshot is assigned in the constructor; Anubis is hand-pinned.
-    const loc = new Probe().lookup('Anubis The Ride');
-    expect(loc).toBeDefined();
-    expect(typeof loc!.latitude).toBe('number');
-    expect(typeof loc!.longitude).toBe('number');
+  function jsonResponse(payload: unknown) {
+    return {json: async () => payload};
+  }
+
+  function createProbe(poiItems: unknown[]): Probe {
+    const park = new Probe();
+    park.fetchPOI = async () => jsonResponse({items: poiItems}) as any;
+    park.fetchEntertainments = async () => jsonResponse({items: []}) as any;
+    return park;
+  }
+
+  test('populates attraction location from the bundled snapshot', async () => {
+    const entities = await createProbe([{
+      id: 'poi-1',
+      title: 'Attractions',
+      type: {label: 'Attractions'},
+      map_coordinates: {x: 10, y: 20},
+      contains: [{
+        id: 'anubis',
+        title: 'Anubis The Ride',
+        type: 'attraction',
+      }],
+    }]).buildEntitiesForTest();
+
+    const anubis = entities.find((e) => e.id === 'anubis');
+    expect(anubis?.location).toEqual({latitude: 51.081837, longitude: 2.597878});
   });
 
-  test('folds curly/straight apostrophes and is case-insensitive', () => {
-    const p = new Probe().withLocations({
-      "Vic's Whirlwind": {latitude: 51.08, longitude: 2.59},
-    });
-    // Feed emits a curly apostrophe; snapshot key uses a straight one.
-    expect(p.lookup('Vic’s Whirlwind')).toEqual({latitude: 51.08, longitude: 2.59});
-    // Case differences still match.
-    expect(p.lookup("vic's whirlwind")).toEqual({latitude: 51.08, longitude: 2.59});
+  test('prefers snapshot coordinates over mapped POI coordinates', async () => {
+    const entities = await createProbe([{
+      id: 'poi-1',
+      title: 'Attractions',
+      type: {label: 'Attractions'},
+      map_coordinates: {x: 10, y: 20},
+      contains: [{
+        id: 'anubis',
+        title: 'Anubis The Ride',
+        type: 'attraction',
+      }],
+    }]).buildEntitiesForTest();
+
+    const anubis = entities.find((e) => e.id === 'anubis');
+    expect(anubis?.location).toEqual({latitude: 51.081837, longitude: 2.597878});
+    expect(anubis?.location).not.toEqual(fallbackLocation);
   });
 
-  test('returns undefined for an unknown title', () => {
-    expect(new Probe().lookup('Nonexistent Ride')).toBeUndefined();
+  test('matches snapshot titles with curly apostrophes through buildEntityList', async () => {
+    const entities = await createProbe([{
+      id: 'poi-1',
+      title: 'Attractions',
+      type: {label: 'Attractions'},
+      map_coordinates: {x: 10, y: 20},
+      contains: [{
+        id: 'vics',
+        title: 'Vic’s Whirlwind',
+        type: 'attraction',
+      }],
+    }]).buildEntitiesForTest();
+
+    const vics = entities.find((e) => e.id === 'vics');
+    expect(vics?.location).toEqual({latitude: 51.082082, longitude: 2.5958043});
+  });
+
+  test('skips POI children without a usable title', async () => {
+    const entities = await createProbe([{
+      id: 'poi-1',
+      title: 'Attractions',
+      type: {label: 'Attractions'},
+      map_coordinates: {x: 10, y: 20},
+      contains: [
+        {id: 'missing-title', type: 'attraction'},
+        {id: 'null-title', title: null, type: 'foods_and_drinks'},
+        {id: 'anubis', title: 'Anubis The Ride', type: 'attraction'},
+      ],
+    }]).buildEntitiesForTest();
+
+    expect(entities.find((e) => e.id === 'missing-title')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'null-title')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'anubis')).toBeDefined();
   });
 });

--- a/src/parks/plopsa/locations/README.md
+++ b/src/parks/plopsa/locations/README.md
@@ -1,0 +1,46 @@
+# Plopsaland De Panne — POI location snapshot
+
+`plopsaland-de-panne.json` maps each POI **title** (exactly as the middleware
+feed emits it in `contains[].title`) to a hand-verified `{latitude, longitude}`.
+
+## Why a static snapshot
+
+The Plopsa middleware feed (`/api/points-of-interest`) exposes only
+`map_coordinates` — pixel coordinates on the park-map image — not lat/lng. De
+Panne, unlike Deutschland, has no pixel→geo transform (`mapCoordinates()`
+returns `undefined`), so without this snapshot its rides and restaurants have no
+location. The base class prefers this per-title lookup and falls back to the
+pixel transform (Deutschland only).
+
+## How the coordinates were derived
+
+1. **Titles** came from the live `points-of-interest` feed (attraction +
+   `foods_and_drinks` items).
+2. **Seed coordinates** came from Google Places (New) Text Search and the Apple
+   Maps Server API, biased to the park and filtered to an in-park bounding box.
+   Only name-verified matches were trusted; generic "Plopsaland Belgium" park
+   pins were rejected.
+3. **Manual pinning** — the remaining rides (kids' rides, food stalls that no
+   API indexes precisely) were placed by hand on a satellite basemap, cross-
+   referenced against the official parkplan. The website's own marker
+   coordinates (`point_x/point_y`, authored against `PLB_Parkplan2026_0.jpg` via
+   a Leaflet `imageOverlay`) were used as a visual reference.
+
+## Coverage / maintenance
+
+- 86 of 87 POIs are located. **Merry-go-Round** is intentionally absent — it is
+  not shown on the park map.
+- Matching folds curly/straight apostrophes and is case-insensitive
+  (`lookupPoiLocation` in `../plopsa.ts`).
+- POIs Plopsa adds later will land without a location until this file is
+  refreshed. To add one, append a `"<exact feed title>": {latitude, longitude}`
+  entry.
+
+## Regenerating / refreshing the snapshot
+
+This file was produced with the **[plopsa-pinning-tool](https://github.com/TimBroddin/plopsa-pinning-tool)**
+— a three-pane tool (ride list · Apple satellite map · official parkplan
+overlay) that seeds coordinates from Google Places + Apple Maps and lets you
+place the rest by hand. Use it to refresh this snapshot for a new season or to
+add newly-opened POIs, then copy its `data/plopsaland-de-panne.json` output
+here.

--- a/src/parks/plopsa/locations/plopsaland-de-panne.json
+++ b/src/parks/plopsa/locations/plopsaland-de-panne.json
@@ -1,0 +1,346 @@
+{
+  "#LikeMe Coaster": {
+    "latitude": 51.0808942,
+    "longitude": 2.5963891
+  },
+  "Alberto's Churros": {
+    "latitude": 51.081728,
+    "longitude": 2.6004596
+  },
+  "Anubis The Ride": {
+    "latitude": 51.081837,
+    "longitude": 2.597878
+  },
+  "Aperto": {
+    "latitude": 51.0807633,
+    "longitude": 2.5986411
+  },
+  "Balloon Race": {
+    "latitude": 51.0831808,
+    "longitude": 2.597639
+  },
+  "Big's Garden": {
+    "latitude": 51.0827359,
+    "longitude": 2.600466
+  },
+  "Bistro Helena": {
+    "latitude": 51.0795142,
+    "longitude": 2.5971836
+  },
+  "Blabbermouth's Corner": {
+    "latitude": 51.0799562,
+    "longitude": 2.5981895
+  },
+  "Bumba Snack": {
+    "latitude": 51.0829933,
+    "longitude": 2.5982196
+  },
+  "Bumba's Playground": {
+    "latitude": 51.0828185,
+    "longitude": 2.5982049
+  },
+  "Bumba's World Trip": {
+    "latitude": 51.083415,
+    "longitude": 2.5981741
+  },
+  "Bumballoon": {
+    "latitude": 51.0831108,
+    "longitude": 2.5984054
+  },
+  "Bumbar": {
+    "latitude": 51.0830111,
+    "longitude": 2.5985163
+  },
+  "Chez Albert": {
+    "latitude": 51.082758,
+    "longitude": 2.5972141
+  },
+  "Cocktailbar": {
+    "latitude": 51.0813193,
+    "longitude": 2.6016722
+  },
+  "DinoSplash": {
+    "latitude": 51.0793511,
+    "longitude": 2.5972987
+  },
+  "French Fries": {
+    "latitude": 51.0817086,
+    "longitude": 2.5998156
+  },
+  "Frits & Frats": {
+    "latitude": 51.0807459,
+    "longitude": 2.5959214
+  },
+  "Frituur Mirror Tent": {
+    "latitude": 51.0830403,
+    "longitude": 2.5979818
+  },
+  "Heidi The Ride": {
+    "latitude": 51.0787293,
+    "longitude": 2.5969225
+  },
+  "Joe Bar": {
+    "latitude": 51.081416,
+    "longitude": 2.6013368
+  },
+  "K3 Roller Skater": {
+    "latitude": 51.0799555,
+    "longitude": 2.5964963
+  },
+  "K3's Kitchen": {
+    "latitude": 51.0803643,
+    "longitude": 2.5958424
+  },
+  "Maya's Restaurant (Panos)": {
+    "latitude": 51.0818882,
+    "longitude": 2.5997175
+  },
+  "Mega Mindy Jet-ski": {
+    "latitude": 51.0799237,
+    "longitude": 2.5969228
+  },
+  "Megamobiel": {
+    "latitude": 51.0797781,
+    "longitude": 2.5969691
+  },
+  "Mevrouw Praline": {
+    "latitude": 51.0829857,
+    "longitude": 2.5969389
+  },
+  "Mr. Spaghetti": {
+    "latitude": 51.0816618,
+    "longitude": 2.5996589
+  },
+  "Nachtwacht Snack": {
+    "latitude": 51.0811766,
+    "longitude": 2.595669
+  },
+  "Nachtwacht-Flyer": {
+    "latitude": 51.081275,
+    "longitude": 2.5956233
+  },
+  "Panos Halvar's Sandwich": {
+    "latitude": 51.082649,
+    "longitude": 2.5961482
+  },
+  "Pizza Hut": {
+    "latitude": 51.078813,
+    "longitude": 2.5975002
+  },
+  "Plaza Barbecue": {
+    "latitude": 51.0816009,
+    "longitude": 2.6003567
+  },
+  "Plop Hamburger Restaurant": {
+    "latitude": 51.0801684,
+    "longitude": 2.5980039
+  },
+  "Plop's Barrel": {
+    "latitude": 51.0824501,
+    "longitude": 2.5988662
+  },
+  "Plop's Garden": {
+    "latitude": 51.0800673,
+    "longitude": 2.5976521
+  },
+  "Plop's Woods": {
+    "latitude": 51.0825182,
+    "longitude": 2.5987103
+  },
+  "Plopsa Summer Bar": {
+    "latitude": 51.0808245,
+    "longitude": 2.5982704
+  },
+  "Poppa's Climbing Tower": {
+    "latitude": 51.0832057,
+    "longitude": 2.5980301
+  },
+  "Prinsessia Restaurant": {
+    "latitude": 51.0815436,
+    "longitude": 2.59633
+  },
+  "Restaurant Le Grand Buffet": {
+    "latitude": 51.0812378,
+    "longitude": 2.6011235
+  },
+  "Safari": {
+    "latitude": 51.0827932,
+    "longitude": 2.5974874
+  },
+  "Shadowmere Barbecue": {
+    "latitude": 51.0795407,
+    "longitude": 2.5975482
+  },
+  "Sibuna": {
+    "latitude": 51.0817296,
+    "longitude": 2.5974634
+  },
+  "Spirello Cottage": {
+    "latitude": 51.0792349,
+    "longitude": 2.5975728
+  },
+  "Storm At Sea": {
+    "latitude": 51.0814571,
+    "longitude": 2.5974432
+  },
+  "SuperSplash": {
+    "latitude": 51.0813228,
+    "longitude": 2.5988116
+  },
+  "The Animal Carousel": {
+    "latitude": 51.0788435,
+    "longitude": 2.5978549
+  },
+  "The Animal Farm": {
+    "latitude": 51.0827,
+    "longitude": 2.6000944
+  },
+  "The Ball Bath": {
+    "latitude": 51.0822317,
+    "longitude": 2.5998648
+  },
+  "The Big & Betsy Farm": {
+    "latitude": 51.0828926,
+    "longitude": 2.599892
+  },
+  "The Big Wave": {
+    "latitude": 51.0825959,
+    "longitude": 2.5968785
+  },
+  "The Bucket": {
+    "latitude": 51.0804142,
+    "longitude": 2.5979468
+  },
+  "The Bumper Cars": {
+    "latitude": 51.0827111,
+    "longitude": 2.5982051
+  },
+  "The Carriage": {
+    "latitude": 51.0828895,
+    "longitude": 2.6003945
+  },
+  "The Chute": {
+    "latitude": 51.0819869,
+    "longitude": 2.5994654
+  },
+  "The Climbing Tree": {
+    "latitude": 51.0821917,
+    "longitude": 2.5994676
+  },
+  "The Coffee Cups": {
+    "latitude": 51.0815786,
+    "longitude": 2.5965625
+  },
+  "The Crazy Bus": {
+    "latitude": 51.0830832,
+    "longitude": 2.5985585
+  },
+  "The Dancing Fountains": {
+    "latitude": 51.0814073,
+    "longitude": 2.5997485
+  },
+  "The Dough Roll": {
+    "latitude": 51.0788208,
+    "longitude": 2.5973843
+  },
+  "The Ducks": {
+    "latitude": 51.0800386,
+    "longitude": 2.5983763
+  },
+  "The Falling Tower": {
+    "latitude": 51.0819497,
+    "longitude": 2.6000596
+  },
+  "The Farmhouse at Big & Betsy": {
+    "latitude": 51.0828926,
+    "longitude": 2.599892
+  },
+  "The Flowery Merry-go-Round": {
+    "latitude": 51.0818178,
+    "longitude": 2.60031
+  },
+  "The Flying Bikes": {
+    "latitude": 51.0799068,
+    "longitude": 2.5972581
+  },
+  "The Frogs": {
+    "latitude": 51.0802973,
+    "longitude": 2.5975589
+  },
+  "The Pedal Boats": {
+    "latitude": 51.081302,
+    "longitude": 2.5974002
+  },
+  "The Pirate Ship": {
+    "latitude": 51.0811285,
+    "longitude": 2.5972836
+  },
+  "The Rabbits": {
+    "latitude": 51.0806299,
+    "longitude": 2.5979991
+  },
+  "The Raft": {
+    "latitude": 51.0818478,
+    "longitude": 2.600128
+  },
+  "The Ride to Happiness by Tomorrowland": {
+    "latitude": 51.0810025,
+    "longitude": 2.5987745
+  },
+  "The Spider's Web": {
+    "latitude": 51.0820491,
+    "longitude": 2.6002462
+  },
+  "The Suspension Bridge": {
+    "latitude": 51.0811015,
+    "longitude": 2.5977919
+  },
+  "The Swinging Tree": {
+    "latitude": 51.0822181,
+    "longitude": 2.6002173
+  },
+  "The Tractors": {
+    "latitude": 51.0827776,
+    "longitude": 2.599694
+  },
+  "The Traffic Park": {
+    "latitude": 51.0830922,
+    "longitude": 2.5992824
+  },
+  "The Water Lilies": {
+    "latitude": 51.0819726,
+    "longitude": 2.600274
+  },
+  "Tik Tak": {
+    "latitude": 51.0804191,
+    "longitude": 2.5961933
+  },
+  "Tumbi's Ball Pool": {
+    "latitude": 51.0832598,
+    "longitude": 2.5982713
+  },
+  "Vic's Whirlwind": {
+    "latitude": 51.082082,
+    "longitude": 2.5958043
+  },
+  "Viking Grill": {
+    "latitude": 51.0826381,
+    "longitude": 2.5955003
+  },
+  "Wickie The Battle": {
+    "latitude": 51.0823296,
+    "longitude": 2.596197
+  },
+  "Wienerwalz": {
+    "latitude": 51.0831487,
+    "longitude": 2.5972715
+  },
+  "Willy's Playground": {
+    "latitude": 51.0821831,
+    "longitude": 2.5996633
+  },
+  "Ylva's Fruit": {
+    "latitude": 51.0825059,
+    "longitude": 2.5956396
+  }
+}

--- a/src/parks/plopsa/locations/plopsaland-de-panne.json
+++ b/src/parks/plopsa/locations/plopsaland-de-panne.json
@@ -252,8 +252,8 @@
     "longitude": 2.6000596
   },
   "The Farmhouse at Big & Betsy": {
-    "latitude": 51.0828926,
-    "longitude": 2.599892
+    "latitude": 51.0830475,
+    "longitude": 2.6001153
   },
   "The Flowery Merry-go-Round": {
     "latitude": 51.0818178,

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -21,6 +21,7 @@ import {CacheLib} from '../../cache.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
 import {formatDate, addDays, formatInTimezone} from '../../datetime.js';
+import dePanneLocations from './locations/plopsaland-de-panne.json' with {type: 'json'};
 
 // ── API response types ──────────────────────────────────────────
 
@@ -286,6 +287,43 @@ class PlopsaBase extends Destination {
     return undefined;
   }
 
+  /**
+   * Optional snapshot of per-POI coordinates, keyed by POI title. The
+   * middleware feed only exposes map-image pixel coordinates (`map_coordinates`),
+   * not lat/lng, and De Panne has no pixel→geo transform (see `mapCoordinates`).
+   * De Panne therefore loads a static JSON snapshot of hand-verified ride and
+   * restaurant coordinates (see `locations/plopsaland-de-panne.json`), assigned
+   * in the subclass constructor. POIs added by Plopsa later land without
+   * coordinates until the snapshot is refreshed.
+   */
+  protected poiLocations?: Record<string, {latitude: number; longitude: number}>;
+
+  /** Lazily-built lookup for poiLocations, keyed by normalized title. */
+  private normalizedPoiLocations?: Map<string, {latitude: number; longitude: number}>;
+
+  /**
+   * Normalize POI titles for matching. The feed and the snapshot can differ in
+   * apostrophe style (’ U+2019 vs ') and case; fold both to one form.
+   */
+  private normalizePoiTitle(title: string): string {
+    return title.replace(/[‘’]/g, "'").toLowerCase();
+  }
+
+  /** Look up a hand-verified coordinate for a POI by its title, if any. */
+  protected lookupPoiLocation(
+    title: string,
+  ): {latitude: number; longitude: number} | undefined {
+    if (!this.poiLocations) return undefined;
+    if (!this.normalizedPoiLocations) {
+      this.normalizedPoiLocations = new Map(
+        Object.entries(this.poiLocations).map(
+          ([k, v]) => [this.normalizePoiTitle(k), v] as const,
+        ),
+      );
+    }
+    return this.normalizedPoiLocations.get(this.normalizePoiTitle(title));
+  }
+
   // ── Destination ───────────────────────────────────────────────
 
   async getDestinations(): Promise<Entity[]> {
@@ -327,7 +365,8 @@ class PlopsaBase extends Destination {
 
     // Attractions and restaurants from POI
     for (const poi of poiData?.items ?? []) {
-      const coords = this.mapCoordinates(poi.map_coordinates);
+      // Fallback pixel→geo coords for the whole POI (Deutschland only).
+      const poiCoords = this.mapCoordinates(poi.map_coordinates);
 
       for (const item of poi.contains ?? []) {
         if (item.type === 'attraction') {
@@ -339,6 +378,8 @@ class PlopsaBase extends Destination {
             destinationId: this.destinationId,
             timezone: this.timezone,
           } as Entity;
+          // Prefer the hand-verified per-title snapshot, then the pixel transform.
+          const coords = this.lookupPoiLocation(item.title) ?? poiCoords;
           if (coords) {
             (entity as any).location = coords;
           }
@@ -352,6 +393,7 @@ class PlopsaBase extends Destination {
             destinationId: this.destinationId,
             timezone: this.timezone,
           } as Entity;
+          const coords = this.lookupPoiLocation(item.title) ?? poiCoords;
           if (coords) {
             (entity as any).location = coords;
           }
@@ -566,6 +608,9 @@ export class Plopsaland extends PlopsaBase {
     this.timezone = 'Europe/Brussels';
     this.parkLat = 51.0808363;
     this.parkLng = 2.5957221;
+    // Hand-verified per-POI coordinates: the middleware feed has no ride-level
+    // lat/lng and De Panne has no pixel→geo transform. See locations/README.
+    this.poiLocations = dePanneLocations as Record<string, {latitude: number; longitude: number}>;
     // calendarUrl: the /en/plopsaland-de-panne/ slug redirects to /en/plopsaland-belgium/
     // so use the redirect target. Set via PLOPSALAND_CALENDARURL env var.
   }

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -28,7 +28,7 @@ import dePanneLocations from './locations/plopsaland-de-panne.json' with {type: 
 interface PlopsaContainsItem {
   id: string;
   plopsa_id?: string;
-  title: string;
+  title?: string | null;
   type: 'attraction' | 'foods_and_drinks' | 'shop' | string;
   height_specs?: {
     min_height?: number;
@@ -311,9 +311,9 @@ class PlopsaBase extends Destination {
 
   /** Look up a hand-verified coordinate for a POI by its title, if any. */
   protected lookupPoiLocation(
-    title: string,
+    title: string | null | undefined,
   ): {latitude: number; longitude: number} | undefined {
-    if (!this.poiLocations) return undefined;
+    if (!this.poiLocations || !title) return undefined;
     if (!this.normalizedPoiLocations) {
       this.normalizedPoiLocations = new Map(
         Object.entries(this.poiLocations).map(
@@ -369,17 +369,20 @@ class PlopsaBase extends Destination {
       const poiCoords = this.mapCoordinates(poi.map_coordinates);
 
       for (const item of poi.contains ?? []) {
+        const title = typeof item.title === 'string' ? item.title : '';
+        if (!title) continue;
+
         if (item.type === 'attraction') {
           const entity: Entity = {
             id: this.entityId(item),
-            name: item.title,
+            name: title,
             entityType: 'ATTRACTION',
             parentId: this.parkId,
             destinationId: this.destinationId,
             timezone: this.timezone,
           } as Entity;
           // Prefer the hand-verified per-title snapshot, then the pixel transform.
-          const coords = this.lookupPoiLocation(item.title) ?? poiCoords;
+          const coords = this.lookupPoiLocation(title) ?? poiCoords;
           if (coords) {
             (entity as any).location = coords;
           }
@@ -387,13 +390,13 @@ class PlopsaBase extends Destination {
         } else if (item.type === 'foods_and_drinks') {
           const entity: Entity = {
             id: this.entityId(item),
-            name: item.title,
+            name: title,
             entityType: 'RESTAURANT',
             parentId: this.parkId,
             destinationId: this.destinationId,
             timezone: this.timezone,
           } as Entity;
-          const coords = this.lookupPoiLocation(item.title) ?? poiCoords;
+          const coords = this.lookupPoiLocation(title) ?? poiCoords;
           if (coords) {
             (entity as any).location = coords;
           }


### PR DESCRIPTION
## What

Adds hand-verified latitude/longitude for every Plopsaland **De Panne**
attraction and restaurant.

## Why

The Plopsa middleware feed (`/api/points-of-interest`) exposes only *pixel*
coordinates on the park-map image, not lat/lng. Plopsaland Deutschland has an
affine pixel→geo transform, but **De Panne doesn't** — so its attractions and
restaurants shipped with no `location`.

## How

- `PlopsaBase` gains `poiLocations` + `lookupPoiLocation()`, keyed by POI title
  with normalized matching (case-insensitive + curly/straight apostrophe
  folding). This mirrors the existing Enchanted Parks `attractionLocations`
  pattern.
- `buildEntityList()` now prefers this snapshot for both `ATTRACTION` and
  `RESTAURANT`, falling back to `mapCoordinates()` (Deutschland's pixel
  transform) when there's no snapshot entry — so Deutschland is unchanged.
- The De Panne constructor loads
  `locations/plopsaland-de-panne.json`.
- Coordinates were seeded from Google Places + Apple Maps (name-verified
  matches only) and finished by hand on a satellite map. Provenance and refresh
  instructions are in `locations/README.md`.

## Coverage

**86 of 87 POIs** located — all 34 restaurants, 52/53 attractions.
*Merry-go-Round* is intentionally absent (it is not shown on the park map).

## Testing

- 3 new unit tests for the lookup (known-ride resolution, apostrophe/case
  folding, unknown-title miss). Full suite green (1252 tests).
- Verified **end-to-end against the live API**: `getEntities()` builds 101
  entities with 52/53 attractions and 34/34 restaurants receiving coordinates;
  `getLiveData()` and `getSchedules()` pass.

## Notes

- No dependency, config, or behavior changes for any other park.
- Snapshot can be refreshed with the tooling linked in `locations/README.md`.