### PR TITLE
fix(oceanpark): rebuild on website scraping — mobile app API suspended

### DIFF
--- a/TODO.MD
+++ b/TODO.MD
@@ -27,7 +27,7 @@
 - Universal Studios Singapore (USS)
 - Lotte World
 - Chimelong: Guangzhou + Zhuhai (2 destinations)
-- Ocean Park Hong Kong: Auth token, coordinate affine transform, showtimes, park schedule
+- Ocean Park Hong Kong: Website RSC-JSON scraping (mobile app API was suspended), coordinate affine transform, showtimes, park schedule
 
 **Totals: ~119 destinations, 1068 tests, 45 test files**
 

--- a/src/parks/oceanpark/__tests__/oceanpark.test.ts
+++ b/src/parks/oceanpark/__tests__/oceanpark.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Unit tests for Ocean Park Hong Kong.
+ *
+ * The mobile app's API (sop.oceanpark.com.hk) was suspended along with the
+ * app; this park now scrapes the public website's server-rendered pages.
+ * These tests exercise the pure parsing helpers and the entity/live-data/
+ * schedule builders offline, without hitting the real site. Full integration
+ * is exercised via `npm run dev -- oceanparkhongkong`.
+ */
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
+import {
+  OceanParkHongKong,
+  extractRscArray,
+  findMatchingBracket,
+  slugFromUrl,
+  slugify,
+  parseQueueMinutes,
+  parseHourRange,
+  computeAffineTransform,
+} from '../oceanpark.js';
+
+const TZ = 'Asia/Hong_Kong';
+
+// ── extractRscArray / findMatchingBracket ────────────────────────────────────
+
+describe('findMatchingBracket', () => {
+  test('finds the matching close bracket for a simple array', () => {
+    const str = '[1,2,3]tail';
+    expect(findMatchingBracket(str, 0, '[', ']')).toBe(7);
+  });
+
+  test('ignores brackets that appear inside a quoted string', () => {
+    const str = '[1,"a[b]c",3]tail';
+    expect(findMatchingBracket(str, 0, '[', ']')).toBe(13);
+  });
+
+  test('honours escaped quotes so a string does not end early', () => {
+    // The string value is: a"[not a real close]
+    const str = String.raw`[1,"a\"[not a real close]",3]TAIL`;
+    const end = findMatchingBracket(str, 0, '[', ']');
+    expect(str.slice(end)).toBe('TAIL');
+  });
+
+  test('returns -1 when the bracket never closes', () => {
+    expect(findMatchingBracket('[1,2,3', 0, '[', ']')).toBe(-1);
+  });
+});
+
+/**
+ * Wrap decoded page content as a Next.js flight script chunk, letting
+ * JSON.stringify handle the escaping (exactly as the real page does) instead
+ * of hand-writing backslashes in fixtures.
+ */
+function wrapPush(decodedContent: string): string {
+  return `<script>self.__next_f.push([1,${JSON.stringify(decodedContent)}])</script>`;
+}
+
+describe('extractRscArray', () => {
+  test('extracts an array embedded in a single push() chunk', () => {
+    const html = wrapPush('preamble junk\n"items":[{"nodeId":"abc"}]tail');
+    const arr = extractRscArray(html, '"items":');
+    expect(arr).toEqual([{nodeId: 'abc'}]);
+  });
+
+  test('skips non-matching push() chunks and finds the marker in a later one', () => {
+    const html = wrapPush('unrelated chunk with no marker') +
+      wrapPush('"items":[{"nodeId":"xyz"}]');
+    const arr = extractRscArray(html, '"items":');
+    expect(arr).toEqual([{nodeId: 'xyz'}]);
+  });
+
+  test('handles description text containing raw brackets without breaking the parse', () => {
+    const html = wrapPush('"items":[{"description":"See the [Summit] show","nodeId":"1"}]');
+    const arr = extractRscArray(html, '"items":') as any[];
+    expect(arr).toHaveLength(1);
+    expect(arr[0].description).toBe('See the [Summit] show');
+  });
+
+  test('returns null when there is no self.__next_f.push at all', () => {
+    expect(extractRscArray('<html><body>no rsc here</body></html>', '"items":')).toBeNull();
+  });
+
+  test('returns null when the marker is never found', () => {
+    const html = wrapPush(String.raw`"nothingHere":[1,2,3]`);
+    expect(extractRscArray(html, '"items":')).toBeNull();
+  });
+});
+
+// ── slugFromUrl / slugify ─────────────────────────────────────────────────
+
+describe('slugFromUrl', () => {
+  test('returns the last path segment', () => {
+    expect(slugFromUrl('https://www.oceanpark.com.hk/en/a-day-at-the-park/attractions/arctic-blast'))
+      .toBe('arctic-blast');
+  });
+
+  test('ignores a trailing slash', () => {
+    expect(slugFromUrl('https://www.oceanpark.com.hk/en/a-day-at-the-park/dining-shopping/shopping/'))
+      .toBe('shopping');
+  });
+});
+
+describe('slugify', () => {
+  test('lowercases and hyphenates spaces/punctuation', () => {
+    expect(slugify('Whiskers and Friends Meet (near Waterfront Gift Shop)'))
+      .toBe('whiskers-and-friends-meet-near-waterfront-gift-shop');
+  });
+
+  test('strips accents', () => {
+    expect(slugify('Café Ánimé')).toBe('cafe-anime');
+  });
+
+  test('trims leading/trailing hyphens produced by punctuation at the edges', () => {
+    expect(slugify('"Marine Wonders"')).toBe('marine-wonders');
+  });
+});
+
+// ── parseQueueMinutes ─────────────────────────────────────────────────────
+
+describe('parseQueueMinutes', () => {
+  test('parses a normal wait', () => {
+    expect(parseQueueMinutes(' 10  mins')).toBe(10);
+  });
+
+  test('parses zero distinctly from null (walk right on, not "no data")', () => {
+    expect(parseQueueMinutes(' 0  mins')).toBe(0);
+  });
+
+  test('returns null for an explicit null (no queue mechanic / no signal)', () => {
+    expect(parseQueueMinutes(null)).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(parseQueueMinutes(undefined)).toBeNull();
+  });
+
+  test('returns null for text with no number', () => {
+    expect(parseQueueMinutes('Closed')).toBeNull();
+  });
+});
+
+// ── parseHourRange ────────────────────────────────────────────────────────
+
+describe('parseHourRange', () => {
+  test('parses a standard am-pm range to 24h', () => {
+    expect(parseHourRange('10:00 am - 7:00 pm')).toEqual({open: '10:00', close: '19:00'});
+  });
+
+  test('handles 12:00 pm (noon) correctly', () => {
+    expect(parseHourRange('12:00 pm - 8:30 pm')).toEqual({open: '12:00', close: '20:30'});
+  });
+
+  test('handles 12:00 am (midnight) correctly', () => {
+    expect(parseHourRange('12:00 am - 6:00 am')).toEqual({open: '00:00', close: '06:00'});
+  });
+
+  test('returns null for an empty string (unpublished / closed day)', () => {
+    expect(parseHourRange('')).toBeNull();
+  });
+
+  test('returns null for unparseable text', () => {
+    expect(parseHourRange('Temporarily Closed')).toBeNull();
+  });
+});
+
+// ── computeAffineTransform ────────────────────────────────────────────────
+
+describe('computeAffineTransform', () => {
+  test('recovers an exact linear mapping from noiseless reference points', () => {
+    // lat = 0.001*x + 0*y + 22, lng = 0*x + 0.001*y + 114
+    const refPoints = [
+      {pixelX: 0, pixelY: 0, latitude: 22, longitude: 114},
+      {pixelX: 1000, pixelY: 0, latitude: 23, longitude: 114},
+      {pixelX: 0, pixelY: 1000, latitude: 22, longitude: 115},
+      {pixelX: 1000, pixelY: 1000, latitude: 23, longitude: 115},
+    ];
+    const coeffs = computeAffineTransform(refPoints)!;
+    expect(coeffs).toBeDefined();
+    const lat = coeffs.a * 500 + coeffs.b * 500 + coeffs.c;
+    const lng = coeffs.d * 500 + coeffs.e * 500 + coeffs.f;
+    expect(lat).toBeCloseTo(22.5, 6);
+    expect(lng).toBeCloseTo(114.5, 6);
+  });
+
+  test('returns null for collinear (degenerate) reference points', () => {
+    const refPoints = [
+      {pixelX: 0, pixelY: 0, latitude: 22, longitude: 114},
+      {pixelX: 1, pixelY: 1, latitude: 22.1, longitude: 114.1},
+      {pixelX: 2, pixelY: 2, latitude: 22.2, longitude: 114.2},
+    ];
+    expect(computeAffineTransform(refPoints)).toBeNull();
+  });
+});
+
+// ── Class builders (stubbed network layer) ───────────────────────────────────
+
+type CoordEntry = [string, {latitude: number; longitude: number}];
+
+class Probe extends OceanParkHongKong {
+  private readonly _attractions: any[];
+  private readonly _diningTabs: any[];
+  private readonly _scheduleItems: any[];
+  private readonly _hoursByDate: Record<string, string | null>;
+  private readonly _coordEntries: CoordEntry[];
+
+  constructor(opts: {
+    attractions?: any[];
+    diningTabs?: any[];
+    scheduleItems?: any[];
+    hoursByDate?: Record<string, string | null>;
+    coordEntries?: CoordEntry[];
+  } = {}) {
+    super();
+    this._attractions = opts.attractions ?? [];
+    this._diningTabs = opts.diningTabs ?? [];
+    this._scheduleItems = opts.scheduleItems ?? [];
+    this._hoursByDate = opts.hoursByDate ?? {};
+    this._coordEntries = opts.coordEntries ?? [];
+  }
+
+  override async getAttractionItems(): Promise<any[]> {
+    return this._attractions;
+  }
+
+  override async getDiningTabs(): Promise<any[]> {
+    return this._diningTabs;
+  }
+
+  override async getDailyScheduleItems(_date: string): Promise<any[]> {
+    return this._scheduleItems;
+  }
+
+  override async getParkOpeningHoursValue(date: string): Promise<string | null> {
+    return this._hoursByDate[date] ?? null;
+  }
+
+  override async getCoordinateMapEntries(): Promise<CoordEntry[]> {
+    return this._coordEntries;
+  }
+
+  public entities(): Promise<any[]> {
+    return (this as any).buildEntityList();
+  }
+
+  public liveData(): Promise<any[]> {
+    return (this as any).buildLiveData();
+  }
+
+  public schedules(): Promise<any[]> {
+    return (this as any).buildSchedules();
+  }
+}
+
+const mkAttraction = (overrides: Partial<any> = {}) => ({
+  nodeId: 'node-1',
+  nodeUrl: {label: 'Arctic Blast', url: 'https://www.oceanpark.com.hk/en/a-day-at-the-park/attractions/arctic-blast'},
+  attractionTypes: [{id: 'thrill-rides', label: 'Thrill Rides'}],
+  height: {min: 0, max: 300},
+  queueTime: {text: ' 10  mins'},
+  ...overrides,
+});
+
+describe('buildEntityList', () => {
+  test('maps a ride attraction with a real height restriction', async () => {
+    const probe = new Probe({
+      attractions: [mkAttraction({height: {min: 100, max: 300}})],
+    });
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction).toBeDefined();
+    expect(attraction.name).toBe('Arctic Blast');
+    expect(attraction.attractionType).toBe('RIDE');
+    expect(attraction.tags).toHaveLength(1);
+    expect(attraction.tags[0].tag).toBe('MINIMUM_HEIGHT');
+  });
+
+  test('classifies in-park-transportation as TRANSPORT', async () => {
+    const probe = new Probe({
+      attractions: [mkAttraction({
+        nodeId: 'node-2',
+        attractionTypes: [{id: 'in-park-transportation', label: 'In-park Transportation'}],
+      })],
+    });
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-2');
+    expect(attraction.attractionType).toBe('TRANSPORT');
+  });
+
+  test('does not tag min/max height at the "no restriction" sentinel (0 / 300)', async () => {
+    const probe = new Probe({attractions: [mkAttraction({height: {min: 0, max: 300}})]});
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction.tags).toBeUndefined();
+  });
+
+  test('joins attraction coordinates by URL slug', async () => {
+    const probe = new Probe({
+      attractions: [mkAttraction()],
+      coordEntries: [['arctic-blast', {latitude: 1, longitude: 2}]],
+    });
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction.location).toEqual({latitude: 1, longitude: 2});
+  });
+
+  test('falls back to the default location when no coordinate match exists', async () => {
+    const probe = new Probe({attractions: [mkAttraction()], coordEntries: []});
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction.location.latitude).toBeCloseTo(22.2465, 4);
+  });
+
+  test('only the "restaurants" tab becomes RESTAURANT entities; other tabs are ignored', async () => {
+    const probe = new Probe({
+      diningTabs: [
+        {
+          tab: {id: 'restaurants', label: 'Restaurants'},
+          pageItems: [{nodeUrl: {label: "Neptune's Restaurant", url: 'https://www.oceanpark.com.hk/en/a-day-at-the-park/dining-shopping/restaurants/neptune-s-restaurant'}}],
+        },
+        {
+          tab: {id: 'food-kiosks', label: 'Food Kiosks'},
+          cardItems: [{title: 'Popcorn Cart'}],
+        },
+      ],
+    });
+    const entities = await probe.entities();
+    const restaurants = entities.filter((e) => e.entityType === 'RESTAURANT');
+    expect(restaurants).toHaveLength(1);
+    expect(restaurants[0].id).toBe('restaurant_neptune-s-restaurant');
+    expect(entities.find((e) => e.name === 'Popcorn Cart')).toBeUndefined();
+  });
+
+  test('shows are deduplicated by title and get a slugified id', async () => {
+    const probe = new Probe({
+      scheduleItems: [
+        {title: 'All Star Jam', timeSlot: ['11:00:00']},
+        {title: 'All Star Jam', timeSlot: ['15:30:00']},
+      ],
+    });
+    const entities = await probe.entities();
+    const shows = entities.filter((e) => e.entityType === 'SHOW');
+    expect(shows).toHaveLength(1);
+    expect(shows[0].id).toBe('show_all-star-jam');
+  });
+
+  test('always includes the DESTINATION and PARK entities', async () => {
+    const probe = new Probe();
+    const entities = await probe.entities();
+    expect(entities.find((e) => e.entityType === 'PARK')).toBeDefined();
+  });
+});
+
+describe('buildLiveData', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Fixed at 2026-07-07T12:00:00+08:00 (noon HK, no DST) so a ±1h window
+    // never crosses a calendar day boundary.
+    vi.setSystemTime(new Date('2026-07-07T04:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('a numeric queueTime maps to OPERATING with that standby wait', async () => {
+    const probe = new Probe({attractions: [mkAttraction({queueTime: {text: ' 10  mins'}})]});
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'attraction_node-1');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.queue.STANDBY.waitTime).toBe(10);
+  });
+
+  test('a "0 mins" queueTime is OPERATING with a zero wait, not CLOSED', async () => {
+    const probe = new Probe({attractions: [mkAttraction({queueTime: {text: ' 0  mins'}})]});
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'attraction_node-1');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.queue.STANDBY.waitTime).toBe(0);
+  });
+
+  test('an explicit null queueTime (no queue mechanic / no signal) is CLOSED with no queue', async () => {
+    const probe = new Probe({attractions: [mkAttraction({queueTime: null})]});
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'attraction_node-1');
+    expect(entry.status).toBe('CLOSED');
+    expect(entry.queue).toBeUndefined();
+  });
+
+  test('a show with only future showtimes today is OPERATING and lists them', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'All Star Jam', timeSlot: ['13:00:00']}], // 1pm, after our noon "now"
+    });
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'show_all-star-jam');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.showtimes).toHaveLength(1);
+    expect(entry.showtimes[0].startTime.startsWith('2026-07-07T13:00')).toBe(true);
+  });
+
+  test('a show with only past showtimes today is CLOSED with no showtimes', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'All Star Jam', timeSlot: ['11:00:00']}], // 11am, before our noon "now"
+    });
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'show_all-star-jam');
+    expect(entry.status).toBe('CLOSED');
+    expect(entry.showtimes).toBeUndefined();
+  });
+
+  test('a show with one past and one future slot keeps only the future one', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'All Star Jam', timeSlot: ['11:00:00', '13:00:00']}],
+    });
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'show_all-star-jam');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.showtimes).toHaveLength(1);
+    expect(entry.showtimes[0].startTime.startsWith('2026-07-07T13:00')).toBe(true);
+  });
+});
+
+describe('buildSchedules', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-07T04:00:00Z')); // noon HK
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('emits an OPERATING entry for a date with published hours', async () => {
+    const probe = new Probe({hoursByDate: {'2026-07-07': '10:00 am - 7:00 pm'}});
+    const scheds = await probe.schedules();
+    const entry = scheds[0].schedule.find((s: any) => s.date === '2026-07-07');
+    expect(entry).toBeDefined();
+    expect(entry.type).toBe('OPERATING');
+    expect(entry.openingTime.startsWith('2026-07-07T10:00')).toBe(true);
+    expect(entry.closingTime.startsWith('2026-07-07T19:00')).toBe(true);
+  });
+
+  test('skips a date with no published hours (empty string) rather than emitting a bogus entry', async () => {
+    const probe = new Probe({hoursByDate: {'2026-07-07': ''}});
+    const scheds = await probe.schedules();
+    expect(scheds[0].schedule.find((s: any) => s.date === '2026-07-07')).toBeUndefined();
+  });
+
+  test('skips a date with no data at all (beyond the published window)', async () => {
+    const probe = new Probe({hoursByDate: {}});
+    const scheds = await probe.schedules();
+    expect(scheds[0].schedule).toHaveLength(0);
+  });
+});

--- a/src/parks/oceanpark/__tests__/oceanpark.test.ts
+++ b/src/parks/oceanpark/__tests__/oceanpark.test.ts
@@ -14,8 +14,10 @@ import {
   findMatchingBracket,
   slugFromUrl,
   slugify,
+  groupShowsBySlug,
   parseQueueMinutes,
   parseHourRange,
+  addDaysToDateString,
   computeAffineTransform,
 } from '../oceanpark.js';
 
@@ -43,6 +45,15 @@ describe('findMatchingBracket', () => {
 
   test('returns -1 when the bracket never closes', () => {
     expect(findMatchingBracket('[1,2,3', 0, '[', ']')).toBe(-1);
+  });
+
+  test('an escaped backslash immediately before a real closing quote does not extend the string', () => {
+    // The string value is: a\  (a, then a literal backslash) — the quote right
+    // after it is real and closes the string, so the following `]` is
+    // structural, not part of the string content.
+    const str = String.raw`[1,"a\\",3]TAIL`;
+    const end = findMatchingBracket(str, 0, '[', ']');
+    expect(str.slice(end)).toBe('TAIL');
   });
 });
 
@@ -84,6 +95,30 @@ describe('extractRscArray', () => {
     const html = wrapPush(String.raw`"nothingHere":[1,2,3]`);
     expect(extractRscArray(html, '"items":')).toBeNull();
   });
+
+  test('a validate callback rejects a same-named marker from the wrong widget and keeps scanning', () => {
+    // First chunk's "items" array is a nav/breadcrumb list, not the target
+    // shape; a validator checking for the expected key should skip it and
+    // find the real one in a later chunk.
+    const html = wrapPush('"items":[{"label":"Home"}]') +
+      wrapPush('"items":[{"nodeId":"abc"}]');
+    const arr = extractRscArray(html, '"items":', (a) => a.length === 0 || (typeof a[0] === 'object' && a[0] !== null && 'nodeId' in (a[0] as object)));
+    expect(arr).toEqual([{nodeId: 'abc'}]);
+  });
+
+  test('caps scanning on a document larger than the size limit', () => {
+    const huge = 'x'.repeat(2_000_001) + wrapPush('"items":[{"nodeId":"abc"}]');
+    expect(extractRscArray(huge, '"items":')).toBeNull();
+  });
+
+  test('does not hang on many unterminated push() occurrences (quadratic-scan guard)', () => {
+    // 500 unterminated push() calls back to back — well past MAX_PUSH_ATTEMPTS.
+    // Without the attempt cap this would rescan to end-of-string 500 times.
+    const malformed = 'self.__next_f.push(['.repeat(500);
+    const start = Date.now();
+    expect(extractRscArray(malformed, '"items":')).toBeNull();
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
 });
 
 // ── slugFromUrl / slugify ─────────────────────────────────────────────────
@@ -97,6 +132,16 @@ describe('slugFromUrl', () => {
   test('ignores a trailing slash', () => {
     expect(slugFromUrl('https://www.oceanpark.com.hk/en/a-day-at-the-park/dining-shopping/shopping/'))
       .toBe('shopping');
+  });
+
+  test('strips a query string before taking the last segment', () => {
+    expect(slugFromUrl('https://www.oceanpark.com.hk/en/a-day-at-the-park/attractions/arctic-blast?utm=nav'))
+      .toBe('arctic-blast');
+  });
+
+  test('strips a fragment before taking the last segment', () => {
+    expect(slugFromUrl('https://www.oceanpark.com.hk/en/a-day-at-the-park/attractions/arctic-blast#reviews'))
+      .toBe('arctic-blast');
   });
 });
 
@@ -112,6 +157,50 @@ describe('slugify', () => {
 
   test('trims leading/trailing hyphens produced by punctuation at the edges', () => {
     expect(slugify('"Marine Wonders"')).toBe('marine-wonders');
+  });
+
+  test('returns an empty string for punctuation-only input', () => {
+    expect(slugify('!!!')).toBe('');
+  });
+
+  test('returns an empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+});
+
+describe('groupShowsBySlug', () => {
+  test('groups identical titles together under one slug', () => {
+    const groups = groupShowsBySlug([
+      {title: 'All Star Jam', timeSlot: ['11:00:00']},
+      {title: 'All Star Jam', timeSlot: ['15:30:00']},
+    ]);
+    expect(groups.size).toBe(1);
+    expect(groups.get('all-star-jam')!.items).toHaveLength(2);
+  });
+
+  test('two distinct titles that collide on slug keep only the first, and drop the second', () => {
+    const groups = groupShowsBySlug([
+      {title: 'Whiskers & Friends', timeSlot: ['11:00:00']},
+      {title: 'Whiskers, Friends', timeSlot: ['15:00:00']},
+    ]);
+    // Both normalize to "whiskers-friends" — only one group must survive,
+    // never two entries silently sharing the same id.
+    expect(groups.size).toBe(1);
+    expect(groups.get('whiskers-friends')!.title).toBe('Whiskers & Friends');
+    expect(groups.get('whiskers-friends')!.items).toHaveLength(1);
+  });
+
+  test('a title that normalizes to an empty slug is dropped entirely', () => {
+    const groups = groupShowsBySlug([{title: '!!!', timeSlot: ['11:00:00']}]);
+    expect(groups.size).toBe(0);
+  });
+
+  test('distinct titles with distinct slugs both survive', () => {
+    const groups = groupShowsBySlug([
+      {title: 'All Star Jam', timeSlot: ['11:00:00']},
+      {title: 'Animal Fun Talk', timeSlot: ['12:00:00']},
+    ]);
+    expect(groups.size).toBe(2);
   });
 });
 
@@ -137,6 +226,12 @@ describe('parseQueueMinutes', () => {
   test('returns null for text with no number', () => {
     expect(parseQueueMinutes('Closed')).toBeNull();
   });
+
+  test('does not mistake an unrelated digit for a wait time', () => {
+    // A status like "Reopens at 5pm" has a digit but isn't a wait-time
+    // reading; only a number directly adjacent to "min" counts.
+    expect(parseQueueMinutes('Reopens at 5pm')).toBeNull();
+  });
 });
 
 // ── parseHourRange ────────────────────────────────────────────────────────
@@ -160,6 +255,31 @@ describe('parseHourRange', () => {
 
   test('returns null for unparseable text', () => {
     expect(parseHourRange('Temporarily Closed')).toBeNull();
+  });
+
+  test('parses an overnight range with no day-rollover awareness (caller\'s job to roll it)', () => {
+    // parseHourRange itself is date-agnostic — it just converts each side to
+    // 24h. Rolling the close time to the next calendar date is buildSchedules'
+    // responsibility (covered in the buildSchedules describe block below).
+    expect(parseHourRange('6:00 pm - 12:30 am')).toEqual({open: '18:00', close: '00:30'});
+  });
+});
+
+describe('addDaysToDateString', () => {
+  test('adds days within the same month', () => {
+    expect(addDaysToDateString('2026-07-07', 3)).toBe('2026-07-10');
+  });
+
+  test('rolls over a month boundary', () => {
+    expect(addDaysToDateString('2026-07-31', 1)).toBe('2026-08-01');
+  });
+
+  test('rolls over a year boundary', () => {
+    expect(addDaysToDateString('2026-12-31', 1)).toBe('2027-01-01');
+  });
+
+  test('adding zero days returns the same date', () => {
+    expect(addDaysToDateString('2026-07-07', 0)).toBe('2026-07-07');
   });
 });
 
@@ -293,6 +413,122 @@ describe('buildEntityList', () => {
     expect(attraction.tags).toBeUndefined();
   });
 
+  test('tags a real maximum height restriction', async () => {
+    const probe = new Probe({attractions: [mkAttraction({height: {min: 0, max: 150}})]});
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction.tags).toHaveLength(1);
+    expect(attraction.tags[0].tag).toBe('MAXIMUM_HEIGHT');
+  });
+
+  test('defaults to RIDE when attractionTypes is empty', async () => {
+    const probe = new Probe({attractions: [mkAttraction({attractionTypes: []})]});
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction.attractionType).toBe('RIDE');
+  });
+
+  test('defaults to RIDE when attractionTypes is missing entirely', async () => {
+    const {attractionTypes, ...rest} = mkAttraction();
+    const probe = new Probe({attractions: [rest]});
+    const entities = await probe.entities();
+    const attraction = entities.find((e) => e.id === 'attraction_node-1');
+    expect(attraction.attractionType).toBe('RIDE');
+  });
+
+  test('skips an attraction item missing nodeUrl instead of crashing the whole build', async () => {
+    const {nodeUrl, ...malformed} = mkAttraction();
+    const probe = new Probe({
+      attractions: [malformed, mkAttraction({nodeId: 'node-2', nodeUrl: {label: 'Bumper Blaster', url: '.../bumper-blaster'}})],
+    });
+    const entities = await probe.entities();
+    expect(entities.find((e) => e.id === 'attraction_node-1')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'attraction_node-2')).toBeDefined();
+  });
+
+  test('skips an attraction item missing nodeId instead of producing an "attraction_undefined" id', async () => {
+    const {nodeId, ...malformed} = mkAttraction();
+    const probe = new Probe({attractions: [malformed]});
+    const entities = await probe.entities();
+    expect(entities.find((e) => e.entityType === 'ATTRACTION')).toBeUndefined();
+  });
+
+  test('skips a restaurant item missing nodeUrl instead of crashing the whole build', async () => {
+    const probe = new Probe({
+      diningTabs: [{
+        tab: {id: 'restaurants', label: 'Restaurants'},
+        pageItems: [
+          {} as any,
+          {nodeUrl: {label: "Neptune's Restaurant", url: '.../neptune-s-restaurant'}},
+        ],
+      }],
+    });
+    const entities = await probe.entities();
+    const restaurants = entities.filter((e) => e.entityType === 'RESTAURANT');
+    expect(restaurants).toHaveLength(1);
+    expect(restaurants[0].name).toBe("Neptune's Restaurant");
+  });
+
+  test('restaurant coordinates join by URL slug and fall back to the default when unmatched', async () => {
+    const probe = new Probe({
+      diningTabs: [{
+        tab: {id: 'restaurants', label: 'Restaurants'},
+        pageItems: [{nodeUrl: {label: "Neptune's Restaurant", url: 'https://www.oceanpark.com.hk/en/a-day-at-the-park/dining-shopping/restaurants/neptune-s-restaurant'}}],
+      }],
+      coordEntries: [['neptune-s-restaurant', {latitude: 3, longitude: 4}]],
+    });
+    const entities = await probe.entities();
+    const restaurant = entities.find((e) => e.entityType === 'RESTAURANT');
+    expect(restaurant.location).toEqual({latitude: 3, longitude: 4});
+  });
+
+  test('restaurant falls back to the default location when no coordinate match exists', async () => {
+    const probe = new Probe({
+      diningTabs: [{
+        tab: {id: 'restaurants', label: 'Restaurants'},
+        pageItems: [{nodeUrl: {label: "Neptune's Restaurant", url: 'https://www.oceanpark.com.hk/en/a-day-at-the-park/dining-shopping/restaurants/neptune-s-restaurant'}}],
+      }],
+      coordEntries: [],
+    });
+    const entities = await probe.entities();
+    const restaurant = entities.find((e) => e.entityType === 'RESTAURANT');
+    expect(restaurant.location.latitude).toBeCloseTo(22.2465, 4);
+  });
+
+  test('show coordinates join by slugified title and fall back to the default when unmatched', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'All Star Jam', timeSlot: ['11:00:00']}],
+      coordEntries: [['all-star-jam', {latitude: 5, longitude: 6}]],
+    });
+    const entities = await probe.entities();
+    const show = entities.find((e) => e.entityType === 'SHOW');
+    expect(show.location).toEqual({latitude: 5, longitude: 6});
+  });
+
+  test('show falls back to the default location when no coordinate match exists', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'All Star Jam', timeSlot: ['11:00:00']}],
+      coordEntries: [],
+    });
+    const entities = await probe.entities();
+    const show = entities.find((e) => e.entityType === 'SHOW');
+    expect(show.location.latitude).toBeCloseTo(22.2465, 4);
+  });
+
+  test('two shows whose titles collide on slug do not produce duplicate entity ids', async () => {
+    const probe = new Probe({
+      scheduleItems: [
+        {title: 'Whiskers & Friends', timeSlot: ['11:00:00']},
+        {title: 'Whiskers, Friends', timeSlot: ['15:00:00']},
+      ],
+    });
+    const entities = await probe.entities();
+    const shows = entities.filter((e) => e.entityType === 'SHOW');
+    const ids = shows.map((e: any) => e.id);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate ids
+    expect(shows).toHaveLength(1);
+  });
+
   test('joins attraction coordinates by URL slug', async () => {
     const probe = new Probe({
       attractions: [mkAttraction()],
@@ -343,10 +579,50 @@ describe('buildEntityList', () => {
     expect(shows[0].id).toBe('show_all-star-jam');
   });
 
-  test('always includes the DESTINATION and PARK entities', async () => {
+  test('always includes the PARK entity', async () => {
+    // buildEntityList() never returns a DESTINATION entity — that comes from
+    // getDestinations() below, merged in separately by the base class.
     const probe = new Probe();
     const entities = await probe.entities();
+    const park = entities.find((e) => e.entityType === 'PARK');
+    expect(park).toBeDefined();
+    expect(park!.id).toBe('oceanpark');
+  });
+
+  test('an attractions-fetch failure degrades to zero attractions instead of throwing the whole build', async () => {
+    const probe = new Probe({
+      diningTabs: [{
+        tab: {id: 'restaurants', label: 'Restaurants'},
+        pageItems: [{nodeUrl: {label: "Neptune's Restaurant", url: '.../neptune-s-restaurant'}}],
+      }],
+    });
+    (probe as any).getAttractionItems = () => Promise.reject(new Error('attractions page down'));
+
+    const entities = await probe.entities();
+    expect(entities.find((e) => e.entityType === 'ATTRACTION')).toBeUndefined();
+    // The unrelated dining source still comes through.
+    expect(entities.find((e) => e.entityType === 'RESTAURANT')).toBeDefined();
     expect(entities.find((e) => e.entityType === 'PARK')).toBeDefined();
+  });
+
+  test('a dining-fetch failure degrades to zero restaurants without losing attractions', async () => {
+    const probe = new Probe({attractions: [mkAttraction()]});
+    (probe as any).getDiningTabs = () => Promise.reject(new Error('dining page down'));
+
+    const entities = await probe.entities();
+    expect(entities.find((e) => e.entityType === 'RESTAURANT')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'attraction_node-1')).toBeDefined();
+  });
+});
+
+describe('getDestinations', () => {
+  test('returns a single DESTINATION entity with the expected id, type, and timezone', async () => {
+    const probe = new Probe();
+    const destinations = await probe.getDestinations();
+    expect(destinations).toHaveLength(1);
+    expect(destinations[0].id).toBe('oceanparkresort');
+    expect(destinations[0].entityType).toBe('DESTINATION');
+    expect(destinations[0].timezone).toBe(TZ);
   });
 });
 
@@ -417,6 +693,40 @@ describe('buildLiveData', () => {
     expect(entry.showtimes).toHaveLength(1);
     expect(entry.showtimes[0].startTime.startsWith('2026-07-07T13:00')).toBe(true);
   });
+
+  test('two shows colliding on slug do not clobber each other into one merged live-data row under one id', async () => {
+    const probe = new Probe({
+      scheduleItems: [
+        {title: 'Whiskers & Friends', timeSlot: ['13:00:00']},
+        {title: 'Whiskers, Friends', timeSlot: ['14:00:00']},
+      ],
+    });
+    const live = await probe.liveData();
+    const showEntries = live.filter((l) => l.id.startsWith('show_'));
+    const ids = showEntries.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate ids in the emitted array
+  });
+
+  test('a shows-fetch failure degrades to no show live data without losing attraction wait times', async () => {
+    const probe = new Probe({attractions: [mkAttraction({queueTime: {text: ' 10  mins'}})]});
+    (probe as any).getDailyScheduleItems = () => Promise.reject(new Error('daily schedule route down'));
+
+    const live = await probe.liveData();
+    expect(live.find((l) => l.id.startsWith('show_'))).toBeUndefined();
+    const attraction = live.find((l) => l.id === 'attraction_node-1');
+    expect(attraction.status).toBe('OPERATING');
+    expect(attraction.queue.STANDBY.waitTime).toBe(10);
+  });
+
+  test('an attractions-fetch failure degrades to no attraction wait times without losing show live data', async () => {
+    const probe = new Probe({scheduleItems: [{title: 'All Star Jam', timeSlot: ['13:00:00']}]});
+    (probe as any).getAttractionItems = () => Promise.reject(new Error('attractions page down'));
+
+    const live = await probe.liveData();
+    expect(live.find((l) => l.id.startsWith('attraction_'))).toBeUndefined();
+    const show = live.find((l) => l.id === 'show_all-star-jam');
+    expect(show.status).toBe('OPERATING');
+  });
 });
 
 describe('buildSchedules', () => {
@@ -449,5 +759,44 @@ describe('buildSchedules', () => {
     const probe = new Probe({hoursByDate: {}});
     const scheds = await probe.schedules();
     expect(scheds[0].schedule).toHaveLength(0);
+  });
+
+  test('rolls an overnight closing time to the next calendar date instead of before the opening time', async () => {
+    const probe = new Probe({hoursByDate: {'2026-07-07': '6:00 pm - 12:30 am'}});
+    const scheds = await probe.schedules();
+    const entry = scheds[0].schedule.find((s: any) => s.date === '2026-07-07');
+    expect(entry).toBeDefined();
+    expect(entry.openingTime.startsWith('2026-07-07T18:00')).toBe(true);
+    expect(entry.closingTime.startsWith('2026-07-08T00:30')).toBe(true);
+    expect(new Date(entry.closingTime).getTime()).toBeGreaterThan(new Date(entry.openingTime).getTime());
+  });
+
+  test('a normal same-day range is not rolled forward (no regression)', async () => {
+    const probe = new Probe({hoursByDate: {'2026-07-07': '10:00 am - 7:00 pm'}});
+    const scheds = await probe.schedules();
+    const entry = scheds[0].schedule.find((s: any) => s.date === '2026-07-07');
+    expect(entry.closingTime.startsWith('2026-07-07T19:00')).toBe(true);
+  });
+
+  test('logs a warning when a date has non-empty but unparseable hours text', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const probe = new Probe({hoursByDate: {'2026-07-07': '10:00 - 19:00'}}); // 24h format, not the expected am/pm
+    const scheds = await probe.schedules();
+    expect(scheds[0].schedule.find((s: any) => s.date === '2026-07-07')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('2026-07-07'));
+    warnSpy.mockRestore();
+  });
+
+  test('one failed date request degrades to fewer days instead of zeroing the entire schedule', async () => {
+    const probe = new Probe({hoursByDate: {'2026-07-08': '10:00 am - 7:00 pm'}});
+    const originalGet = probe.getParkOpeningHoursValue.bind(probe);
+    (probe as any).getParkOpeningHoursValue = (date: string) => {
+      if (date === '2026-07-07') return Promise.reject(new Error('transient 502'));
+      return originalGet(date);
+    };
+
+    const scheds = await probe.schedules();
+    expect(scheds[0].schedule.find((s: any) => s.date === '2026-07-07')).toBeUndefined();
+    expect(scheds[0].schedule.find((s: any) => s.date === '2026-07-08')).toBeDefined();
   });
 });

--- a/src/parks/oceanpark/oceanpark.ts
+++ b/src/parks/oceanpark/oceanpark.ts
@@ -23,13 +23,21 @@
  * and per-attraction "Summit closes early" special hours. Shopping and food
  * kiosk locations are also left out — no entity-type precedent for them and
  * the site gives them no numeric ID or UUID, only a title.
+ *
+ * Scraping resilience: this is a screen-scrape of a third-party site that can
+ * change structure without notice, so every extraction point is defensive —
+ * malformed individual items are dropped (and logged) rather than crashing
+ * the whole build, and independent upstream sources (attractions, dining,
+ * shows, schedule, coordinates) each fail in isolation so one flaky endpoint
+ * degrades rather than zeroes out the destination's output.
  */
 
 import {Destination, DestinationConstructor} from '../../destination.js';
 import config from '../../config.js';
+import {cache} from '../../cache.js';
 import {http, HTTPObj} from '../../http.js';
 import {destinationController} from '../../destinationRegistry.js';
-import {formatInTimezone, formatDate, addDays, constructDateTime} from '../../datetime.js';
+import {formatInTimezone, formatDate, constructDateTime} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 import type {Entity, LiveData, EntitySchedule, ScheduleEntry} from '@themeparks/typelib';
 import {AttractionTypeEnum} from '@themeparks/typelib';
@@ -50,6 +58,22 @@ const MAP_CATEGORIES = ['attractions', 'animals', 'dining', 'transportations', '
 
 /** How many days ahead to probe for published park hours. */
 const SCHEDULE_DAYS = 60;
+
+/**
+ * Real RSC payloads for these pages run a few hundred KB. Anything wildly
+ * larger is either a bug upstream, a WAF/CDN interstitial swapped in for the
+ * real page, or a truncated response — bail out before attempting to scan it
+ * rather than risk pathological scan cost on adversarial/corrupted input.
+ */
+const MAX_SCRAPE_HTML_LENGTH = 2_000_000;
+
+/**
+ * A normal page has a few dozen flight-payload chunks. Far more
+ * self.__next_f.push() occurrences than that means the document is
+ * malformed — cap the number of candidates tried so a document packed with
+ * unterminated push() tokens can't force many full-document rescans.
+ */
+const MAX_PUSH_ATTEMPTS = 100;
 
 // ── Website JSON shapes (embedded RSC payloads / Next.js API routes) ────────
 
@@ -117,7 +141,18 @@ interface AffineCoeffs {
   d: number; e: number; f: number; // lng = d*x + e*y + f
 }
 
+/** A group of same-slug schedule entries collapsed to one show identity. */
+interface ShowGroup {
+  title: string;
+  items: OceanParkScheduleItem[];
+}
+
 // ── Pure Functions ──────────────────────────────────────────────────────────
+
+/** Stringify `err` for a log line without throwing on non-Error values. */
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 /**
  * Find the balanced closing bracket matching `str[openIdx]`, honouring JSON
@@ -172,12 +207,32 @@ export function findJsonArray(text: string, marker: string): unknown[] | null {
  * unicode, etc. all handled by JSON.parse) rather than hand-rolled backslash
  * stripping. `marker` (e.g. `"items":`) then locates the target array within
  * that unescaped string.
+ *
+ * `validate` optionally rejects a marker match whose array doesn't look like
+ * the expected shape (e.g. a same-named `"items"` array from an unrelated nav
+ * widget earlier in the document) and keeps scanning for another push() chunk
+ * instead of returning the wrong data.
+ *
+ * Bounded by MAX_SCRAPE_HTML_LENGTH / MAX_PUSH_ATTEMPTS: an unbounded scan
+ * over a malformed or adversarially truncated document (every
+ * findMatchingBracket failure re-scans to end-of-string) is quadratic in the
+ * number of unterminated push() occurrences — these caps keep worst case
+ * bounded instead of blocking the process for tens of seconds on a mangled
+ * upstream response.
  */
-export function extractRscArray(html: string, marker: string): unknown[] | null {
+export function extractRscArray(
+  html: string,
+  marker: string,
+  validate?: (arr: unknown[]) => boolean,
+): unknown[] | null {
+  if (html.length > MAX_SCRAPE_HTML_LENGTH) return null;
+
   const pushToken = 'self.__next_f.push(';
   let searchFrom = 0;
+  let attempts = 0;
 
   for (;;) {
+    if (++attempts > MAX_PUSH_ATTEMPTS) return null;
     const pushIdx = html.indexOf(pushToken, searchFrom);
     if (pushIdx === -1) return null;
     const argStart = pushIdx + pushToken.length;
@@ -196,13 +251,32 @@ export function extractRscArray(html: string, marker: string): unknown[] | null 
     if (!Array.isArray(payload) || typeof payload[1] !== 'string') continue;
 
     const arr = findJsonArray(payload[1], marker);
-    if (arr) return arr;
+    if (arr && (!validate || validate(arr))) return arr;
   }
 }
 
-/** Last non-empty path segment of a URL — Ocean Park's canonical entity slug. */
+/** First element looks like an object with `key` — a cheap shape check to reject a same-named array from the wrong widget. */
+function firstItemHasKey(key: string): (arr: unknown[]) => boolean {
+  return (arr) => arr.length === 0 || (typeof arr[0] === 'object' && arr[0] !== null && key in (arr[0] as object));
+}
+
+/**
+ * An attraction item needs a stable identity (nodeId) and a name/slug source
+ * (nodeUrl) to be usable — both are dereferenced unguarded downstream, so a
+ * card missing either must be dropped here rather than crash the whole
+ * entity list or live-data build, or collide with another item on the
+ * fallback id "attraction_undefined".
+ */
+function isValidAttractionItem(item: OceanParkAttractionItem): boolean {
+  const ok = !!item?.nodeId && !!item?.nodeUrl?.url && !!item?.nodeUrl?.label;
+  if (!ok) console.warn(`[OceanPark] skipping malformed attraction item: ${JSON.stringify(item).slice(0, 200)}`);
+  return ok;
+}
+
+/** Last non-empty path segment of a URL (query string/fragment stripped) — Ocean Park's canonical entity slug. */
 export function slugFromUrl(url: string): string {
-  const parts = url.split('/').filter(Boolean);
+  const clean = url.split('?')[0].split('#')[0];
+  const parts = clean.split('/').filter(Boolean);
   return parts[parts.length - 1] ?? '';
 }
 
@@ -217,7 +291,48 @@ export function slugify(text: string): string {
 }
 
 /**
- * Parse "10 mins" / " 0  mins" style queue text into minutes.
+ * Group schedule items by slug rather than by raw title. slugify() collapses
+ * differently-punctuated titles (e.g. "Whiskers & Friends" / "Whiskers,
+ * Friends") onto the same id, so grouping by title alone would let two
+ * distinct shows silently share one entity/live-data id and clobber each
+ * other. The first title seen for a slug wins; a different title landing on
+ * an already-claimed slug is dropped (logged) rather than silently merged.
+ * A title that normalizes to an empty slug is dropped the same way.
+ *
+ * Used by both buildEntityList and buildLiveData so the two always agree on
+ * exactly which id each show maps to.
+ */
+export function groupShowsBySlug(scheduleItems: OceanParkScheduleItem[]): Map<string, ShowGroup> {
+  const bySlug = new Map<string, ShowGroup>();
+
+  for (const item of scheduleItems) {
+    const slug = slugify(item.title);
+    if (!slug) {
+      console.warn(`[OceanPark] skipping show with empty slug after normalisation: "${item.title}"`);
+      continue;
+    }
+
+    const existing = bySlug.get(slug);
+    if (!existing) {
+      bySlug.set(slug, {title: item.title, items: [item]});
+    } else if (existing.title === item.title) {
+      existing.items.push(item);
+    } else {
+      console.warn(
+        `[OceanPark] show "${item.title}" collides on slug "${slug}" with already-seen "${existing.title}"; dropping the later one to avoid a duplicate entity id`,
+      );
+    }
+  }
+
+  return bySlug;
+}
+
+/**
+ * Parse "10 mins" / " 0  mins" style queue text into minutes. Requires the
+ * number to actually be adjacent to "min" so incidental digits elsewhere in
+ * a status string (e.g. a future "Reopens at 5pm") can't be misread as a
+ * wait time.
+ *
  * Returns null for missing/unparseable text — the website uses an explicit
  * `null` queueTime for attractions with no queue mechanic (walkthroughs,
  * animal exhibits), which we can't distinguish from "currently closed"
@@ -225,9 +340,9 @@ export function slugify(text: string): string {
  */
 export function parseQueueMinutes(text: string | null | undefined): number | null {
   if (text == null) return null;
-  const m = text.match(/\d+/);
+  const m = text.match(/(\d+)\s*min/i);
   if (!m) return null;
-  const n = Number(m[0]);
+  const n = Number(m[1]);
   return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
@@ -246,6 +361,21 @@ export function parseHourRange(text: string): {open: string; close: string} | nu
     open: `${to24h(m[1], m[3])}:${m[2]}`,
     close: `${to24h(m[4], m[6])}:${m[5]}`,
   };
+}
+
+/**
+ * Add `days` to a YYYY-MM-DD calendar date string via pure calendar
+ * arithmetic (Date.UTC normalises month/day overflow), with no dependency on
+ * the host process's local timezone. Deliberately not the shared
+ * addDays()+formatDate(tz) pattern used elsewhere in the codebase — that
+ * pattern steps the day-of-month in the *host's* local timezone before
+ * converting to the target timezone, which can misfire by a day around a
+ * host-timezone DST transition. Building 60 schedule dates makes that a much
+ * bigger surface here than a single-date adjustment.
+ */
+export function addDaysToDateString(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d + days)).toISOString().slice(0, 10);
 }
 
 /**
@@ -375,16 +505,39 @@ export class OceanParkHongKong extends Destination {
 
   // ── Parsed Accessors ──────────────────────────────────────────────────────
 
+  /**
+   * @cache here (matching fetchAttractionsPage's 60s TTL) avoids redoing the
+   * RSC bracket-scan + JSON.parse on every buildLiveData() poll when the
+   * underlying HTML is already an HTTP-layer cache hit.
+   *
+   * Returns the raw parsed list, not yet validated per-item — buildEntityList
+   * and buildLiveData each filter with isValidAttractionItem() at their own
+   * consumption point (matching the restaurant-item pattern below) so a
+   * malformed card can't crash either builder's .map()/loop.
+   */
+  @cache({ttlSeconds: 60})
   async getAttractionItems(): Promise<OceanParkAttractionItem[]> {
     const resp = await this.fetchAttractionsPage();
     const html = await resp.text();
-    return (extractRscArray(html, '"items":') as OceanParkAttractionItem[] | null) ?? [];
+    const items = extractRscArray(html, '"items":', firstItemHasKey('nodeId')) as OceanParkAttractionItem[] | null;
+    if (!items) {
+      console.warn('[OceanPark] attractions page RSC data not found; entity list and wait times will be empty this cycle');
+      return [];
+    }
+    return items;
   }
 
+  /** See getAttractionItems() — same caching/dropped-item rationale, restaurant items validated where they're flattened out of tabs in buildEntityList. */
+  @cache({ttlSeconds: 3600})
   async getDiningTabs(): Promise<OceanParkDiningTab[]> {
     const resp = await this.fetchDiningPage();
     const html = await resp.text();
-    return (extractRscArray(html, '"items":') as OceanParkDiningTab[] | null) ?? [];
+    const tabs = extractRscArray(html, '"items":', firstItemHasKey('tab')) as OceanParkDiningTab[] | null;
+    if (!tabs) {
+      console.warn('[OceanPark] dining page RSC data not found; restaurant list will be empty this cycle');
+      return [];
+    }
+    return tabs;
   }
 
   async getDailyScheduleItems(date: string): Promise<OceanParkScheduleItem[]> {
@@ -466,16 +619,25 @@ export class OceanParkHongKong extends Destination {
   protected async buildEntityList(): Promise<Entity[]> {
     const today = formatDate(new Date(), TIMEZONE);
 
+    // Four independent upstream sources (SSR attractions page, SSR dining
+    // page, the daily-schedule API route, and the map subdomain) — each
+    // isolated with its own .catch() so one flaky source degrades that
+    // category to empty rather than throwing away the whole entity list.
     const [attractionItems, diningTabs, scheduleItems, coordEntries] = await Promise.all([
-      this.getAttractionItems(),
-      this.getDiningTabs(),
-      this.getDailyScheduleItems(today),
-      // Coordinates are best-effort — a degenerate transform or unreachable
-      // map subdomain shouldn't take the whole entity list with it. Entities
-      // fall back to the destination's default lat/lng when this is empty.
+      this.getAttractionItems().catch((err: unknown) => {
+        console.warn(`[OceanPark] attractions fetch failed (${errMsg(err)}); no attractions this cycle`);
+        return [] as OceanParkAttractionItem[];
+      }),
+      this.getDiningTabs().catch((err: unknown) => {
+        console.warn(`[OceanPark] dining fetch failed (${errMsg(err)}); no restaurants this cycle`);
+        return [] as OceanParkDiningTab[];
+      }),
+      this.getDailyScheduleItems(today).catch((err: unknown) => {
+        console.warn(`[OceanPark] daily schedule fetch failed (${errMsg(err)}); no shows this cycle`);
+        return [] as OceanParkScheduleItem[];
+      }),
       this.getCoordinateMapEntries().catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn(`[OceanPark] coordinate map unavailable (${msg}); entities will use default location`);
+        console.warn(`[OceanPark] coordinate map unavailable (${errMsg(err)}); entities will use default location`);
         return [] as [string, {latitude: number; longitude: number}][];
       }),
     ]);
@@ -492,7 +654,7 @@ export class OceanParkHongKong extends Destination {
       location: {latitude: DEFAULT_LAT, longitude: DEFAULT_LNG},
     } as Entity;
 
-    const attractionEntities: Entity[] = attractionItems.map(item => {
+    const attractionEntities: Entity[] = attractionItems.filter(isValidAttractionItem).map(item => {
       const isTransport = (item.attractionTypes ?? []).some(t => t.id === 'in-park-transportation');
       const coords = coordMap.get(slugFromUrl(item.nodeUrl.url));
 
@@ -520,6 +682,11 @@ export class OceanParkHongKong extends Destination {
     const restaurantEntities: Entity[] = diningTabs
       .filter(tab => tab.tab?.id === 'restaurants')
       .flatMap(tab => tab.pageItems ?? [])
+      .filter(item => {
+        const ok = !!item?.nodeUrl?.url && !!item?.nodeUrl?.label;
+        if (!ok) console.warn(`[OceanPark] skipping malformed restaurant item: ${JSON.stringify(item).slice(0, 200)}`);
+        return ok;
+      })
       .map(item => {
         const slug = slugFromUrl(item.nodeUrl.url);
         const coords = coordMap.get(slug);
@@ -535,15 +702,15 @@ export class OceanParkHongKong extends Destination {
       });
 
     // Shows have no id/URL from the website at all — only a title, via the
-    // daily-schedule endpoint. Slugify for a stable, deterministic id and
-    // best-effort match it against the map's show slugs for coordinates.
-    const showTitles = [...new Set(scheduleItems.map(item => item.title))];
-    const showEntities: Entity[] = showTitles.map(title => {
-      const slug = slugify(title);
+    // daily-schedule endpoint. groupShowsBySlug() resolves slug collisions
+    // once, consistently with buildLiveData, and best-effort matches each
+    // slug against the map's show slugs for coordinates.
+    const showGroups = groupShowsBySlug(scheduleItems);
+    const showEntities: Entity[] = [...showGroups.entries()].map(([slug, group]) => {
       const coords = coordMap.get(slug);
       return {
         id: `show_${slug}`,
-        name: title,
+        name: group.title,
         entityType: 'SHOW',
         parentId: PARK_ID,
         destinationId: DESTINATION_ID,
@@ -560,14 +727,23 @@ export class OceanParkHongKong extends Destination {
   protected async buildLiveData(): Promise<LiveData[]> {
     const today = formatDate(new Date(), TIMEZONE);
 
+    // Two independent sources (SSR attractions page vs. the daily-schedule
+    // API route) — isolated so one going down doesn't wipe out live data
+    // that came from the other, healthy one.
     const [attractionItems, scheduleItems] = await Promise.all([
-      this.getAttractionItems(),
-      this.getDailyScheduleItems(today),
+      this.getAttractionItems().catch((err: unknown) => {
+        console.warn(`[OceanPark] attractions fetch failed (${errMsg(err)}); no attraction wait times this cycle`);
+        return [] as OceanParkAttractionItem[];
+      }),
+      this.getDailyScheduleItems(today).catch((err: unknown) => {
+        console.warn(`[OceanPark] daily schedule fetch failed (${errMsg(err)}); no show live data this cycle`);
+        return [] as OceanParkScheduleItem[];
+      }),
     ]);
 
     const liveData: LiveData[] = [];
 
-    for (const item of attractionItems) {
+    for (const item of attractionItems.filter(isValidAttractionItem)) {
       const wt = parseQueueMinutes(item.queueTime?.text);
 
       const ld: LiveData = {
@@ -584,24 +760,20 @@ export class OceanParkHongKong extends Destination {
       liveData.push(ld);
     }
 
-    // Shows — group today's programme entries by title and emit remaining
+    // Shows — group today's programme entries by slug (same grouping
+    // buildEntityList uses, so ids always agree) and emit remaining
     // showtimes. No explicit end time is published, only a start.
-    const byTitle = new Map<string, OceanParkScheduleItem[]>();
-    for (const item of scheduleItems) {
-      if (!byTitle.has(item.title)) byTitle.set(item.title, []);
-      byTitle.get(item.title)!.push(item);
-    }
-
+    const showGroups = groupShowsBySlug(scheduleItems);
     const now = Date.now();
-    for (const [title, entries] of byTitle) {
-      const showtimes = entries
+    for (const [slug, group] of showGroups) {
+      const showtimes = group.items
         .flatMap(entry => entry.timeSlot ?? [])
         .map(t => formatInTimezone(new Date(constructDateTime(today, t, TIMEZONE)), TIMEZONE, 'iso'))
         .filter(iso => new Date(iso).getTime() >= now)
         .map(iso => ({type: 'Performance Time', startTime: iso}));
 
       const ld: LiveData = {
-        id: `show_${slugify(title)}`,
+        id: `show_${slug}`,
         status: showtimes.length > 0 ? 'OPERATING' : 'CLOSED',
       } as LiveData;
       if (showtimes.length > 0) ld.showtimes = showtimes;
@@ -615,20 +787,53 @@ export class OceanParkHongKong extends Destination {
   // ── Schedules ─────────────────────────────────────────────────────────────
 
   protected async buildSchedules(): Promise<EntitySchedule[]> {
-    const dates = Array.from({length: SCHEDULE_DAYS}, (_, i) => formatDate(addDays(new Date(), i), TIMEZONE));
-    const hoursTexts = await Promise.all(dates.map(d => this.getParkOpeningHoursValue(d)));
+    const today = formatDate(new Date(), TIMEZONE);
+    const dates = Array.from({length: SCHEDULE_DAYS}, (_, i) => addDaysToDateString(today, i));
+
+    // Promise.allSettled, not Promise.all — 60 independent per-date
+    // requests means one transient failure (a single 5xx, a malformed
+    // response) must degrade to "one fewer day" rather than reject the
+    // entire schedule down to zero days.
+    const results = await Promise.allSettled(dates.map(d => this.getParkOpeningHoursValue(d)));
 
     const scheduleEntries: ScheduleEntry[] = [];
+    let failedCount = 0;
+
     for (let i = 0; i < dates.length; i++) {
-      const range = parseHourRange(hoursTexts[i] ?? '');
-      if (!range) continue; // no hours published for this date (closed, or beyond the published window)
+      const result = results[i];
+      if (result.status === 'rejected') {
+        failedCount++;
+        continue;
+      }
+
+      const hoursText = result.value;
+      const range = parseHourRange(hoursText ?? '');
+      if (!range) {
+        // Empty text means "closed / beyond the published window" — expected
+        // and not logged. Non-empty-but-unparseable means the site's hours
+        // format changed underneath us; that's worth a log line so it's not
+        // silently indistinguishable from a real closure.
+        if (hoursText) {
+          console.warn(`[OceanPark] unrecognised opening-hours text for ${dates[i]}: "${hoursText}"`);
+        }
+        continue;
+      }
+
+      // A close time numerically "before" the open time on a 24h clock (e.g.
+      // "6:00 pm - 12:30 am") means the park closes after midnight the
+      // following calendar day, not before it opened the same day.
+      const closeDate = range.close <= range.open ? addDaysToDateString(dates[i], 1) : dates[i];
 
       scheduleEntries.push({
         date: dates[i],
         type: 'OPERATING',
         openingTime: constructDateTime(dates[i], range.open, TIMEZONE),
-        closingTime: constructDateTime(dates[i], range.close, TIMEZONE),
+        closingTime: constructDateTime(closeDate, range.close, TIMEZONE),
       });
+    }
+
+    if (failedCount > 0) {
+      console.warn(`[OceanPark] ${failedCount}/${dates.length} schedule date requests failed; schedule may have gaps`);
     }
 
     return [{

--- a/src/parks/oceanpark/oceanpark.ts
+++ b/src/parks/oceanpark/oceanpark.ts
@@ -1,24 +1,35 @@
 /**
  * Ocean Park Hong Kong
  *
- * Single destination with one park. Attractions, shows, and dining are fetched
- * from a mobile API (sop.oceanpark.com.hk) that requires a short-lived bearer
- * token ("optoken") in each request header.
+ * The official mobile app (and its API at sop.oceanpark.com.hk) was suspended
+ * along with the app itself — every endpoint now returns a permanent 502 from
+ * Ocean Park's own gateway. All data is instead scraped from the public website
+ * (www.oceanpark.com.hk), which server-renders attraction/dining data —
+ * including live wait times — as an embedded React Server Component (RSC) JSON
+ * payload. No auth, no token, same page anyone gets in a browser.
  *
- * Coordinate data: The park app exposes a map at map.oceanpark.com.hk with
- * entity pixel positions. Reference points (pixel → lat/lng anchors) are
- * fetched and used to compute an affine transform so all entity coordinates
- * can be derived from their pixel positions.
+ * Entity IDs changed as a result: the app's numeric IDs don't exist in the
+ * website's data at all, so entities are keyed on the website's own stable
+ * identifiers (CMS node UUIDs for attractions, URL slugs elsewhere).
+ *
+ * Coordinate data: unchanged — map.oceanpark.com.hk still exposes pixel
+ * positions via reference_points.json + per-category JSON files. Each map
+ * entry now carries a `url` field pointing at the canonical website page, so
+ * entities are joined to coordinates by URL slug instead of the old numeric
+ * extEntityCode.
+ *
+ * Known gaps vs. the old app-based implementation (the website simply doesn't
+ * expose these): FastPass/paid-return-time flags, pregnancy/wet-ride warnings,
+ * and per-attraction "Summit closes early" special hours. Shopping and food
+ * kiosk locations are also left out — no entity-type precedent for them and
+ * the site gives them no numeric ID or UUID, only a title.
  */
 
-import crypto from 'crypto';
 import {Destination, DestinationConstructor} from '../../destination.js';
 import config from '../../config.js';
-import {cache} from '../../cache.js';
 import {http, HTTPObj} from '../../http.js';
-import {inject} from '../../injector.js';
 import {destinationController} from '../../destinationRegistry.js';
-import {hostnameFromUrl, formatInTimezone, formatDate} from '../../datetime.js';
+import {formatInTimezone, formatDate, addDays, constructDateTime} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 import type {Entity, LiveData, EntitySchedule, ScheduleEntry} from '@themeparks/typelib';
 import {AttractionTypeEnum} from '@themeparks/typelib';
@@ -31,92 +42,61 @@ const PARK_ID = 'oceanpark';
 const DEFAULT_LAT = 22.2465;
 const DEFAULT_LNG = 114.1748;
 
-/** Ocean Park entity sort IDs */
-const SORT_ID = {
-  TRANSPORT: 7,
-  RIDES: 8,
-  SHOWS: 15,
-  DINING: 17,
-} as const;
+/** The website reports "no restriction" as max height 300cm / min height 0cm. */
+const HEIGHT_NO_LIMIT_CM = 300;
 
 /** Map category slugs that contain entity pixel positions */
 const MAP_CATEGORIES = ['attractions', 'animals', 'dining', 'transportations', 'shows', 'shops'] as const;
 
-// ── API Interfaces ──────────────────────────────────────────────────────────
+/** How many days ahead to probe for published park hours. */
+const SCHEDULE_DAYS = 60;
 
-interface OceanParkTokenResponse {
-  data?: {
-    token?: string;
-    tokenExpire?: number; // Unix ms expiry
-  };
+// ── Website JSON shapes (embedded RSC payloads / Next.js API routes) ────────
+
+interface OceanParkNodeUrl {
+  label: string;
+  url: string;
 }
 
-interface OceanParkCondition {
-  conditionDesc?: string;
-  description?: string;
+interface OceanParkTag {
+  id?: string;
+  label?: string;
 }
 
-interface OceanParkOperatingHour {
-  openDate: string; // 'YYYY-MM-DD'
-  openTime?: number; // Unix ms
-  closeTime?: number; // Unix ms
+interface OceanParkQueueTime {
+  text?: string | null;
 }
 
-interface OceanParkPflowInfo {
-  entityStatus?: string; // 'open' | 'close' | etc.
-  entityWaitTime?: number | null;
-  operatingHourList?: OceanParkOperatingHour[];
+/** An attraction card from the /attractions listing page. */
+interface OceanParkAttractionItem {
+  nodeId: string;
+  nodeUrl: OceanParkNodeUrl;
+  attractionTypes?: OceanParkTag[];
+  height?: {min?: number; max?: number};
+  queueTime?: OceanParkQueueTime | null;
 }
 
-interface OceanParkEntity {
-  id: number;
-  name: string;
-  typeId?: number;
-  extEntityCode?: string | number;
-  conditionList?: Array<string | OceanParkCondition>;
-  raFacilityType?: string;
-  pflowInfo?: OceanParkPflowInfo;
+/** A restaurant card from the "Restaurants" tab's pageItems. */
+interface OceanParkRestaurantItem {
+  nodeUrl: OceanParkNodeUrl;
 }
 
-interface OceanParkEntityListResponse {
-  data?: {
-    data?: OceanParkEntity[];
-  };
+interface OceanParkDiningTab {
+  tab: {id: string; label: string};
+  pageItems?: OceanParkRestaurantItem[];
 }
 
-interface OceanParkTimeSlot {
-  startTime: number; // Unix ms
-  endTime: number; // Unix ms
+interface OceanParkScheduleItem {
+  title: string;
+  timeSlot?: string[];
 }
 
-interface OceanParkActivity {
-  timeList?: OceanParkTimeSlot[];
+interface OceanParkDailyScheduleResponse {
+  items?: OceanParkScheduleItem[];
 }
 
-interface OceanParkEntityDetail {
-  relateList?: Array<{type: string; [key: string]: unknown}>;
-  activityList?: OceanParkActivity[];
-}
-
-interface OceanParkEntityDetailResponse {
-  data?: OceanParkEntityDetail;
-}
-
-interface OceanParkParkDay {
-  openDate: string; // 'YYYY-MM-DD'
-  parkStatus: string; // 'open' | 'close' | etc.
-  parkOpenTime?: string; // Unix ms as string
-  parkCloseTime?: string; // Unix ms as string
-  parkingOpenTime?: string;
-  parkingCloseTime?: string;
-  summitStaus?: string; // Note: typo in API
-  summitCloseTime?: string;
-}
-
-interface OceanParkScheduleResponse {
-  data?: {
-    parkOperatingHourList?: OceanParkParkDay[];
-  };
+interface OceanParkParkOpeningHoursResponse {
+  parkOpeningHoursValue?: string;
 }
 
 interface OceanParkReferencePoint {
@@ -127,7 +107,7 @@ interface OceanParkReferencePoint {
 }
 
 interface OceanParkMapEntity {
-  api_key?: string | number;
+  url?: string;
   x?: number;
   y?: number;
 }
@@ -140,11 +120,140 @@ interface AffineCoeffs {
 // ── Pure Functions ──────────────────────────────────────────────────────────
 
 /**
+ * Find the balanced closing bracket matching `str[openIdx]`, honouring JSON
+ * string quoting so brackets inside string literals (e.g. `[`/`]` in prose)
+ * don't throw off the count.
+ */
+export function findMatchingBracket(str: string, openIdx: number, openChar: string, closeChar: string): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = openIdx; i < str.length; i++) {
+    const c = str[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (c === '\\') escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') { inString = true; continue; }
+    if (c === openChar) depth++;
+    else if (c === closeChar) {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+/** Locate `"marker":[...]` in `text` and parse the array. */
+export function findJsonArray(text: string, marker: string): unknown[] | null {
+  const markerIdx = text.indexOf(marker);
+  if (markerIdx === -1) return null;
+  let i = markerIdx + marker.length;
+  while (text[i] === ' ') i++;
+  if (text[i] !== '[') return null;
+  const end = findMatchingBracket(text, i, '[', ']');
+  if (end === -1) return null;
+  try {
+    return JSON.parse(text.slice(i, end)) as unknown[];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract a JSON array embedded in a Next.js React Server Component "flight"
+ * payload: `self.__next_f.push([1,"...escaped string..."])`.
+ *
+ * The push() argument is itself valid JSON — `[1, "<escaped string>"]` — so
+ * parsing it directly yields a correctly unescaped inner string (quotes,
+ * unicode, etc. all handled by JSON.parse) rather than hand-rolled backslash
+ * stripping. `marker` (e.g. `"items":`) then locates the target array within
+ * that unescaped string.
+ */
+export function extractRscArray(html: string, marker: string): unknown[] | null {
+  const pushToken = 'self.__next_f.push(';
+  let searchFrom = 0;
+
+  for (;;) {
+    const pushIdx = html.indexOf(pushToken, searchFrom);
+    if (pushIdx === -1) return null;
+    const argStart = pushIdx + pushToken.length;
+
+    if (html[argStart] !== '[') { searchFrom = argStart + 1; continue; }
+    const argEnd = findMatchingBracket(html, argStart, '[', ']');
+    if (argEnd === -1) { searchFrom = argStart + 1; continue; }
+    searchFrom = argEnd;
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(html.slice(argStart, argEnd));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(payload) || typeof payload[1] !== 'string') continue;
+
+    const arr = findJsonArray(payload[1], marker);
+    if (arr) return arr;
+  }
+}
+
+/** Last non-empty path segment of a URL — Ocean Park's canonical entity slug. */
+export function slugFromUrl(url: string): string {
+  const parts = url.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? '';
+}
+
+/** Deterministic slug for entities the website gives no id/URL for (shows). */
+export function slugify(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Parse "10 mins" / " 0  mins" style queue text into minutes.
+ * Returns null for missing/unparseable text — the website uses an explicit
+ * `null` queueTime for attractions with no queue mechanic (walkthroughs,
+ * animal exhibits), which we can't distinguish from "currently closed"
+ * without a live signal, so both cases fall through to null here.
+ */
+export function parseQueueMinutes(text: string | null | undefined): number | null {
+  if (text == null) return null;
+  const m = text.match(/\d+/);
+  if (!m) return null;
+  const n = Number(m[0]);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/** Parse a "10:00 am - 7:00 pm" style range into 24h HH:mm strings. */
+export function parseHourRange(text: string): {open: string; close: string} | null {
+  const m = text.match(/(\d{1,2}):(\d{2})\s*([ap]m)\s*-\s*(\d{1,2}):(\d{2})\s*([ap]m)/i);
+  if (!m) return null;
+
+  const to24h = (hourStr: string, ampm: string): string => {
+    let hour = parseInt(hourStr, 10) % 12;
+    if (ampm.toLowerCase() === 'pm') hour += 12;
+    return String(hour).padStart(2, '0');
+  };
+
+  return {
+    open: `${to24h(m[1], m[3])}:${m[2]}`,
+    close: `${to24h(m[4], m[6])}:${m[5]}`,
+  };
+}
+
+/**
  * Compute affine transform coefficients from a set of reference points.
  * Solves lat = a*x + b*y + c and lng = d*x + e*y + f using least-squares
  * normal equations (Cramer's rule on the 3×3 system).
  */
-function computeAffineTransform(refPoints: OceanParkReferencePoint[]): AffineCoeffs | null {
+export function computeAffineTransform(refPoints: OceanParkReferencePoint[]): AffineCoeffs | null {
   let sumX = 0, sumY = 0, sumXX = 0, sumXY = 0, sumYY = 0;
   let sumLat = 0, sumXLat = 0, sumYLat = 0;
   let sumLng = 0, sumXLng = 0, sumYLng = 0;
@@ -184,34 +293,12 @@ function computeAffineTransform(refPoints: OceanParkReferencePoint[]): AffineCoe
   return {a, b, c, d, e, f};
 }
 
-/**
- * Parse height restriction values from a conditionList.
- * Supports patterns: "Height: 140cm" (min) and "Between 100cm and 140cm" (max).
- */
-function parseHeightTag(conditionList: Array<string | OceanParkCondition>): {min: number | null; max: number | null} {
-  let min: number | null = null;
-  let max: number | null = null;
-
-  for (const cond of conditionList) {
-    const text = typeof cond === 'string' ? cond : (cond.conditionDesc ?? cond.description ?? '');
-
-    const minMatch = text.match(/Height:\s*(\d+)\s*cm/i);
-    if (minMatch) min = parseInt(minMatch[1], 10);
-
-    const maxMatch = text.match(/Between\s*\d+\s*cm.*?and\s*(\d+)\s*cm/i);
-    if (maxMatch) max = parseInt(maxMatch[1], 10);
-  }
-
-  return {min, max};
-}
-
 // ── Implementation ──────────────────────────────────────────────────────────
 
 @destinationController({category: 'Ocean Park'})
 export class OceanParkHongKong extends Destination {
   @config baseURL: string = '';
   @config mapURL: string = '';
-  @config parkId: number = 1;
 
   timezone = TIMEZONE;
 
@@ -224,125 +311,45 @@ export class OceanParkHongKong extends Destination {
     return 'oceanpark';
   }
 
-  // ── Initialisation ────────────────────────────────────────────────────────
-
-  /** Pre-warm the token cache before entity/live data calls fire in parallel. */
-  protected async _init(): Promise<void> {
-    await this.getToken();
-  }
-
-  // ── Authentication ────────────────────────────────────────────────────────
-
-  /**
-   * Stable device UUID — generated once, persisted in SQLite for 3 months.
-   * Ocean Park's API uses this to associate tokens with a logical device.
-   */
-  @cache({ttlSeconds: 60 * 60 * 24 * 90})
-  async getDeviceId(): Promise<string> {
-    return crypto.randomUUID();
-  }
-
-  /** Raw HTTP call to the token endpoint — tagged 'auth' to exclude from injection. */
-  // `tags` isn't in the @http decorator's option type yet but flows through
-  // to the request object — cast is the localised escape.
-  @http({tags: ['auth']} as any)
-  async fetchToken(): Promise<HTTPObj> {
-    const deviceId = await this.getDeviceId();
-    return {
-      method: 'POST',
-      url: `${this.baseURL}/api/common/user/token`,
-      body: JSON.stringify({pId: this.parkId, lang: 'en', deviceId}),
-      headers: {'content-type': 'application/json'},
-      options: {json: false},
-      tags: ['auth'],
-    } as any as HTTPObj;
-  }
-
-  /**
-   * Auth token with dynamic TTL.
-   * Returns an object with `token` + `ttl` so @cache can read the expiry.
-   * Use getToken() to obtain just the token string.
-   */
-  @cache({callback: (result: {token: string; ttl: number}) => result.ttl})
-  async getTokenData(): Promise<{token: string; ttl: number}> {
-    const resp = await this.fetchToken();
-    const body: OceanParkTokenResponse = await resp.json();
-    const token = body?.data?.token;
-    const tokenExpire = body?.data?.tokenExpire;
-
-    if (!token) throw new Error('OceanPark: failed to obtain auth token');
-
-    const ttl = tokenExpire
-      ? Math.max((tokenExpire - Date.now()) / 1000, 60)
-      : 60 * 60 * 23;
-
-    return {token, ttl};
-  }
-
-  /** Returns the current valid auth token. */
-  async getToken(): Promise<string> {
-    return (await this.getTokenData()).token;
-  }
-
-  /**
-   * Inject the optoken header into every request to the main API domain,
-   * except for the token endpoint itself (excluded via tags filter).
-   */
-  @inject({
-    eventName: 'httpRequest',
-    hostname: function(this: OceanParkHongKong) { return hostnameFromUrl(this.baseURL); },
-    tags: {$nin: ['auth']},
-  })
-  async injectToken(req: HTTPObj): Promise<void> {
-    const token = await this.getToken();
-    req.headers = {
-      ...req.headers,
-      'optoken': token,
-      'content-type': 'application/json',
-    };
-  }
-
   // ── HTTP Fetch Methods ────────────────────────────────────────────────────
 
-  /**
-   * Fetch the entity list for a given sortId.
-   * sortId 7 = transport, 8 = rides, 15 = shows, 17 = dining.
-   * Short cache (60s) since this also carries live wait-time data.
-   */
+  /** SSR attractions listing — embeds live queue times. Short cache since wait times refresh often. */
   @http({cacheSeconds: 60})
-  async fetchEntityList(sortId: number): Promise<HTTPObj> {
+  async fetchAttractionsPage(): Promise<HTTPObj> {
     return {
-      method: 'POST',
-      url: `${this.baseURL}/api/common/entity/list`,
-      body: JSON.stringify({pId: this.parkId, lang: 'en', sortId}),
+      method: 'GET',
+      url: `${this.baseURL}/en/a-day-at-the-park/attractions`,
       options: {json: false},
     } as any as HTTPObj;
   }
 
-  /**
-   * Fetch detailed info for a single entity (FastPass links, show schedule).
-   * Long cache (1h) since this data changes infrequently.
-   */
+  /** SSR dining/shopping listing (Restaurants / Food Kiosks / Shopping tabs). Static-ish, long cache. */
   @http({cacheSeconds: 3600})
-  async fetchEntityDetail(entityId: number): Promise<HTTPObj> {
+  async fetchDiningPage(): Promise<HTTPObj> {
     return {
-      method: 'POST',
-      url: `${this.baseURL}/api/common/entity/detail`,
-      body: JSON.stringify({pId: this.parkId, lang: 'en', entityId}),
+      method: 'GET',
+      url: `${this.baseURL}/en/a-day-at-the-park/dining-shopping/restaurants`,
       options: {json: false},
     } as any as HTTPObj;
   }
 
-  /** Fetch 30-day park operating schedule. Refreshed every hour. */
-  @http({cacheSeconds: 3600})
-  async fetchParkSchedule(): Promise<HTTPObj> {
-    const today = formatDate(new Date(), TIMEZONE);
-    const end = formatDate(new Date(Date.now() + 30 * 24 * 3600 * 1000), TIMEZONE);
+  /** Today's stage/animal programme times. Same-origin Next.js API route, no auth. */
+  @http({cacheSeconds: 1800})
+  async fetchDailySchedule(date: string): Promise<HTTPObj> {
     return {
-      method: 'POST',
-      url: `${this.baseURL}/api/common/park/list`,
-      body: JSON.stringify({pId: this.parkId, lang: 'en', startDate: today, endDate: end}),
-      options: {json: false},
+      method: 'GET',
+      url: `${this.baseURL}/api/main/daily-schedule?date=${encodeURIComponent(date)}`,
+      options: {json: true},
+    } as any as HTTPObj;
+  }
+
+  /** Park open/close hours for a single date, as free text (e.g. "10:00 am - 7:00 pm"). */
+  @http({cacheSeconds: 3600})
+  async fetchParkOpeningHours(date: string): Promise<HTTPObj> {
+    return {
+      method: 'GET',
+      url: `${this.baseURL}/api/main/park-opening-hours?date=${encodeURIComponent(date)}`,
+      options: {json: true},
     } as any as HTTPObj;
   }
 
@@ -367,33 +374,33 @@ export class OceanParkHongKong extends Destination {
   }
 
   // ── Parsed Accessors ──────────────────────────────────────────────────────
-  //
-  // No @cache wrapper here — the underlying @http fetcher already caches the
-  // raw response at the same TTL. Adding @cache on top would just double-write
-  // the parsed payload to SQLite. Failures still propagate from the fetch
-  // layer, so a transient bad upstream doesn't poison a parsed-empty result
-  // into the cache for a full TTL.
 
-  async getEntityList(sortId: number): Promise<OceanParkEntity[]> {
-    const resp = await this.fetchEntityList(sortId);
-    const body: OceanParkEntityListResponse = await resp.json();
-    return body?.data?.data ?? [];
+  async getAttractionItems(): Promise<OceanParkAttractionItem[]> {
+    const resp = await this.fetchAttractionsPage();
+    const html = await resp.text();
+    return (extractRscArray(html, '"items":') as OceanParkAttractionItem[] | null) ?? [];
   }
 
-  async getEntityDetail(entityId: number): Promise<OceanParkEntityDetail> {
-    const resp = await this.fetchEntityDetail(entityId);
-    const body: OceanParkEntityDetailResponse = await resp.json();
-    return body?.data ?? {};
+  async getDiningTabs(): Promise<OceanParkDiningTab[]> {
+    const resp = await this.fetchDiningPage();
+    const html = await resp.text();
+    return (extractRscArray(html, '"items":') as OceanParkDiningTab[] | null) ?? [];
   }
 
-  async getParkSchedule(): Promise<OceanParkParkDay[]> {
-    const resp = await this.fetchParkSchedule();
-    const body: OceanParkScheduleResponse = await resp.json();
-    return body?.data?.parkOperatingHourList ?? [];
+  async getDailyScheduleItems(date: string): Promise<OceanParkScheduleItem[]> {
+    const resp = await this.fetchDailySchedule(date);
+    const body: OceanParkDailyScheduleResponse = await resp.json();
+    return body?.items ?? [];
+  }
+
+  async getParkOpeningHoursValue(date: string): Promise<string | null> {
+    const resp = await this.fetchParkOpeningHours(date);
+    const body: OceanParkParkOpeningHoursResponse = await resp.json();
+    return body?.parkOpeningHoursValue ?? null;
   }
 
   /**
-   * Build a serialisable map from api_key → {latitude, longitude} by:
+   * Build a serialisable map from URL slug → {latitude, longitude} by:
    * 1. Fetching reference points and computing an affine pixel→geo transform.
    * 2. Fetching each map category and projecting each entity's pixel position.
    *
@@ -427,9 +434,9 @@ export class OceanParkHongKong extends Destination {
       if (!Array.isArray(entities)) continue;
 
       for (const e of entities) {
-        if (e.api_key != null && e.x != null && e.y != null) {
+        if (e.url && e.x != null && e.y != null) {
           entries.push([
-            String(e.api_key),
+            slugFromUrl(e.url),
             {
               latitude:  coeffs.a * e.x + coeffs.b * e.y + coeffs.c,
               longitude: coeffs.d * e.x + coeffs.e * e.y + coeffs.f,
@@ -457,11 +464,12 @@ export class OceanParkHongKong extends Destination {
   // ── Entity List ───────────────────────────────────────────────────────────
 
   protected async buildEntityList(): Promise<Entity[]> {
-    const [rides, transport, shows, dining, coordEntries] = await Promise.all([
-      this.getEntityList(SORT_ID.RIDES),
-      this.getEntityList(SORT_ID.TRANSPORT),
-      this.getEntityList(SORT_ID.SHOWS),
-      this.getEntityList(SORT_ID.DINING),
+    const today = formatDate(new Date(), TIMEZONE);
+
+    const [attractionItems, diningTabs, scheduleItems, coordEntries] = await Promise.all([
+      this.getAttractionItems(),
+      this.getDiningTabs(),
+      this.getDailyScheduleItems(today),
       // Coordinates are best-effort — a degenerate transform or unreachable
       // map subdomain shouldn't take the whole entity list with it. Entities
       // fall back to the destination's default lat/lng when this is empty.
@@ -484,45 +492,19 @@ export class OceanParkHongKong extends Destination {
       location: {latitude: DEFAULT_LAT, longitude: DEFAULT_LNG},
     } as Entity;
 
-    // Fetch details for rides + transport to check for FastPass (relateList)
-    const attractions = [...rides, ...transport];
-    const details = await Promise.all(
-      attractions.map(e => this.getEntityDetail(e.id).catch(() => ({} as OceanParkEntityDetail))),
-    );
+    const attractionEntities: Entity[] = attractionItems.map(item => {
+      const isTransport = (item.attractionTypes ?? []).some(t => t.id === 'in-park-transportation');
+      const coords = coordMap.get(slugFromUrl(item.nodeUrl.url));
 
-    const attractionEntities: Entity[] = attractions.map((entity, i) => {
-      // Source of truth for transport-vs-ride is the list this entity came
-      // from, not `entity.typeId` (which is optional and uses a different
-      // ID space than SORT_ID). Everything past `rides.length` came from
-      // the transport list.
-      const isTransport = i >= rides.length;
-      const coords = coordMap.get(String(entity.extEntityCode));
-      const detail = details[i];
       const tags = [];
-
-      // Coordinates already live on `entity.location` below — don't also
-      // push a TagBuilder.location() tag (per TagBuilder docs, that helper
-      // is for sub-locations distinct from the entity's own location).
-      const conditionList = entity.conditionList ?? [];
-      const {min, max} = parseHeightTag(conditionList);
-      if (min !== null) tags.push(TagBuilder.minimumHeight(min, 'cm'));
-      if (max !== null) tags.push(TagBuilder.maximumHeight(max, 'cm'));
-
-      const hasPregnantWarning = conditionList.some(c => {
-        const text = typeof c === 'string' ? c : (c.conditionDesc ?? c.description ?? '');
-        return /pregnant/i.test(text);
-      });
-      if (hasPregnantWarning) tags.push(TagBuilder.unsuitableForPregnantPeople());
-
-      if (entity.raFacilityType === 'Wet Rides') tags.push(TagBuilder.mayGetWet());
-
-      const hasFastPass = Array.isArray(detail?.relateList) &&
-        detail.relateList.some(r => r.type === 'ticket');
-      if (hasFastPass) tags.push(TagBuilder.paidReturnTime());
+      const minHeight = item.height?.min ?? 0;
+      const maxHeight = item.height?.max ?? HEIGHT_NO_LIMIT_CM;
+      if (minHeight > 0) tags.push(TagBuilder.minimumHeight(minHeight, 'cm'));
+      if (maxHeight < HEIGHT_NO_LIMIT_CM) tags.push(TagBuilder.maximumHeight(maxHeight, 'cm'));
 
       const built: Entity = {
-        id: `attraction_${entity.id}`,
-        name: entity.name,
+        id: `attraction_${item.nodeId}`,
+        name: item.nodeUrl.label,
         entityType: 'ATTRACTION',
         attractionType: isTransport ? AttractionTypeEnum.TRANSPORT : AttractionTypeEnum.RIDE,
         parentId: PARK_ID,
@@ -535,11 +517,33 @@ export class OceanParkHongKong extends Destination {
       return built;
     });
 
-    const showEntities: Entity[] = shows.map(entity => {
-      const coords = coordMap.get(String(entity.extEntityCode));
+    const restaurantEntities: Entity[] = diningTabs
+      .filter(tab => tab.tab?.id === 'restaurants')
+      .flatMap(tab => tab.pageItems ?? [])
+      .map(item => {
+        const slug = slugFromUrl(item.nodeUrl.url);
+        const coords = coordMap.get(slug);
+        return {
+          id: `restaurant_${slug}`,
+          name: item.nodeUrl.label,
+          entityType: 'RESTAURANT',
+          parentId: PARK_ID,
+          destinationId: DESTINATION_ID,
+          timezone: TIMEZONE,
+          location: coords ?? {latitude: DEFAULT_LAT, longitude: DEFAULT_LNG},
+        } as Entity;
+      });
+
+    // Shows have no id/URL from the website at all — only a title, via the
+    // daily-schedule endpoint. Slugify for a stable, deterministic id and
+    // best-effort match it against the map's show slugs for coordinates.
+    const showTitles = [...new Set(scheduleItems.map(item => item.title))];
+    const showEntities: Entity[] = showTitles.map(title => {
+      const slug = slugify(title);
+      const coords = coordMap.get(slug);
       return {
-        id: `show_${entity.id}`,
-        name: entity.name,
+        id: `show_${slug}`,
+        name: title,
         entityType: 'SHOW',
         parentId: PARK_ID,
         destinationId: DESTINATION_ID,
@@ -548,20 +552,7 @@ export class OceanParkHongKong extends Destination {
       } as Entity;
     });
 
-    const restaurantEntities: Entity[] = dining.map(entity => {
-      const coords = coordMap.get(String(entity.extEntityCode));
-      return {
-        id: `restaurant_${entity.id}`,
-        name: entity.name,
-        entityType: 'RESTAURANT',
-        parentId: PARK_ID,
-        destinationId: DESTINATION_ID,
-        timezone: TIMEZONE,
-        location: coords ?? {latitude: DEFAULT_LAT, longitude: DEFAULT_LNG},
-      } as Entity;
-    });
-
-    return [park, ...attractionEntities, ...showEntities, ...restaurantEntities];
+    return [park, ...attractionEntities, ...restaurantEntities, ...showEntities];
   }
 
   // ── Live Data ─────────────────────────────────────────────────────────────
@@ -569,88 +560,50 @@ export class OceanParkHongKong extends Destination {
   protected async buildLiveData(): Promise<LiveData[]> {
     const today = formatDate(new Date(), TIMEZONE);
 
-    const [rides, transport, shows] = await Promise.all([
-      this.getEntityList(SORT_ID.RIDES),
-      this.getEntityList(SORT_ID.TRANSPORT),
-      this.getEntityList(SORT_ID.SHOWS),
+    const [attractionItems, scheduleItems] = await Promise.all([
+      this.getAttractionItems(),
+      this.getDailyScheduleItems(today),
     ]);
 
     const liveData: LiveData[] = [];
 
-    // Rides and transport — include wait time and today's operating hours when open
-    for (const entity of [...rides, ...transport]) {
-      const pflow = entity.pflowInfo ?? {};
-      const isOpen = pflow.entityStatus === 'open';
-
-      // The Ocean Park API uses entityWaitTime = -1 as a sentinel for
-      // "no live measurement available" (observed for the whole roster at
-      // park-closed hours, even with entityStatus = "open"). Without a
-      // live signal we can't credibly claim the ride is operating, so gate
-      // OPERATING on a finite, non-negative wait. Missing/null entries get
-      // the same treatment — same downstream impact.
-      //
-      // Coerce explicitly: Number(null) is 0, which would silently emit a
-      // "0 min wait" rather than falling through to CLOSED.
-      const raw = pflow.entityWaitTime as number | string | null | undefined;
-      const wt = raw == null || raw === '' ? NaN : Number(raw);
-      const hasLiveWait = Number.isFinite(wt) && wt >= 0;
+    for (const item of attractionItems) {
+      const wt = parseQueueMinutes(item.queueTime?.text);
 
       const ld: LiveData = {
-        id: `attraction_${entity.id}`,
-        status: isOpen && hasLiveWait ? 'OPERATING' : 'CLOSED',
+        id: `attraction_${item.nodeId}`,
+        // The website gives no explicit open/closed flag — queueTime is the
+        // only live signal. No signal (null) means either "no queue
+        // mechanic" or "currently closed" and we can't tell which, so it
+        // falls through to CLOSED rather than fabricating an OPERATING
+        // status with no evidence behind it.
+        status: wt !== null ? 'OPERATING' : 'CLOSED',
       } as LiveData;
 
-      if (ld.status === 'OPERATING') {
-        ld.queue = {STANDBY: {waitTime: wt}};
-      }
-
-      const todayHours = (pflow.operatingHourList ?? []).find(
-        h => h.openDate === today && h.openTime && h.closeTime,
-      );
-      if (todayHours) {
-        ld.operatingHours = [{
-          // 'OPERATING' (uppercase) matches every other park's emission and
-          // any downstream string matchers. 'iso' format keeps the +08:00
-          // offset consistent with buildSchedules below.
-          type: 'OPERATING',
-          startTime: formatInTimezone(new Date(todayHours.openTime!), TIMEZONE, 'iso'),
-          endTime: formatInTimezone(new Date(todayHours.closeTime!), TIMEZONE, 'iso'),
-        }];
-      }
-
+      if (wt !== null) ld.queue = {STANDBY: {waitTime: wt}};
       liveData.push(ld);
     }
 
-    // Shows — include showtimes from entity detail activityList
-    const showDetails = await Promise.all(
-      shows.map(e => this.getEntityDetail(e.id).catch(() => ({} as OceanParkEntityDetail))),
-    );
+    // Shows — group today's programme entries by title and emit remaining
+    // showtimes. No explicit end time is published, only a start.
+    const byTitle = new Map<string, OceanParkScheduleItem[]>();
+    for (const item of scheduleItems) {
+      if (!byTitle.has(item.title)) byTitle.set(item.title, []);
+      byTitle.get(item.title)!.push(item);
+    }
 
     const now = Date.now();
-    for (let i = 0; i < shows.length; i++) {
-      const entity = shows[i];
-      const isOpen = entity.pflowInfo?.entityStatus === 'open';
-      const detail = showDetails[i];
-
-      // Filter out performances that have already ended today — a guest at
-      // 3pm shouldn't see this morning's 11am show listed as upcoming.
-      // Project timestamps via formatInTimezone so the emitted ISO strings
-      // carry the +08:00 offset (matches buildSchedules).
-      const showtimes = (detail.activityList ?? []).flatMap(activity =>
-        (activity.timeList ?? [])
-          .filter(t => Number.isFinite(t.startTime) && Number.isFinite(t.endTime) && t.endTime >= now)
-          .map(t => ({
-            type: 'Performance Time',
-            startTime: formatInTimezone(new Date(t.startTime), TIMEZONE, 'iso'),
-            endTime: formatInTimezone(new Date(t.endTime), TIMEZONE, 'iso'),
-          })),
-      );
+    for (const [title, entries] of byTitle) {
+      const showtimes = entries
+        .flatMap(entry => entry.timeSlot ?? [])
+        .map(t => formatInTimezone(new Date(constructDateTime(today, t, TIMEZONE)), TIMEZONE, 'iso'))
+        .filter(iso => new Date(iso).getTime() >= now)
+        .map(iso => ({type: 'Performance Time', startTime: iso}));
 
       const ld: LiveData = {
-        id: `show_${entity.id}`,
-        status: isOpen ? 'OPERATING' : 'CLOSED',
+        id: `show_${slugify(title)}`,
+        status: showtimes.length > 0 ? 'OPERATING' : 'CLOSED',
       } as LiveData;
-
       if (showtimes.length > 0) ld.showtimes = showtimes;
 
       liveData.push(ld);
@@ -662,62 +615,20 @@ export class OceanParkHongKong extends Destination {
   // ── Schedules ─────────────────────────────────────────────────────────────
 
   protected async buildSchedules(): Promise<EntitySchedule[]> {
-    const parkDays = await this.getParkSchedule();
+    const dates = Array.from({length: SCHEDULE_DAYS}, (_, i) => formatDate(addDays(new Date(), i), TIMEZONE));
+    const hoursTexts = await Promise.all(dates.map(d => this.getParkOpeningHoursValue(d)));
+
     const scheduleEntries: ScheduleEntry[] = [];
-
-    /** Parse a Unix-ms timestamp string to a Date, rejecting non-finite values. */
-    const parseTs = (v: string | number | undefined | null): Date | null => {
-      if (v === null || v === undefined || v === '') return null;
-      const n = Number(v);
-      return Number.isFinite(n) ? new Date(n) : null;
-    };
-
-    for (const day of parkDays) {
-      if (day.parkStatus !== 'open') continue;
-
-      const open = parseTs(day.parkOpenTime);
-      const close = parseTs(day.parkCloseTime);
-      if (!open || !close) continue;
+    for (let i = 0; i < dates.length; i++) {
+      const range = parseHourRange(hoursTexts[i] ?? '');
+      if (!range) continue; // no hours published for this date (closed, or beyond the published window)
 
       scheduleEntries.push({
-        date: day.openDate,
+        date: dates[i],
         type: 'OPERATING',
-        openingTime: formatInTimezone(open, TIMEZONE, 'iso'),
-        closingTime: formatInTimezone(close, TIMEZONE, 'iso'),
+        openingTime: constructDateTime(dates[i], range.open, TIMEZONE),
+        closingTime: constructDateTime(dates[i], range.close, TIMEZONE),
       });
-
-      const parkingOpen = parseTs(day.parkingOpenTime);
-      const parkingClose = parseTs(day.parkingCloseTime);
-      if (parkingOpen && parkingClose) {
-        scheduleEntries.push({
-          date: day.openDate,
-          type: 'INFO',
-          description: 'Parking',
-          openingTime: formatInTimezone(parkingOpen, TIMEZONE, 'iso'),
-          closingTime: formatInTimezone(parkingClose, TIMEZONE, 'iso'),
-        });
-      }
-
-      // The Summit zone closes earlier than the main park on some days.
-      // API has `summitStaus` (sic — upstream typo); also accept `summitStatus`
-      // defensively in case it's ever corrected. There's no `summitOpenTime`
-      // in the payload, so we assume Summit opens with the main park —
-      // documented as part of the description so downstream consumers know.
-      const summitStatus = day.summitStaus ?? (day as {summitStatus?: string}).summitStatus;
-      const summitClose = parseTs(day.summitCloseTime);
-      if (
-        summitStatus === 'open' &&
-        summitClose &&
-        summitClose.getTime() < close.getTime()
-      ) {
-        scheduleEntries.push({
-          date: day.openDate,
-          type: 'INFO',
-          description: 'The Summit (closes earlier than the rest of the park)',
-          openingTime: formatInTimezone(open, TIMEZONE, 'iso'),
-          closingTime: formatInTimezone(summitClose, TIMEZONE, 'iso'),
-        });
-      }
     }
 
     return [{


### PR DESCRIPTION
## Summary
- Ocean Park's mobile app (and its API at sop.oceanpark.com.hk) has been suspended — every endpoint now returns a permanent 502 from Ocean Park's own gateway, which is why entities/live-data/schedules had been stale for about a week.
- Rebuilt the destination against the public website (www.oceanpark.com.hk), which server-renders the same data — including live per-attraction wait times — as an embedded React Server Component JSON payload. No auth required.
- Entity IDs changed: attractions are now keyed on the website's own node UUID, restaurants/shows on a URL/title slug, since the app's numeric IDs don't exist in this data source at all. Coordinates still come from map.oceanpark.com.hk, now joined by URL slug instead of the old numeric id.
- Known gaps vs. the old implementation (the website doesn't expose these): FastPass/paid-return-time flags, pregnancy/wet-ride warnings, per-attraction "Summit closes early" special hours, and shopping/food-kiosk locations (no stable id in the source data).

## Test plan
- [x] `npm run build` — clean typecheck
- [x] `npm test` — full suite green (1292 tests, including 43 new Ocean Park unit tests covering the RSC-JSON extractor, slug/queue/hour-range parsers, and the entity/live-data/schedule builders)
- [x] `npm run dev -- oceanparkhongkong` — live run against the real website: 71 entities (43 attractions, 8 restaurants, 18 shows), 61 live data entries (32 with real wait times), 56-day schedule

## Follow-up (blocking, needs Jamie)
Entity IDs changed for this destination. Per the migration workflow, this needs `npm run migrate -- oceanparkhongkong` run and confirmed before merging/enabling, plus `npm run migrate:audit` for the DESTINATION externalId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)