### PR TITLE
fix(gentingskyworlds): configurable auth header for the token service

### DIFF
--- a/src/parks/genting/__tests__/gentingskyworlds.test.ts
+++ b/src/parks/genting/__tests__/gentingskyworlds.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GentingSkyworlds } from '../gentingskyworlds.js';
+import { CacheLib } from '../../../cache.js';
+
+/**
+ * The VQ bearer is fetched from an external token service. Some services expect
+ * the credential in a header other than `Authorization`, so `tokenAuthHeader`
+ * makes the header name configurable (default `Authorization`, backward-compat).
+ */
+describe('GentingSkyworlds.getAccessToken — token-service credential header', () => {
+    const ENV_KEYS = [
+        'GENTINGSKYWORLDS_TOKENURL',
+        'GENTINGSKYWORLDS_TOKENAUTH',
+        'GENTINGSKYWORLDS_TOKENAUTHHEADER',
+    ];
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        CacheLib.clear();
+        for (const k of ENV_KEYS) delete process.env[k];
+        fetchMock = vi.fn(async () => ({
+            ok: true,
+            json: async () => ({ accessToken: 'TOK123', exp: 4102444800000 }),
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        for (const k of ENV_KEYS) delete process.env[k];
+        CacheLib.clear();
+    });
+
+    test('sends tokenAuth under a custom tokenAuthHeader when configured', async () => {
+        process.env.GENTINGSKYWORLDS_TOKENURL = 'https://token.example/a';
+        process.env.GENTINGSKYWORLDS_TOKENAUTH = 'secret-abc';
+        process.env.GENTINGSKYWORLDS_TOKENAUTHHEADER = 'x-custom-key';
+
+        const token = await new GentingSkyworlds().getAccessToken();
+
+        expect(token).toBe('TOK123');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, opts] = fetchMock.mock.calls[0] as [string, any];
+        expect(url).toBe('https://token.example/a');
+        expect(opts.headers['x-custom-key']).toBe('secret-abc');
+        expect(opts.headers).not.toHaveProperty('Authorization');
+    });
+
+    test('defaults to the Authorization header when tokenAuthHeader is unset (backward compatible)', async () => {
+        process.env.GENTINGSKYWORLDS_TOKENURL = 'https://token.example/b';
+        process.env.GENTINGSKYWORLDS_TOKENAUTH = 'secret-def';
+
+        await new GentingSkyworlds().getAccessToken();
+
+        const [, opts] = fetchMock.mock.calls[0] as [string, any];
+        expect(opts.headers['Authorization']).toBe('secret-def');
+    });
+
+    test('sends no credential header when tokenAuth is empty', async () => {
+        process.env.GENTINGSKYWORLDS_TOKENURL = 'https://token.example/c';
+
+        await new GentingSkyworlds().getAccessToken();
+
+        const [, opts] = fetchMock.mock.calls[0] as [string, any];
+        expect(opts.headers).not.toHaveProperty('Authorization');
+        expect(Object.keys(opts.headers)).toEqual(['Accept']);
+    });
+});

--- a/src/parks/genting/gentingskyworlds.ts
+++ b/src/parks/genting/gentingskyworlds.ts
@@ -19,8 +19,8 @@ import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
  * Virtual-queue endpoints additionally need a 7-day bearer issued by an
  * OTP-only login flow. Because the OTP cycle cannot run inside this process,
  * the bearer is supplied by an external token service: when `tokenUrl` is
- * configured, this destination performs `GET ${tokenUrl}` (with optional
- * `Authorization: ${tokenAuth}` header) and expects a JSON document of shape
+ * configured, this destination performs `GET ${tokenUrl}` (with an optional
+ * `${tokenAuthHeader}: ${tokenAuth}` credential header) and expects a JSON document of shape
  *   { accessToken: string, exp: number /* epoch ms *​/, ... }
  * The token is cached in-process for a few hours before being re-fetched —
  * the token service is responsible for keeping `accessToken` rolling well
@@ -138,8 +138,15 @@ export class GentingSkyworlds extends Destination {
    */
   @config tokenUrl: string = '';
 
-  /** Optional `Authorization` header value sent on the token-URL GET. */
+  /** Optional credential sent to the token service (under `tokenAuthHeader`). */
   @config tokenAuth: string = '';
+
+  /**
+   * Header name under which `tokenAuth` is sent on the token-URL GET. Defaults
+   * to `Authorization`; override when the token service expects the credential
+   * in a different header.
+   */
+  @config tokenAuthHeader: string = 'Authorization';
 
   constructor(options?: DestinationConstructor) {
     super(options);
@@ -182,7 +189,7 @@ export class GentingSkyworlds extends Destination {
     try {
       return await CacheLib.wrap(cacheKey, async () => {
         const headers: Record<string, string> = {'Accept': 'application/json'};
-        if (this.tokenAuth) headers['Authorization'] = this.tokenAuth;
+        if (this.tokenAuth) headers[this.tokenAuthHeader || 'Authorization'] = this.tokenAuth;
         const resp = await fetch(this.tokenUrl, {headers});
         if (!resp.ok) throw new Error(`token service HTTP ${resp.status}`);
         const doc = await resp.json() as GentingTokenDoc;


### PR DESCRIPTION
## Summary
The Genting VQ destination fetches its bearer from an external token service via `tokenUrl`. The credential was always sent as `Authorization`, but some token services expect it in a different header, so the fetch failed auth against those.

Add a `tokenAuthHeader` config (env `GENTINGSKYWORLDS_TOKENAUTHHEADER`) naming the header the `tokenAuth` credential is sent under. Defaults to `Authorization`, so existing setups are unaffected.

## Test Plan
- [x] `tokenAuthHeader` set → credential sent under that header, not `Authorization`
- [x] `tokenAuthHeader` unset → defaults to `Authorization` (backward compatible)
- [x] `tokenAuth` empty → no credential header sent
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)