### PR TITLE
feat(attractionsio): venue & park opening hours, show times, and wider category coverage for all 16 parks

### DIFF
--- a/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
+++ b/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Integration tests for the Attractions.io v1 base class.
+ *
+ * Unlike showtimes.test.ts (which unit-tests the pure ShowTimes helpers), these
+ * drive the real `buildEntityList()` and `buildLiveData()` on a live subclass —
+ * the entity classification (including the wider category coverage), the
+ * restaurant `IsOpen` fallback, the Resort park-hours extraction, the
+ * time-derived park status, and the malformed-ShowTimes containment. The raw
+ * network methods (`getPOIData` / `fetchLiveData`) are stubbed with fixtures so
+ * nothing hits the API. Full integration is exercised via `npm run dev -- <park>`.
+ */
+
+import {describe, test, expect, beforeEach, afterEach, vi} from 'vitest';
+import {AttractionsIOV1, parseLiveOpeningTimes} from '../attractionsiov1.js';
+import {CacheLib} from '../../../cache.js';
+
+const TZ = 'Europe/Berlin';
+const DATE = '2026-07-08';
+
+// Berlin is +02:00 in July, so 12:00 local == 10:00Z and 23:00 local == 21:00Z.
+const NOON = new Date('2026-07-08T10:00:00Z');
+const NIGHT = new Date('2026-07-08T21:00:00Z');
+
+const range = (open: string, close: string) =>
+  JSON.stringify({type: 'range', start: `${DATE} ${open}`, end: `${DATE} ${close}`});
+
+// A daily point-start show (no range_length) at the given wall-clock time.
+const pointShow = (time: string) =>
+  JSON.stringify({type: 'period', offset_date: `2020-01-01 ${time}`, period_length: {day: 1}});
+
+/**
+ * Fixture records: two attractions (one via a child category), three shows
+ * (one under the wider "4D Movies" label, one with a deliberately malformed
+ * ShowTimes), three restaurants (one under "Food & Drinks", one with no live
+ * IsOpen signal), and a shop that must NOT be classified as anything.
+ */
+function mkRecords(): any {
+  return {
+    Resort: [{_id: 1, Name: 'Probe Resort'}],
+    Category: [
+      {_id: 10, Name: 'Rides'},
+      {_id: 11, Name: 'Thrill Rides', Parent: 10},
+      {_id: 20, Name: 'Shows'},
+      {_id: 21, Name: '4D Movies'},
+      {_id: 30, Name: 'Restaurants'},
+      {_id: 31, Name: 'Food & Drinks'},
+      {_id: 40, Name: 'Shopping'},
+    ],
+    Item: [
+      {_id: 100, Name: 'Big Coaster', Category: 10},
+      {_id: 101, Name: 'Kiddie Coaster', Category: 11},
+      {_id: 200, Name: 'Magic Show', Category: 20, ShowTimes: pointShow('14:00:00')},
+      {_id: 201, Name: '4D Film', Category: 21, ShowTimes: pointShow('15:00:00')},
+      {_id: 202, Name: 'Broken Show', Category: 20, ShowTimes: '{"type":"range","start":null,"end":null}'},
+      {_id: 300, Name: 'Burger Place', Category: 30},
+      {_id: 301, Name: 'Coffee Bar', Category: 31},
+      {_id: 302, Name: 'Early Kiosk', Category: 30},
+      {_id: 400, Name: 'Gift Shop', Category: 40},
+    ],
+  };
+}
+
+function mkLive(): any {
+  return {
+    entities: {
+      Item: {
+        records: [
+          {_id: 100, IsOperational: true, QueueTime: 1800}, // 30 min
+          {_id: 300, IsOpen: true, OpeningTimes: range('10:00:00', '20:00:00')},
+          {_id: 301, OpeningTimes: range('10:00:00', '20:00:00')}, // no IsOpen → window fallback
+          {_id: 302, OpeningTimes: range('10:00:00', '11:00:00')}, // no IsOpen, already closed by noon
+        ],
+      },
+      Resort: {
+        records: [{_id: 1, OpeningTimes: range('10:00:00', '18:00:00')}],
+      },
+    },
+  };
+}
+
+class Probe extends AttractionsIOV1 {
+  private readonly _records: any;
+  private readonly _live: any;
+
+  constructor(records: any = mkRecords(), live: any = mkLive()) {
+    super({config: {destinationId: 'probe-resort', parkId: 'probe-park', timezone: TZ}});
+    this._records = records;
+    this._live = live;
+  }
+
+  override async getPOIData(): Promise<any> {
+    return this._records;
+  }
+
+  override async fetchLiveData(): Promise<any> {
+    return {json: async () => this._live};
+  }
+
+  entities(): Promise<any[]> {
+    return (this as any).buildEntityList();
+  }
+
+  live(): Promise<any[]> {
+    return (this as any).buildLiveData();
+  }
+}
+
+beforeEach(() => {
+  // getCategoryIDs is @cache-decorated; clear between tests so fixtures with the
+  // same destinationId can't leak category ids from a prior test.
+  CacheLib.clearAll();
+});
+
+describe('buildEntityList — classification', () => {
+  test('classifies attractions, shows and restaurants by category name', async () => {
+    const entities = await new Probe().entities();
+    const byType = (t: string) => entities.filter(e => e.entityType === t);
+
+    expect(byType('PARK')).toHaveLength(1);
+    expect(byType('ATTRACTION').map(e => e.id).sort()).toEqual(['100', '101']);
+    expect(byType('SHOW').map(e => e.id).sort()).toEqual(['200', '201', '202']);
+    expect(byType('RESTAURANT').map(e => e.id).sort()).toEqual(['300', '301', '302']);
+  });
+
+  test('includes items nested under a child category (getCategoryIDs walks children)', async () => {
+    const entities = await new Probe().entities();
+    const kiddie = entities.find(e => e.id === '101');
+    expect(kiddie?.entityType).toBe('ATTRACTION');
+  });
+
+  test('wider coverage: "4D Movies" is a SHOW and "Food & Drinks" is a RESTAURANT', async () => {
+    const entities = await new Probe().entities();
+    expect(entities.find(e => e.id === '201')?.entityType).toBe('SHOW');
+    expect(entities.find(e => e.id === '301')?.entityType).toBe('RESTAURANT');
+  });
+
+  test('an item under an unrecognised category (Shopping) is not emitted', async () => {
+    const entities = await new Probe().entities();
+    expect(entities.find(e => e.id === '400')).toBeUndefined();
+  });
+});
+
+describe('buildLiveData', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOON);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('an operational attraction reports OPERATING with the standby wait in minutes', async () => {
+    const live = await new Probe().live();
+    const entry = live.find(l => l.id === '100');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.queue.STANDBY.waitTime).toBe(30);
+  });
+
+  test('the park status is OPERATING when now is inside the live opening window', async () => {
+    const live = await new Probe().live();
+    const park = live.find(l => l.id === 'probe-park');
+    expect(park).toBeDefined();
+    expect(park.status).toBe('OPERATING');
+    expect(park.operatingHours).toHaveLength(1);
+  });
+
+  test('the park status is CLOSED at night, not a hardcoded OPERATING', async () => {
+    vi.setSystemTime(NIGHT);
+    const live = await new Probe().live();
+    const park = live.find(l => l.id === 'probe-park');
+    expect(park).toBeDefined();
+    expect(park.status).toBe('CLOSED');
+    // The hours are still published even though the park is currently closed.
+    expect(park.operatingHours).toHaveLength(1);
+  });
+
+  test('a restaurant with a live IsOpen:true is OPERATING regardless of the window', async () => {
+    const live = await new Probe().live();
+    expect(live.find(l => l.id === '300').status).toBe('OPERATING');
+  });
+
+  test('a restaurant with no IsOpen falls back to the window: open now → OPERATING', async () => {
+    const live = await new Probe().live();
+    expect(live.find(l => l.id === '301').status).toBe('OPERATING');
+  });
+
+  test('a restaurant with no IsOpen falls back to the window: past its hours → CLOSED', async () => {
+    const live = await new Probe().live();
+    expect(live.find(l => l.id === '302').status).toBe('CLOSED');
+  });
+
+  test('a show with an upcoming point start is OPERATING and lists the time', async () => {
+    const live = await new Probe().live();
+    const show = live.find(l => l.id === '200'); // 14:00, after our noon "now"
+    expect(show.status).toBe('OPERATING');
+    expect(show.showtimes).toHaveLength(1);
+    expect(show.showtimes[0].startTime.startsWith('2026-07-08T14:00:00')).toBe(true);
+  });
+
+  test('a malformed ShowTimes record does not crash live data for the whole park', async () => {
+    const live = await new Probe().live();
+    // The broken show (202) is contained — it neither throws nor emits bogus
+    // times — while every other entity still gets live data.
+    expect(() => live).not.toThrow();
+    const broken = live.find(l => l.id === '202');
+    expect(broken.showtimes).toBeUndefined();
+    expect(broken.status).toBe('CLOSED');
+    // The sibling attraction, park and restaurants still came through.
+    expect(live.find(l => l.id === '100')).toBeDefined();
+    expect(live.find(l => l.id === 'probe-park')).toBeDefined();
+    expect(live.find(l => l.id === '300')).toBeDefined();
+  });
+});
+
+describe('parseLiveOpeningTimes', () => {
+  test('parses a single stringified range object into one OPERATING slot', () => {
+    const slots = parseLiveOpeningTimes(range('10:00:00', '18:00:00'), TZ);
+    expect(slots).toHaveLength(1);
+    expect(slots[0].type).toBe('OPERATING');
+    expect(slots[0].startTime.startsWith('2026-07-08T10:00:00')).toBe(true);
+    expect(slots[0].endTime?.startsWith('2026-07-08T18:00:00')).toBe(true);
+  });
+
+  test('parses an array of ranges', () => {
+    const raw = JSON.stringify([
+      {type: 'range', start: `${DATE} 10:00:00`, end: `${DATE} 13:00:00`},
+      {type: 'range', start: `${DATE} 14:00:00`, end: `${DATE} 18:00:00`},
+    ]);
+    expect(parseLiveOpeningTimes(raw, TZ)).toHaveLength(2);
+  });
+
+  test('returns [] for null / blank / non-JSON / non-range input', () => {
+    expect(parseLiveOpeningTimes(null, TZ)).toEqual([]);
+    expect(parseLiveOpeningTimes(undefined, TZ)).toEqual([]);
+    expect(parseLiveOpeningTimes('', TZ)).toEqual([]);
+    expect(parseLiveOpeningTimes('not json', TZ)).toEqual([]);
+    expect(parseLiveOpeningTimes('{"type":"closed"}', TZ)).toEqual([]);
+  });
+
+  test('skips a range whose bounds are missing or non-string', () => {
+    expect(parseLiveOpeningTimes('{"type":"range","start":123,"end":456}', TZ)).toEqual([]);
+    expect(parseLiveOpeningTimes('{"type":"range","start":"bad","end":"also-bad"}', TZ)).toEqual([]);
+  });
+});

--- a/src/parks/attractionsio/__tests__/showtimes.test.ts
+++ b/src/parks/attractionsio/__tests__/showtimes.test.ts
@@ -105,6 +105,14 @@ describe('showTimesForDate — real fixtures', () => {
     expect(showTimesForDate('nonsense', '2026-07-08', TZ)).toEqual([]);
   });
 
+  test('a range with null/non-string bounds yields [] instead of throwing', () => {
+    // parseNaiveMs must not call .trim() on a non-string, or one malformed
+    // record would crash the whole park's live-data build.
+    expect(() => showTimesForDate('{"type":"range","start":null,"end":null}', '2026-07-08', TZ)).not.toThrow();
+    expect(showTimesForDate('{"type":"range","start":null,"end":null}', '2026-07-08', TZ)).toEqual([]);
+    expect(showTimesForDate('{"type":"range"}', '2026-07-08', TZ)).toEqual([]);
+  });
+
   test('applies the correct offset across DST (winter → +01:00)', () => {
     const winter = '{"type":"range","start":"2026-01-10 10:00:00","end":"2026-01-10 12:00:00"}';
     expect(showTimesForDate(winter, '2026-01-10', TZ)).toEqual([

--- a/src/parks/attractionsio/__tests__/showtimes.test.ts
+++ b/src/parks/attractionsio/__tests__/showtimes.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the Attractions.io ShowTimes temporal set-algebra evaluator
+ * (parseShowTimes / evaluateShowTimeNode / showTimesForDate), exported from the
+ * attractionsiov1 park module.
+ *
+ * Fixtures are the real `ShowTimes` trees captured from Heide Park records data
+ * (Toothless Meet & Greet, Peppa Meet & Greet with multiple daily slots, and
+ * the Kinderanimation whose schedule varies by weekday).
+ */
+
+import {describe, test, expect} from 'vitest';
+import {
+  parseShowTimes,
+  evaluateShowTimeNode,
+  showTimesForDate,
+  type ShowTimeNode,
+} from '../attractionsiov1.js';
+
+const TZ = 'Europe/Berlin';
+
+// ── Real ShowTimes fixtures ─────────────────────────────────────────────────
+
+// Toothless (15556): every day 12:00–12:30 across three weekly blocks Jun 22 → Jul 13.
+const TOOTHLESS =
+  '{"type":"union","children":[{"type":"intersection","children":[{"type":"range","start":"2026-06-22 00:00:00","end":"2026-06-29 00:00:00"},{"type":"period","offset_date":"2020-01-01 12:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"range","start":"2026-06-29 00:00:00","end":"2026-07-06 00:00:00"},{"type":"period","offset_date":"2020-01-01 12:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"range","start":"2026-07-06 00:00:00","end":"2026-07-13 00:00:00"},{"type":"period","offset_date":"2020-01-01 12:00:00","period_length":{"day":1},"range_length":{"minute":30}}]}]}';
+
+// Peppa (15555): in the Jul 6–13 block runs daily 11:15 & 12:15 (20 min) plus Mon–Sat 15:30.
+const PEPPA =
+  '{"type":"union","children":[{"type":"intersection","children":[{"type":"range","start":"2026-06-22 00:00:00","end":"2026-06-29 00:00:00"},{"type":"union","children":[{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-03 00:00:00","period_length":{"day":7},"range_length":{"day":5}},{"type":"period","offset_date":"2020-01-01 12:15:00","period_length":{"day":1},"range_length":{"minute":10}}]},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-05 00:00:00","period_length":{"day":7},"range_length":{"day":3}},{"type":"period","offset_date":"2020-01-01 11:15:00","period_length":{"day":1},"range_length":{"minute":10}}]},{"type":"intersection","children":[{"type":"union","children":[{"type":"period","offset_date":"2018-01-05 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2018-01-07 00:00:00","period_length":{"day":7},"range_length":{"day":1}}]},{"type":"period","offset_date":"2020-01-01 15:30:00","period_length":{"day":1},"range_length":{"minute":10}}]}]}]},{"type":"intersection","children":[{"type":"range","start":"2026-06-29 00:00:00","end":"2026-07-06 00:00:00"},{"type":"union","children":[{"type":"period","offset_date":"2020-01-01 12:15:00","period_length":{"day":1},"range_length":{"minute":20}},{"type":"period","offset_date":"2020-01-01 15:30:00","period_length":{"day":1},"range_length":{"minute":20}},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-04 00:00:00","period_length":{"day":7},"range_length":{"day":4}},{"type":"period","offset_date":"2020-01-01 11:15:00","period_length":{"day":1},"range_length":{"minute":20}}]}]}]},{"type":"intersection","children":[{"type":"range","start":"2026-07-06 00:00:00","end":"2026-07-13 00:00:00"},{"type":"union","children":[{"type":"period","offset_date":"2020-01-01 11:15:00","period_length":{"day":1},"range_length":{"minute":20}},{"type":"period","offset_date":"2020-01-01 12:15:00","period_length":{"day":1},"range_length":{"minute":20}},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-08 00:00:00","period_length":{"day":7},"range_length":{"day":6}},{"type":"period","offset_date":"2020-01-01 15:30:00","period_length":{"day":1},"range_length":{"minute":20}}]}]}]}]}';
+
+// Kinderanimation (47786): in the Jul 6–13 block Wed→16:30, Tue/Thu/Sun→14:00, Mon/Fri/Sat→15:00.
+const KINDERANIMATION =
+  '{"type":"union","children":[{"type":"intersection","children":[{"type":"range","start":"2026-06-22 00:00:00","end":"2026-06-29 00:00:00"},{"type":"period","offset_date":"2018-01-08 00:00:00","period_length":{"day":7},"range_length":{"day":2}},{"type":"period","offset_date":"2020-01-01 14:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"range","start":"2026-06-29 00:00:00","end":"2026-07-06 00:00:00"},{"type":"union","children":[{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-03 00:00:00","period_length":{"day":7},"range_length":{"day":2}},{"type":"period","offset_date":"2020-01-01 14:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-06 00:00:00","period_length":{"day":7},"range_length":{"day":4}},{"type":"period","offset_date":"2020-01-01 15:00:00","period_length":{"day":1},"range_length":{"minute":30}}]}]}]},{"type":"intersection","children":[{"type":"range","start":"2026-07-06 00:00:00","end":"2026-07-13 00:00:00"},{"type":"union","children":[{"type":"intersection","children":[{"type":"union","children":[{"type":"period","offset_date":"2018-01-05 00:00:00","period_length":{"day":7},"range_length":{"day":2}},{"type":"period","offset_date":"2018-01-08 00:00:00","period_length":{"day":7},"range_length":{"day":1}}]},{"type":"period","offset_date":"2020-01-01 15:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"union","children":[{"type":"period","offset_date":"2018-01-02 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2018-01-04 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2018-01-07 00:00:00","period_length":{"day":7},"range_length":{"day":1}}]},{"type":"period","offset_date":"2020-01-01 14:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-03 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2020-01-01 16:30:00","period_length":{"day":1},"range_length":{"minute":30}}]}]}]}]}';
+
+const slot = (start: string, end: string, type = 'Showtime') => ({type, startTime: start, endTime: end});
+
+// Convert an evaluated naive-ms interval to "HH:mm" for compact assertions.
+const hhmm = (ms: number) => new Date(ms).toISOString().slice(11, 16);
+
+describe('parseShowTimes', () => {
+  test('parses a valid tree', () => {
+    const node = parseShowTimes(TOOTHLESS);
+    expect(node).not.toBeNull();
+    expect(node?.type).toBe('union');
+  });
+
+  test('returns null for null / blank / non-JSON / typeless input', () => {
+    expect(parseShowTimes(null)).toBeNull();
+    expect(parseShowTimes(undefined)).toBeNull();
+    expect(parseShowTimes('')).toBeNull();
+    expect(parseShowTimes('   ')).toBeNull();
+    expect(parseShowTimes('not json')).toBeNull();
+    expect(parseShowTimes('{"foo":1}')).toBeNull();
+  });
+});
+
+describe('showTimesForDate — real fixtures', () => {
+  test('Toothless: daily 12:00–12:30 on an in-season Wednesday', () => {
+    expect(showTimesForDate(TOOTHLESS, '2026-07-08', TZ)).toEqual([
+      slot('2026-07-08T12:00:00+02:00', '2026-07-08T12:30:00+02:00'),
+    ]);
+  });
+
+  test('Toothless: empty after the season ends (past Jul 13)', () => {
+    expect(showTimesForDate(TOOTHLESS, '2026-08-01', TZ)).toEqual([]);
+  });
+
+  test('Peppa: three ordered slots on the same Wednesday', () => {
+    expect(showTimesForDate(PEPPA, '2026-07-08', TZ)).toEqual([
+      slot('2026-07-08T11:15:00+02:00', '2026-07-08T11:35:00+02:00'),
+      slot('2026-07-08T12:15:00+02:00', '2026-07-08T12:35:00+02:00'),
+      slot('2026-07-08T15:30:00+02:00', '2026-07-08T15:50:00+02:00'),
+    ]);
+  });
+
+  test('Kinderanimation: weekday-specific start time (Wed → 16:30)', () => {
+    expect(showTimesForDate(KINDERANIMATION, '2026-07-08', TZ)).toEqual([
+      slot('2026-07-08T16:30:00+02:00', '2026-07-08T17:00:00+02:00'),
+    ]);
+  });
+
+  test('Kinderanimation: different weekday, different time (Thu → 14:00)', () => {
+    expect(showTimesForDate(KINDERANIMATION, '2026-07-09', TZ)).toEqual([
+      slot('2026-07-09T14:00:00+02:00', '2026-07-09T14:30:00+02:00'),
+    ]);
+  });
+
+  test('honours a custom slot type', () => {
+    const [s] = showTimesForDate(TOOTHLESS, '2026-07-08', TZ, 'Meet & Greet');
+    expect(s.type).toBe('Meet & Greet');
+  });
+
+  test('returns [] for missing/invalid ShowTimes', () => {
+    expect(showTimesForDate(null, '2026-07-08', TZ)).toEqual([]);
+    expect(showTimesForDate('nonsense', '2026-07-08', TZ)).toEqual([]);
+  });
+
+  test('applies the correct offset across DST (winter → +01:00)', () => {
+    const winter = '{"type":"range","start":"2026-01-10 10:00:00","end":"2026-01-10 12:00:00"}';
+    expect(showTimesForDate(winter, '2026-01-10', TZ)).toEqual([
+      slot('2026-01-10T10:00:00+01:00', '2026-01-10T12:00:00+01:00'),
+    ]);
+  });
+});
+
+describe('evaluateShowTimeNode — set algebra', () => {
+  const day = Date.parse('2026-07-08T00:00:00Z');
+  const dayEnd = day + 24 * 60 * 60 * 1000;
+  const range = (start: string, end: string): ShowTimeNode => ({type: 'range', start, end});
+
+  test('union merges overlapping intervals', () => {
+    const node: ShowTimeNode = {
+      type: 'union',
+      children: [range('2026-07-08 10:00:00', '2026-07-08 12:00:00'), range('2026-07-08 11:00:00', '2026-07-08 13:00:00')],
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([['10:00', '13:00']]);
+  });
+
+  test('intersection keeps only the overlap', () => {
+    const node: ShowTimeNode = {
+      type: 'intersection',
+      children: [range('2026-07-08 10:00:00', '2026-07-08 14:00:00'), range('2026-07-08 12:00:00', '2026-07-08 18:00:00')],
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([['12:00', '14:00']]);
+  });
+
+  test('difference removes the subtracted span, leaving both remainders', () => {
+    const node: ShowTimeNode = {
+      type: 'difference',
+      children: [range('2026-07-08 10:00:00', '2026-07-08 18:00:00'), range('2026-07-08 12:00:00', '2026-07-08 13:00:00')],
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([
+      ['10:00', '12:00'],
+      ['13:00', '18:00'],
+    ]);
+  });
+
+  test('complement returns the window minus the child', () => {
+    const node: ShowTimeNode = {
+      type: 'complement',
+      children: [range('2026-07-08 10:00:00', '2026-07-08 12:00:00')],
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([
+      ['00:00', '10:00'],
+      ['12:00', '00:00'], // 12:00 → next midnight (clipped to window end)
+    ]);
+  });
+
+  test('a period with zero-length range yields nothing', () => {
+    const node: ShowTimeNode = {
+      type: 'period',
+      offset_date: '2020-01-01 12:00:00',
+      period_length: {day: 1},
+      range_length: {},
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
+  });
+});

--- a/src/parks/attractionsio/__tests__/showtimes.test.ts
+++ b/src/parks/attractionsio/__tests__/showtimes.test.ts
@@ -32,6 +32,16 @@ const PEPPA =
 const KINDERANIMATION =
   '{"type":"union","children":[{"type":"intersection","children":[{"type":"range","start":"2026-06-22 00:00:00","end":"2026-06-29 00:00:00"},{"type":"period","offset_date":"2018-01-08 00:00:00","period_length":{"day":7},"range_length":{"day":2}},{"type":"period","offset_date":"2020-01-01 14:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"range","start":"2026-06-29 00:00:00","end":"2026-07-06 00:00:00"},{"type":"union","children":[{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-03 00:00:00","period_length":{"day":7},"range_length":{"day":2}},{"type":"period","offset_date":"2020-01-01 14:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-06 00:00:00","period_length":{"day":7},"range_length":{"day":4}},{"type":"period","offset_date":"2020-01-01 15:00:00","period_length":{"day":1},"range_length":{"minute":30}}]}]}]},{"type":"intersection","children":[{"type":"range","start":"2026-07-06 00:00:00","end":"2026-07-13 00:00:00"},{"type":"union","children":[{"type":"intersection","children":[{"type":"union","children":[{"type":"period","offset_date":"2018-01-05 00:00:00","period_length":{"day":7},"range_length":{"day":2}},{"type":"period","offset_date":"2018-01-08 00:00:00","period_length":{"day":7},"range_length":{"day":1}}]},{"type":"period","offset_date":"2020-01-01 15:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"union","children":[{"type":"period","offset_date":"2018-01-02 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2018-01-04 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2018-01-07 00:00:00","period_length":{"day":7},"range_length":{"day":1}}]},{"type":"period","offset_date":"2020-01-01 14:00:00","period_length":{"day":1},"range_length":{"minute":30}}]},{"type":"intersection","children":[{"type":"period","offset_date":"2018-01-03 00:00:00","period_length":{"day":7},"range_length":{"day":1}},{"type":"period","offset_date":"2020-01-01 16:30:00","period_length":{"day":1},"range_length":{"minute":30}}]}]}]}]}';
 
+// Bing Live (Alton Towers 6208): daily 13:30 start with no encoded duration,
+// across two season ranges (the second, Mar 18 → Nov 16, covers summer).
+const BING_LIVE =
+  '{"type":"union","children":[{"type":"intersection","children":[{"type":"range","start":"2026-03-14 00:00:00","end":"2026-03-16 00:00:00"},{"type":"period","offset_date":"2020-01-01 13:30:00","period_length":{"day":1}}]},{"type":"intersection","children":[{"type":"range","start":"2026-03-18 00:00:00","end":"2026-11-16 00:00:00"},{"type":"period","offset_date":"2020-01-01 13:30:00","period_length":{"day":1}}]}]}';
+
+// Once Upon A Brick (LEGOLAND California 17568): three daily start times, each a
+// period with no range_length (no encoded duration).
+const ONCE_UPON_A_BRICK =
+  '{"type":"union","children":[{"type":"period","offset_date":"2020-01-01 13:00:00","period_length":{"day":1}},{"type":"period","offset_date":"2020-01-01 14:15:00","period_length":{"day":1}},{"type":"period","offset_date":"2020-01-01 15:30:00","period_length":{"day":1}}]}';
+
 const slot = (start: string, end: string, type = 'Showtime') => ({type, startTime: start, endTime: end});
 
 // Convert an evaluated naive-ms interval to "HH:mm" for compact assertions.
@@ -101,6 +111,20 @@ describe('showTimesForDate — real fixtures', () => {
       slot('2026-01-10T10:00:00+01:00', '2026-01-10T12:00:00+01:00'),
     ]);
   });
+
+  test('point start times (no range_length) are emitted start-only', () => {
+    expect(showTimesForDate(BING_LIVE, '2026-07-08', 'Europe/London')).toEqual([
+      {type: 'Showtime', startTime: '2026-07-08T13:30:00+01:00'},
+    ]);
+  });
+
+  test('a union of point periods yields ordered start-only slots', () => {
+    expect(showTimesForDate(ONCE_UPON_A_BRICK, '2026-07-08', 'America/Los_Angeles')).toEqual([
+      {type: 'Showtime', startTime: '2026-07-08T13:00:00-07:00'},
+      {type: 'Showtime', startTime: '2026-07-08T14:15:00-07:00'},
+      {type: 'Showtime', startTime: '2026-07-08T15:30:00-07:00'},
+    ]);
+  });
 });
 
 describe('evaluateShowTimeNode — set algebra', () => {
@@ -146,13 +170,55 @@ describe('evaluateShowTimeNode — set algebra', () => {
     ]);
   });
 
-  test('a period with zero-length range yields nothing', () => {
+  test('a period without range_length yields a point start time', () => {
     const node: ShowTimeNode = {
       type: 'period',
       offset_date: '2020-01-01 12:00:00',
       period_length: {day: 1},
       range_length: {},
     };
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([
+      ['12:00', '12:00'],
+    ]);
+  });
+
+  test('a point period survives intersection with a containing span', () => {
+    const node: ShowTimeNode = {
+      type: 'intersection',
+      children: [
+        range('2026-07-08 00:00:00', '2026-07-09 00:00:00'),
+        {type: 'period', offset_date: '2020-01-01 13:30:00', period_length: {day: 1}, range_length: {}},
+      ],
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([
+      ['13:30', '13:30'],
+    ]);
+  });
+
+  test('a point period outside a span is dropped by intersection', () => {
+    const node: ShowTimeNode = {
+      type: 'intersection',
+      children: [
+        range('2026-07-08 10:00:00', '2026-07-08 12:00:00'),
+        {type: 'period', offset_date: '2020-01-01 13:30:00', period_length: {day: 1}, range_length: {}},
+      ],
+    };
     expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
+  });
+
+  test('union keeps distinct points and merges a point into a covering interval', () => {
+    const node: ShowTimeNode = {
+      type: 'union',
+      children: [
+        range('2026-07-08 10:00:00', '2026-07-08 12:00:00'),
+        {type: 'period', offset_date: '2020-01-01 11:00:00', period_length: {day: 1}, range_length: {}},
+        {type: 'period', offset_date: '2020-01-01 15:30:00', period_length: {day: 1}, range_length: {}},
+      ],
+    };
+    // 11:00 falls inside 10:00–12:00 (absorbed); 15:30 stands alone as a point.
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([
+      ['10:00', '12:00'],
+      ['15:30', '15:30'],
+    ]);
   });
 });

--- a/src/parks/attractionsio/__tests__/showtimes.test.ts
+++ b/src/parks/attractionsio/__tests__/showtimes.test.ts
@@ -221,4 +221,48 @@ describe('evaluateShowTimeNode — set algebra', () => {
       ['15:30', '15:30'],
     ]);
   });
+
+  test('two abutting spans intersect to nothing, not a boundary point', () => {
+    const node: ShowTimeNode = {
+      type: 'intersection',
+      children: [
+        range('2026-07-08 10:00:00', '2026-07-08 12:00:00'),
+        range('2026-07-08 12:00:00', '2026-07-08 14:00:00'),
+      ],
+    };
+    // Half-open [10:00,12:00) and [12:00,14:00) only touch at 12:00 — no overlap.
+    expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
+  });
+
+  test('a point on a span exclusive end is excluded by intersection (half-open)', () => {
+    const node: ShowTimeNode = {
+      type: 'intersection',
+      children: [
+        range('2026-07-08 10:00:00', '2026-07-08 13:30:00'),
+        {type: 'period', offset_date: '2020-01-01 13:30:00', period_length: {day: 1}, range_length: {}},
+      ],
+    };
+    // 13:30 is the exclusive end of [10:00,13:30), so the point is not contained.
+    expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
+  });
+
+  test('difference drops a point on the subtracted span start, keeps one outside', () => {
+    const node: ShowTimeNode = {
+      type: 'difference',
+      children: [
+        {
+          type: 'union',
+          children: [
+            {type: 'period', offset_date: '2020-01-01 09:00:00', period_length: {day: 1}, range_length: {}},
+            {type: 'period', offset_date: '2020-01-01 13:30:00', period_length: {day: 1}, range_length: {}},
+          ],
+        },
+        range('2026-07-08 13:30:00', '2026-07-08 18:00:00'),
+      ],
+    };
+    // 13:30 sits on the inclusive start of [13:30,18:00) so it is removed; 09:00 survives.
+    expect(evaluateShowTimeNode(node, day, dayEnd).map(([s, e]) => [hhmm(s), hhmm(e)])).toEqual([
+      ['09:00', '09:00'],
+    ]);
+  });
 });

--- a/src/parks/attractionsio/__tests__/showtimes.test.ts
+++ b/src/parks/attractionsio/__tests__/showtimes.test.ts
@@ -254,6 +254,31 @@ describe('evaluateShowTimeNode — set algebra', () => {
     expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
   });
 
+  test('a period with a non-numeric period_length yields [] (NaN fails the guard, no 100k spin)', () => {
+    // A NaN duration slips past `<= 0` / `< 0` (both false for NaN); without an
+    // explicit finite check the loop would run SHOWTIME_MAX_ITERATIONS doing
+    // nothing on every poll cycle.
+    const node: ShowTimeNode = {
+      type: 'period',
+      offset_date: '2020-01-01 12:00:00',
+      period_length: {day: 'x' as unknown as number},
+      range_length: {minute: 30},
+    };
+    const started = Date.now();
+    expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  test('a period with a non-numeric range_length yields [] (NaN fails the guard)', () => {
+    const node: ShowTimeNode = {
+      type: 'period',
+      offset_date: '2020-01-01 12:00:00',
+      period_length: {day: 1},
+      range_length: {minute: {} as unknown as number},
+    };
+    expect(evaluateShowTimeNode(node, day, dayEnd)).toEqual([]);
+  });
+
   test('difference drops a point on the subtracted span start, keeps one outside', () => {
     const node: ShowTimeNode = {
       type: 'difference',

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -30,9 +30,9 @@ import {inject} from '../../injector.js';
 import {destinationController} from '../../destinationRegistry.js';
 import {CacheLib, database} from '../../cache.js';
 import {makeHttpRequest} from '../../httpProxy.js';
-import {constructDateTime, addDays, formatInTimezone} from '../../datetime.js';
+import {constructDateTime, addDays, formatInTimezone, formatDate} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
-import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
+import type {Entity, LiveData, EntitySchedule, LiveTimeSlot} from '@themeparks/typelib';
 import AdmZip from 'adm-zip';
 import crypto from 'node:crypto';
 
@@ -99,6 +99,8 @@ type RecordItem = {
   Location?: string;
   MinimumHeightRequirement?: number;
   MinimumUnaccompaniedHeightRequirement?: number | null;
+  /** Recurring schedule tree (stringified JSON) for shows/animations. */
+  ShowTimes?: string | null;
 };
 
 type CategoryRecord = {
@@ -658,6 +660,14 @@ class AttractionsIOV1 extends Destination {
     return data.Item.filter(item => item.Category !== undefined && allCatIds.includes(item.Category));
   }
 
+  /**
+   * Category names treated as SHOW entities. Overridable by subclasses whose
+   * park labels its shows differently (e.g. HeidePark uses "Entertainment").
+   */
+  protected getShowCategories(): string[] {
+    return SHOW_CATEGORIES;
+  }
+
   // ── Live data ─────────────────────────────────────────────────────────────
 
   /**
@@ -752,7 +762,7 @@ class AttractionsIOV1 extends Destination {
     );
 
     // Shows
-    const showItems = await this.getItemsForCategories(SHOW_CATEGORIES);
+    const showItems = await this.getItemsForCategories(this.getShowCategories());
     const showEntities = showItems.map(item =>
       buildItemEntity(item, this.parkId, this.destinationId, this.timezone, 'SHOW')
     );
@@ -1142,7 +1152,309 @@ export class Gardaland extends AttractionsIOV1 {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// HeidePark — custom v2 schedule API
+// HeidePark — live-data opening hours
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A live-data `Item` record as returned for HeidePark. Extends the base shape
+ * with the venue fields (restaurants/shops carry these; rides leave them null).
+ * `IsOperational` flags *rides that are running* — it is always false for
+ * dining/retail venues, so `IsOpen` is the correct open/closed signal there.
+ */
+type HeideLiveItemRecord = {
+  _id: number;
+  IsOpen?: boolean;
+  IsOperational?: boolean;
+  OpeningTimes?: string | null;
+};
+
+type HeideLiveResortRecord = {
+  _id: number;
+  OpeningTimes?: string | null;
+};
+
+type HeideLiveResponse = {
+  entities?: {
+    Item?: {records?: HeideLiveItemRecord[]};
+    Resort?: {records?: HeideLiveResortRecord[]};
+  };
+};
+
+/** Split "YYYY-MM-DD HH:MM[:SS]" into {date, time}; null if malformed. */
+function splitLiveDateTime(raw: string): {date: string; time: string} | null {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2})?)/.exec(raw.trim());
+  return m ? {date: m[1], time: m[2]} : null;
+}
+
+/**
+ * Parse an Attractions.io live-data `OpeningTimes` value into schema
+ * LiveTimeSlot entries.
+ *
+ * The field is a *stringified* JSON blob, e.g.
+ *   `{"type":"range","start":"2026-07-08 10:00:00","end":"2026-07-08 18:00:00"}`
+ * (a single object, or defensively an array of them). Start/end are park-local
+ * wall-clock times without an offset, so they are normalised to ISO+offset via
+ * constructDateTime. Returns [] for null/blank/unparseable/non-range values.
+ */
+function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string): LiveTimeSlot[] {
+  if (typeof raw !== 'string' || raw.trim() === '') return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const ranges = Array.isArray(parsed) ? parsed : [parsed];
+  const slots: LiveTimeSlot[] = [];
+
+  for (const r of ranges) {
+    if (
+      !r || typeof r !== 'object' ||
+      (r as any).type !== 'range' ||
+      typeof (r as any).start !== 'string' ||
+      typeof (r as any).end !== 'string'
+    ) continue;
+
+    const start = splitLiveDateTime((r as any).start);
+    const end = splitLiveDateTime((r as any).end);
+    if (!start || !end) continue;
+
+    slots.push({
+      type: 'OPERATING',
+      startTime: constructDateTime(start.date, start.time, timezone),
+      endTime: constructDateTime(end.date, end.time, timezone),
+    });
+  }
+
+  return slots;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HeidePark — show schedules (`ShowTimes` recurring-schedule algebra)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Attractions.io encodes a show/animation's recurring schedule in the records
+ * `ShowTimes` field as a nested set-algebra tree. Evaluating that tree against a
+ * single day yields the concrete performance windows for that day.
+ *
+ * Node grammar (each node is a set of instants):
+ *   • range         — a continuous span [start, end)
+ *   • period        — a repeating window: from `offset_date`, every
+ *                     `period_length`, a window `range_length` long is "on".
+ *                     Daily period (offset 12:00 / range 30min) → "every day
+ *                     12:00–12:30". Weekly period (period_length 7 days) with
+ *                     range_length N days selects N consecutive weekdays;
+ *                     offset_date's weekday picks the start day.
+ *   • union         — set union of children
+ *   • intersection  — set intersection of children
+ *   • difference    — children[0] minus the union of the rest
+ *   • complement    — the evaluation window minus its child
+ *
+ * Timestamps are naive park-local wall-clock; evaluation happens in that naive
+ * space (so daily periods stay fixed across DST), then concrete date + time are
+ * handed to constructDateTime for correctly-offset ISO output.
+ */
+type ShowTimeDuration = {
+  week?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+};
+
+export type ShowTimeNode =
+  | {type: 'range'; start: string; end: string}
+  | {type: 'period'; offset_date: string; period_length: ShowTimeDuration; range_length: ShowTimeDuration}
+  | {type: 'union' | 'intersection' | 'difference' | 'complement'; children: ShowTimeNode[]};
+
+/** A half-open interval [start, end) in naive-local milliseconds. */
+type ShowTimeInterval = [number, number];
+
+const SHOWTIME_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Guard against pathological period definitions producing unbounded loops. */
+const SHOWTIME_MAX_ITERATIONS = 100_000;
+
+/**
+ * Parse a naive "YYYY-MM-DD HH:MM:SS" (or ISO) wall-clock string to ms, treating
+ * it as UTC so UTC getters reproduce the wall clock. NaN for bad input.
+ */
+function parseNaiveMs(raw: string): number {
+  return Date.parse(raw.trim().replace(' ', 'T') + 'Z');
+}
+
+function showTimeDurationMs(d: ShowTimeDuration | undefined): number {
+  if (!d || typeof d !== 'object') return 0;
+  return (
+    (d.week || 0) * 7 * SHOWTIME_DAY_MS +
+    (d.day || 0) * SHOWTIME_DAY_MS +
+    (d.hour || 0) * 60 * 60 * 1000 +
+    (d.minute || 0) * 60 * 1000 +
+    (d.second || 0) * 1000
+  );
+}
+
+/** Sort and merge overlapping/adjacent intervals into a normalised set. */
+function normaliseIntervals(list: ShowTimeInterval[]): ShowTimeInterval[] {
+  const sorted = list.filter(([s, e]) => s < e).sort((a, b) => a[0] - b[0]);
+  const out: ShowTimeInterval[] = [];
+  for (const [s, e] of sorted) {
+    const last = out[out.length - 1];
+    if (last && s <= last[1]) last[1] = Math.max(last[1], e);
+    else out.push([s, e]);
+  }
+  return out;
+}
+
+function intersectIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTimeInterval[] {
+  const out: ShowTimeInterval[] = [];
+  for (const [as, ae] of a) {
+    for (const [bs, be] of b) {
+      const s = Math.max(as, bs);
+      const e = Math.min(ae, be);
+      if (s < e) out.push([s, e]);
+    }
+  }
+  return normaliseIntervals(out);
+}
+
+/** Remove every part of `b` from `a`. */
+function subtractIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTimeInterval[] {
+  let current = normaliseIntervals(a);
+  for (const [bs, be] of normaliseIntervals(b)) {
+    const next: ShowTimeInterval[] = [];
+    for (const [as, ae] of current) {
+      if (be <= as || bs >= ae) {
+        next.push([as, ae]); // no overlap
+        continue;
+      }
+      if (as < bs) next.push([as, bs]); // left remainder
+      if (be < ae) next.push([be, ae]); // right remainder
+    }
+    current = next;
+  }
+  return normaliseIntervals(current);
+}
+
+/**
+ * Safely parse a raw `ShowTimes` field value into a node, or null when
+ * absent/blank/unparseable.
+ */
+export function parseShowTimes(raw: string | null | undefined): ShowTimeNode | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && typeof parsed.type === 'string'
+      ? (parsed as ShowTimeNode)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evaluate a ShowTimes node against the window [winStart, winEnd) and return the
+ * normalised set of active intervals within that window (naive-local ms).
+ */
+export function evaluateShowTimeNode(
+  node: ShowTimeNode,
+  winStart: number,
+  winEnd: number,
+): ShowTimeInterval[] {
+  switch (node.type) {
+    case 'range': {
+      const s = Math.max(parseNaiveMs(node.start), winStart);
+      const e = Math.min(parseNaiveMs(node.end), winEnd);
+      return Number.isFinite(s) && Number.isFinite(e) && s < e ? [[s, e]] : [];
+    }
+
+    case 'period': {
+      const offset = parseNaiveMs(node.offset_date);
+      const periodMs = showTimeDurationMs(node.period_length);
+      const rangeMs = showTimeDurationMs(node.range_length);
+      if (!Number.isFinite(offset) || periodMs <= 0 || rangeMs <= 0) return [];
+
+      const out: ShowTimeInterval[] = [];
+      let n = Math.floor((winStart - offset - rangeMs) / periodMs);
+      for (let i = 0; i < SHOWTIME_MAX_ITERATIONS; i++, n++) {
+        const s = offset + n * periodMs;
+        if (s >= winEnd) break;
+        const cs = Math.max(s, winStart);
+        const ce = Math.min(s + rangeMs, winEnd);
+        if (cs < ce) out.push([cs, ce]);
+      }
+      return normaliseIntervals(out);
+    }
+
+    case 'union':
+      return normaliseIntervals((node.children || []).flatMap(c => evaluateShowTimeNode(c, winStart, winEnd)));
+
+    case 'intersection': {
+      const children = node.children || [];
+      if (children.length === 0) return [];
+      return children
+        .map(c => evaluateShowTimeNode(c, winStart, winEnd))
+        .reduce((acc, cur) => intersectIntervals(acc, cur));
+    }
+
+    case 'difference': {
+      const children = node.children || [];
+      if (children.length === 0) return [];
+      const [first, ...rest] = children.map(c => evaluateShowTimeNode(c, winStart, winEnd));
+      return rest.reduce((acc, cur) => subtractIntervals(acc, cur), first);
+    }
+
+    case 'complement': {
+      const inner = normaliseIntervals(
+        (node.children || []).flatMap(c => evaluateShowTimeNode(c, winStart, winEnd)),
+      );
+      return subtractIntervals([[winStart, winEnd]], inner);
+    }
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * Evaluate a raw `ShowTimes` value for a single calendar day and return
+ * schema-ready LiveTimeSlot entries with timezone-correct ISO times.
+ *
+ * @param raw   Stringified ShowTimes JSON (or null/undefined).
+ * @param date  Target day "YYYY-MM-DD" in the park's local timezone.
+ * @param timezone  IANA timezone (e.g. "Europe/Berlin").
+ * @param type  Value for each slot's `type` field (defaults to "Showtime").
+ */
+export function showTimesForDate(
+  raw: string | null | undefined,
+  date: string,
+  timezone: string,
+  type: string = 'Showtime',
+): LiveTimeSlot[] {
+  const node = parseShowTimes(raw);
+  if (!node) return [];
+
+  const winStart = parseNaiveMs(`${date} 00:00:00`);
+  if (!Number.isFinite(winStart)) return [];
+  const winEnd = winStart + SHOWTIME_DAY_MS;
+
+  return evaluateShowTimeNode(node, winStart, winEnd).map(([s, e]) => {
+    // s/e are naive-local ms; read back the wall clock via UTC getters.
+    const startIso = new Date(s).toISOString();
+    const endIso = new Date(e).toISOString();
+    return {
+      type,
+      startTime: constructDateTime(startIso.slice(0, 10), startIso.slice(11, 19), timezone),
+      endTime: constructDateTime(endIso.slice(0, 10), endIso.slice(11, 19), timezone),
+    };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HeidePark — destination (custom v2 opening-times API)
 // ─────────────────────────────────────────────────────────────────────────────
 
 type HeideParkOpeningTime = {
@@ -1161,6 +1473,14 @@ type HeideParkScheduleResponse = {
 @config
 class HeideParkBase extends AttractionsIOV1 {
   /**
+   * HeidePark labels its shows/animations "Entertainment" rather than the
+   * default "Shows"/"Show"/"Live Shows", so extend the show category list.
+   */
+  protected getShowCategories(): string[] {
+    return [...SHOW_CATEGORIES, 'Entertainment'];
+  }
+
+  /**
    * Fetch the v2 resort-opening-times endpoint (specific to HeidePark).
    * Cached for 2 hours.
    */
@@ -1172,6 +1492,98 @@ class HeideParkBase extends AttractionsIOV1 {
       options: {json: true},
       tags: ['calendar'],
     } as any as HTTPObj;
+  }
+
+  /**
+   * HeidePark live data.
+   *
+   * Reuses the base implementation for attraction wait times, then augments it
+   * with what the base drops on the floor:
+   *   • restaurant open/closed status + today's opening hours (from the venue
+   *     `OpeningTimes` field, which the base never reads)
+   *   • the park's actual opening window for today (from the Resort record)
+   *   • show performance times for today, evaluated from each show's recurring
+   *     `ShowTimes` schedule in the records data (not the live feed)
+   */
+  protected async buildLiveData(): Promise<LiveData[]> {
+    // Base handles attraction wait times & status.
+    const liveData = await super.buildLiveData();
+
+    let raw: HeideLiveResponse;
+    try {
+      const resp = await this.fetchLiveData();
+      raw = await resp.json();
+    } catch {
+      return liveData;
+    }
+
+    // Restaurants: open/closed status + today's opening hours
+    const entities = await this.getEntities();
+    const restaurantIds = new Set(
+      entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id),
+    );
+
+    const records = raw?.entities?.Item?.records ?? [];
+    for (const record of records) {
+      const id = String(record._id);
+      if (!restaurantIds.has(id)) continue;
+
+      // Dining venues report IsOperational:false unconditionally (it flags
+      // running rides), so IsOpen is the real signal.
+      const entry: LiveData = {
+        id,
+        status: record.IsOpen ? 'OPERATING' : 'CLOSED',
+      };
+
+      const hours = parseLiveOpeningTimes(record.OpeningTimes, this.timezone);
+      if (hours.length > 0) entry.operatingHours = hours;
+
+      liveData.push(entry);
+    }
+
+    // Park: today's actual opening window (from the Resort record)
+    const resort = raw?.entities?.Resort?.records?.[0];
+    const parkHours = parseLiveOpeningTimes(resort?.OpeningTimes, this.timezone);
+    if (parkHours.length > 0) {
+      liveData.push({
+        id: this.parkId,
+        status: 'OPERATING',
+        operatingHours: parkHours,
+      });
+    }
+
+    // Shows: today's performance times, evaluated from each show's recurring
+    // ShowTimes schedule in the records data (not the live feed)
+    const showIds = new Set(entities.filter(e => e.entityType === 'SHOW').map(e => e.id));
+    if (showIds.size > 0) {
+      const today = formatDate(new Date(), this.timezone);
+      const poi = await this.getPOIData();
+      for (const item of poi.Item) {
+        const id = String(item._id);
+        if (!showIds.has(id)) continue;
+
+        const showtimes = showTimesForDate(item.ShowTimes, today, this.timezone);
+
+        // Status derives from the schedule (there is no live "running now" feed):
+        // OPERATING only while a performance is still upcoming or ongoing, then
+        // CLOSED once the day's last performance has ended. The full day's
+        // schedule stays published in `showtimes`.
+        const nowMs = Date.now();
+        const hasUpcoming = showtimes.some(s => {
+          const end = s.endTime ?? s.startTime;
+          return end != null && Date.parse(end) > nowMs;
+        });
+
+        const entry: LiveData = {
+          id,
+          status: hasUpcoming ? 'OPERATING' : 'CLOSED',
+        };
+        if (showtimes.length > 0) entry.showtimes = showtimes;
+        liveData.push(entry);
+      }
+    }
+
+    return liveData;
   }
 
   protected async buildSchedules(): Promise<EntitySchedule[]> {

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -480,7 +480,14 @@ export function evaluateShowTimeNode(
       const offset = parseNaiveMs(node.offset_date);
       const periodMs = showTimeDurationMs(node.period_length);
       const rangeMs = showTimeDurationMs(node.range_length);
-      if (!Number.isFinite(offset) || periodMs <= 0 || rangeMs < 0) return [];
+      // periodMs/rangeMs come from unvalidated external duration fields. A NaN
+      // slips past `<= 0` / `< 0` (both false for NaN) and would then spin the
+      // loop the full SHOWTIME_MAX_ITERATIONS doing nothing — guard explicitly.
+      if (
+        !Number.isFinite(offset) ||
+        !Number.isFinite(periodMs) || periodMs <= 0 ||
+        !Number.isFinite(rangeMs) || rangeMs < 0
+      ) return [];
 
       // A period without a range_length marks point-in-time occurrences: a show
       // start time with no encoded duration. Emit those as zero-length

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -300,6 +300,19 @@ function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string)
   return slots;
 }
 
+/**
+ * Whether `nowMs` sits inside any of the given opening-hour slots, under
+ * half-open [start, end) containment. Slots whose bounds are missing or
+ * unparseable are ignored. Shared by the restaurant and park live-status logic.
+ */
+function isOpenNow(hours: LiveTimeSlot[], nowMs: number): boolean {
+  return hours.some(h => {
+    const s = h.startTime ? Date.parse(h.startTime) : NaN;
+    const e = h.endTime ? Date.parse(h.endTime) : NaN;
+    return Number.isFinite(s) && Number.isFinite(e) && s <= nowMs && nowMs < e;
+  });
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Show schedules (`ShowTimes` recurring-schedule algebra)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1198,13 +1211,7 @@ class AttractionsIOV1 extends Destination {
         if (typeof record.IsOpen === 'boolean') {
           status = record.IsOpen ? 'OPERATING' : 'CLOSED';
         } else {
-          const nowMs = Date.now();
-          const openNow = hours.some(h => {
-            const s = h.startTime ? Date.parse(h.startTime) : NaN;
-            const e = h.endTime ? Date.parse(h.endTime) : NaN;
-            return Number.isFinite(s) && Number.isFinite(e) && s <= nowMs && nowMs < e;
-          });
-          status = openNow ? 'OPERATING' : 'CLOSED';
+          status = isOpenNow(hours, Date.now()) ? 'OPERATING' : 'CLOSED';
         }
 
         const entry: LiveData = {id, status};
@@ -1215,13 +1222,16 @@ class AttractionsIOV1 extends Destination {
       }
     }
 
-    // Park: today's actual opening window (from the Resort record)
+    // Park: today's actual opening window (from the Resort record). Status is
+    // derived from whether "now" sits inside that window — the Resort record
+    // carries the same hours every day, so a fixed OPERATING would report the
+    // park open all night, every night, after close and before open.
     const resort = raw?.entities?.Resort?.records?.[0];
     const parkHours = parseLiveOpeningTimes(resort?.OpeningTimes, this.timezone);
     if (parkHours.length > 0) {
       liveData.push({
         id: this.parkId,
-        status: 'OPERATING',
+        status: isOpenNow(parkHours, Date.now()) ? 'OPERATING' : 'CLOSED',
         operatingHours: parkHours,
       });
     }

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -75,16 +75,29 @@ const ATTRACTION_CATEGORIES = [
   'Rides & Attractions',
 ];
 
-const SHOW_CATEGORIES = ['Shows', 'Show', 'Live Shows'];
+const SHOW_CATEGORIES = ['Shows', 'Show', 'Live Shows', 'Entertainment', 'Shows & 4D Movies', '4D Movies'];
 
 const RESTAURANT_CATEGORIES = [
   'Restaurants',
+  'Restaurant',
   'Fast Food',
+  'Fast food',
   'Snacks',
+  'Snacks & Sweets',
   'Healthy Food',
   'Food',
   'Dining',
   'Food & Drink',
+  'Food & Drinks',
+  'Food & drinks',
+  'Food on to go',
+  'Café & Snacks',
+  'Beverages',
+  'Buffet',
+  'Restaurants & buffets',
+  'Slush ice',
+  'Ice cream, coffee & treats',
+  'Barbecue & food from home',
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1555,14 +1568,6 @@ type HeideParkScheduleResponse = {
 
 @config
 class HeideParkBase extends AttractionsIOV1 {
-  /**
-   * HeidePark labels its shows/animations "Entertainment" rather than the
-   * default "Shows"/"Show"/"Live Shows", so extend the show category list.
-   */
-  protected getShowCategories(): string[] {
-    return [...SHOW_CATEGORIES, 'Entertainment'];
-  }
-
   /**
    * Fetch the v2 resort-opening-times endpoint (specific to HeidePark).
    * Cached for 2 hours.

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -265,7 +265,7 @@ function splitLiveDateTime(raw: string): {date: string; time: string} | null {
  * wall-clock times without an offset, so they are normalised to ISO+offset via
  * constructDateTime. Returns [] for null/blank/unparseable/non-range values.
  */
-function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string): LiveTimeSlot[] {
+export function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string): LiveTimeSlot[] {
   if (typeof raw !== 'string' || raw.trim() === '') return [];
 
   let parsed: unknown;

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -355,7 +355,8 @@ function showTimeDurationMs(d: ShowTimeDuration | undefined): number {
 
 /** Sort and merge overlapping/adjacent intervals into a normalised set. */
 function normaliseIntervals(list: ShowTimeInterval[]): ShowTimeInterval[] {
-  const sorted = list.filter(([s, e]) => s < e).sort((a, b) => a[0] - b[0]);
+  // Keep zero-length points (s === e); drop only malformed s > e intervals.
+  const sorted = list.filter(([s, e]) => s <= e).sort((a, b) => a[0] - b[0] || a[1] - b[1]);
   const out: ShowTimeInterval[] = [];
   for (const [s, e] of sorted) {
     const last = out[out.length - 1];
@@ -371,7 +372,9 @@ function intersectIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowT
     for (const [bs, be] of b) {
       const s = Math.max(as, bs);
       const e = Math.min(ae, be);
-      if (s < e) out.push([s, e]);
+      // Keep the overlap; also keep a point (s === e) when it sits on one of the
+      // operands — a point occurrence contained by a season/weekday span.
+      if (s < e || (s === e && (as === ae || bs === be))) out.push([s, e]);
     }
   }
   return normaliseIntervals(out);
@@ -431,13 +434,23 @@ export function evaluateShowTimeNode(
       const offset = parseNaiveMs(node.offset_date);
       const periodMs = showTimeDurationMs(node.period_length);
       const rangeMs = showTimeDurationMs(node.range_length);
-      if (!Number.isFinite(offset) || periodMs <= 0 || rangeMs <= 0) return [];
+      if (!Number.isFinite(offset) || periodMs <= 0 || rangeMs < 0) return [];
+
+      // A period without a range_length marks point-in-time occurrences: a show
+      // start time with no encoded duration. Emit those as zero-length
+      // intervals [s, s] so they survive intersection with the season/weekday
+      // windows and surface as start-only slots.
+      const isPoint = rangeMs === 0;
 
       const out: ShowTimeInterval[] = [];
       let n = Math.floor((winStart - offset - rangeMs) / periodMs);
       for (let i = 0; i < SHOWTIME_MAX_ITERATIONS; i++, n++) {
         const s = offset + n * periodMs;
         if (s >= winEnd) break;
+        if (isPoint) {
+          if (s >= winStart) out.push([s, s]);
+          continue;
+        }
         const cs = Math.max(s, winStart);
         const ce = Math.min(s + rangeMs, winEnd);
         if (cs < ce) out.push([cs, ce]);
@@ -500,12 +513,17 @@ export function showTimesForDate(
   return evaluateShowTimeNode(node, winStart, winEnd).map(([s, e]) => {
     // s/e are naive-local ms; read back the wall clock via UTC getters.
     const startIso = new Date(s).toISOString();
-    const endIso = new Date(e).toISOString();
-    return {
+    const slot: LiveTimeSlot = {
       type,
       startTime: constructDateTime(startIso.slice(0, 10), startIso.slice(11, 19), timezone),
-      endTime: constructDateTime(endIso.slice(0, 10), endIso.slice(11, 19), timezone),
     };
+    // A point occurrence (s === e) is a start time with no encoded duration —
+    // leave endTime unset. Otherwise attach the concrete end.
+    if (e > s) {
+      const endIso = new Date(e).toISOString();
+      slot.endTime = constructDateTime(endIso.slice(0, 10), endIso.slice(11, 19), timezone);
+    }
+    return slot;
   });
 }
 

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -365,6 +365,11 @@ const SHOWTIME_MAX_ITERATIONS = 100_000;
  * it as UTC so UTC getters reproduce the wall clock. NaN for bad input.
  */
 function parseNaiveMs(raw: string): number {
+  // Records data is external and only loosely typed, so a node's start/end/
+  // offset_date can arrive null, missing or non-string. Guard before .trim()
+  // so bad input yields NaN (which the callers already treat as "drop") rather
+  // than throwing.
+  if (typeof raw !== 'string') return NaN;
   return Date.parse(raw.trim().replace(' ', 'T') + 'Z');
 }
 
@@ -1249,7 +1254,15 @@ class AttractionsIOV1 extends Destination {
         // live-data entry — keep the earlier classification.
         if (attractionIds.has(id) || restaurantIds.has(id)) continue;
 
-        const showtimes = showTimesForDate(item.ShowTimes, today, this.timezone);
+        // A single malformed ShowTimes record must not take down live data for
+        // the whole park (attraction/restaurant/park entries are already on the
+        // array). Contain the failure to this one show and keep the rest.
+        let showtimes: LiveTimeSlot[];
+        try {
+          showtimes = showTimesForDate(item.ShowTimes, today, this.timezone);
+        } catch {
+          continue;
+        }
 
         // Status derives from the schedule (there is no live "running now" feed):
         // OPERATING only while a performance is still upcoming or ongoing, then

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -310,17 +310,17 @@ function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string)
  * single day yields the concrete performance windows for that day.
  *
  * Node grammar (each node is a set of instants):
- *   • range         — a continuous span [start, end)
- *   • period        — a repeating window: from `offset_date`, every
+ *   - range         — a continuous span [start, end)
+ *   - period        — a repeating window: from `offset_date`, every
  *                     `period_length`, a window `range_length` long is "on".
  *                     Daily period (offset 12:00 / range 30min) → "every day
  *                     12:00–12:30". Weekly period (period_length 7 days) with
  *                     range_length N days selects N consecutive weekdays;
  *                     offset_date's weekday picks the start day.
- *   • union         — set union of children
- *   • intersection  — set intersection of children
- *   • difference    — children[0] minus the union of the rest
- *   • complement    — the evaluation window minus its child
+ *   - union         — set union of children
+ *   - intersection  — set intersection of children
+ *   - difference    — children[0] minus the union of the rest
+ *   - complement    — the evaluation window minus its child
  *
  * Timestamps are naive park-local wall-clock; evaluation happens in that naive
  * space (so daily periods stay fixed across DST), then concrete date + time are
@@ -385,9 +385,17 @@ function intersectIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowT
     for (const [bs, be] of b) {
       const s = Math.max(as, bs);
       const e = Math.min(ae, be);
-      // Keep the overlap; also keep a point (s === e) when it sits on one of the
-      // operands — a point occurrence contained by a season/weekday span.
-      if (s < e || (s === e && (as === ae || bs === be))) out.push([s, e]);
+      if (s < e) {
+        out.push([s, e]);
+      } else if (s === e) {
+        // A zero-length point [p, p] survives only when it lies within BOTH
+        // operands under half-open [start, end) containment, so a point on a
+        // span's exclusive end is dropped while an interior one is kept.
+        const p = s;
+        const inA = as === ae ? as === p : as <= p && p < ae;
+        const inB = bs === be ? bs === p : bs <= p && p < be;
+        if (inA && inB) out.push([p, p]);
+      }
     }
   }
   return normaliseIntervals(out);
@@ -399,6 +407,13 @@ function subtractIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTi
   for (const [bs, be] of normaliseIntervals(b)) {
     const next: ShowTimeInterval[] = [];
     for (const [as, ae] of current) {
+      // A zero-length point is removed only when [bs, be) covers it under
+      // half-open containment (bs <= p < be); the generic overlap test below
+      // assumes a positive-width interval.
+      if (as === ae) {
+        if (!(bs <= as && as < be)) next.push([as, ae]);
+        continue;
+      }
       if (be <= as || bs >= ae) {
         next.push([as, ae]); // no overlap
         continue;
@@ -985,7 +1000,7 @@ class AttractionsIOV1 extends Destination {
 
   /**
    * Category names treated as SHOW entities. Overridable by subclasses whose
-   * park labels its shows differently (e.g. HeidePark uses "Entertainment").
+   * park files its shows under a different category name.
    */
   protected getShowCategories(): string[] {
     return SHOW_CATEGORIES;
@@ -1107,10 +1122,10 @@ class AttractionsIOV1 extends Destination {
 
   /**
    * Build live data for every entity type the API exposes:
-   *   • attractions — operating status + standby wait time (live feed)
-   *   • restaurants — open/closed status + today's opening hours (live feed)
-   *   • the park itself — today's opening window (live Resort record)
-   *   • shows — today's performance times, evaluated from each show's recurring
+   *   - attractions — operating status + standby wait time (live feed)
+   *   - restaurants — open/closed status + today's opening hours (live feed)
+   *   - the park itself — today's opening window (live Resort record)
+   *   - shows — today's performance times, evaluated from each show's recurring
    *     ShowTimes schedule in the records data (there is no live show feed)
    *
    * Each block is driven by the entity IDs that actually exist for the park, so
@@ -1173,12 +1188,26 @@ class AttractionsIOV1 extends Destination {
       // report IsOperational:false unconditionally (it flags running rides), so
       // IsOpen is the real signal here.
       if (restaurantIds.has(id)) {
-        const entry: LiveData = {
-          id,
-          status: record.IsOpen ? 'OPERATING' : 'CLOSED',
-        };
-
         const hours = parseLiveOpeningTimes(record.OpeningTimes, this.timezone);
+
+        // IsOpen is the live open/closed signal for dining venues. Some feeds
+        // omit it for a subset of venues; there, fall back to whether "now"
+        // sits inside today's opening window rather than asserting CLOSED with
+        // no evidence.
+        let status: 'OPERATING' | 'CLOSED';
+        if (typeof record.IsOpen === 'boolean') {
+          status = record.IsOpen ? 'OPERATING' : 'CLOSED';
+        } else {
+          const nowMs = Date.now();
+          const openNow = hours.some(h => {
+            const s = h.startTime ? Date.parse(h.startTime) : NaN;
+            const e = h.endTime ? Date.parse(h.endTime) : NaN;
+            return Number.isFinite(s) && Number.isFinite(e) && s <= nowMs && nowMs < e;
+          });
+          status = openNow ? 'OPERATING' : 'CLOSED';
+        }
+
+        const entry: LiveData = {id, status};
         if (hours.length > 0) entry.operatingHours = hours;
 
         liveData.push(entry);
@@ -1205,6 +1234,10 @@ class AttractionsIOV1 extends Destination {
       for (const item of poi.Item) {
         const id = String(item._id);
         if (!showIds.has(id)) continue;
+        // An item classified into more than one type (e.g. a show-named category
+        // nested under an attraction one) must not emit a second, conflicting
+        // live-data entry — keep the earlier classification.
+        if (attractionIds.has(id) || restaurantIds.has(id)) continue;
 
         const showtimes = showTimesForDate(item.ShowTimes, today, this.timezone);
 

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -127,12 +127,27 @@ type LiveDataRecord = {
   IsOperational?: boolean;
   IsOpen?: boolean;
   QueueTime?: number | null;
+  /**
+   * Present on venue records (restaurants/shops); rides leave it null. A
+   * stringified {"type":"range",start,end} blob of today's opening window.
+   * `IsOperational` flags *running rides*, so it is always false for dining/
+   * retail venues — `IsOpen` is the correct open/closed signal there.
+   */
+  OpeningTimes?: string | null;
+};
+
+type LiveDataResortRecord = {
+  _id: number;
+  OpeningTimes?: string | null;
 };
 
 type LiveDataResponse = {
   entities: {
     Item: {
       records: LiveDataRecord[];
+    };
+    Resort?: {
+      records?: LiveDataResortRecord[];
     };
   };
 };
@@ -215,6 +230,283 @@ function parseOpeningHours(raw: string): TimeParseResult {
   }
 
   return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live-data opening-hours parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Split "YYYY-MM-DD HH:MM[:SS]" into {date, time}; null if malformed. */
+function splitLiveDateTime(raw: string): {date: string; time: string} | null {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2})?)/.exec(raw.trim());
+  return m ? {date: m[1], time: m[2]} : null;
+}
+
+/**
+ * Parse an Attractions.io live-data `OpeningTimes` value into schema
+ * LiveTimeSlot entries.
+ *
+ * The field is a *stringified* JSON blob, e.g.
+ *   `{"type":"range","start":"2026-07-08 10:00:00","end":"2026-07-08 18:00:00"}`
+ * (a single object, or defensively an array of them). Start/end are park-local
+ * wall-clock times without an offset, so they are normalised to ISO+offset via
+ * constructDateTime. Returns [] for null/blank/unparseable/non-range values.
+ */
+function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string): LiveTimeSlot[] {
+  if (typeof raw !== 'string' || raw.trim() === '') return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const ranges = Array.isArray(parsed) ? parsed : [parsed];
+  const slots: LiveTimeSlot[] = [];
+
+  for (const r of ranges) {
+    if (
+      !r || typeof r !== 'object' ||
+      (r as any).type !== 'range' ||
+      typeof (r as any).start !== 'string' ||
+      typeof (r as any).end !== 'string'
+    ) continue;
+
+    const start = splitLiveDateTime((r as any).start);
+    const end = splitLiveDateTime((r as any).end);
+    if (!start || !end) continue;
+
+    slots.push({
+      type: 'OPERATING',
+      startTime: constructDateTime(start.date, start.time, timezone),
+      endTime: constructDateTime(end.date, end.time, timezone),
+    });
+  }
+
+  return slots;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Show schedules (`ShowTimes` recurring-schedule algebra)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Attractions.io encodes a show/animation's recurring schedule in the records
+ * `ShowTimes` field as a nested set-algebra tree. Evaluating that tree against a
+ * single day yields the concrete performance windows for that day.
+ *
+ * Node grammar (each node is a set of instants):
+ *   • range         — a continuous span [start, end)
+ *   • period        — a repeating window: from `offset_date`, every
+ *                     `period_length`, a window `range_length` long is "on".
+ *                     Daily period (offset 12:00 / range 30min) → "every day
+ *                     12:00–12:30". Weekly period (period_length 7 days) with
+ *                     range_length N days selects N consecutive weekdays;
+ *                     offset_date's weekday picks the start day.
+ *   • union         — set union of children
+ *   • intersection  — set intersection of children
+ *   • difference    — children[0] minus the union of the rest
+ *   • complement    — the evaluation window minus its child
+ *
+ * Timestamps are naive park-local wall-clock; evaluation happens in that naive
+ * space (so daily periods stay fixed across DST), then concrete date + time are
+ * handed to constructDateTime for correctly-offset ISO output.
+ */
+type ShowTimeDuration = {
+  week?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+};
+
+export type ShowTimeNode =
+  | {type: 'range'; start: string; end: string}
+  | {type: 'period'; offset_date: string; period_length: ShowTimeDuration; range_length: ShowTimeDuration}
+  | {type: 'union' | 'intersection' | 'difference' | 'complement'; children: ShowTimeNode[]};
+
+/** A half-open interval [start, end) in naive-local milliseconds. */
+type ShowTimeInterval = [number, number];
+
+const SHOWTIME_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Guard against pathological period definitions producing unbounded loops. */
+const SHOWTIME_MAX_ITERATIONS = 100_000;
+
+/**
+ * Parse a naive "YYYY-MM-DD HH:MM:SS" (or ISO) wall-clock string to ms, treating
+ * it as UTC so UTC getters reproduce the wall clock. NaN for bad input.
+ */
+function parseNaiveMs(raw: string): number {
+  return Date.parse(raw.trim().replace(' ', 'T') + 'Z');
+}
+
+function showTimeDurationMs(d: ShowTimeDuration | undefined): number {
+  if (!d || typeof d !== 'object') return 0;
+  return (
+    (d.week || 0) * 7 * SHOWTIME_DAY_MS +
+    (d.day || 0) * SHOWTIME_DAY_MS +
+    (d.hour || 0) * 60 * 60 * 1000 +
+    (d.minute || 0) * 60 * 1000 +
+    (d.second || 0) * 1000
+  );
+}
+
+/** Sort and merge overlapping/adjacent intervals into a normalised set. */
+function normaliseIntervals(list: ShowTimeInterval[]): ShowTimeInterval[] {
+  const sorted = list.filter(([s, e]) => s < e).sort((a, b) => a[0] - b[0]);
+  const out: ShowTimeInterval[] = [];
+  for (const [s, e] of sorted) {
+    const last = out[out.length - 1];
+    if (last && s <= last[1]) last[1] = Math.max(last[1], e);
+    else out.push([s, e]);
+  }
+  return out;
+}
+
+function intersectIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTimeInterval[] {
+  const out: ShowTimeInterval[] = [];
+  for (const [as, ae] of a) {
+    for (const [bs, be] of b) {
+      const s = Math.max(as, bs);
+      const e = Math.min(ae, be);
+      if (s < e) out.push([s, e]);
+    }
+  }
+  return normaliseIntervals(out);
+}
+
+/** Remove every part of `b` from `a`. */
+function subtractIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTimeInterval[] {
+  let current = normaliseIntervals(a);
+  for (const [bs, be] of normaliseIntervals(b)) {
+    const next: ShowTimeInterval[] = [];
+    for (const [as, ae] of current) {
+      if (be <= as || bs >= ae) {
+        next.push([as, ae]); // no overlap
+        continue;
+      }
+      if (as < bs) next.push([as, bs]); // left remainder
+      if (be < ae) next.push([be, ae]); // right remainder
+    }
+    current = next;
+  }
+  return normaliseIntervals(current);
+}
+
+/**
+ * Safely parse a raw `ShowTimes` field value into a node, or null when
+ * absent/blank/unparseable.
+ */
+export function parseShowTimes(raw: string | null | undefined): ShowTimeNode | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && typeof parsed.type === 'string'
+      ? (parsed as ShowTimeNode)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evaluate a ShowTimes node against the window [winStart, winEnd) and return the
+ * normalised set of active intervals within that window (naive-local ms).
+ */
+export function evaluateShowTimeNode(
+  node: ShowTimeNode,
+  winStart: number,
+  winEnd: number,
+): ShowTimeInterval[] {
+  switch (node.type) {
+    case 'range': {
+      const s = Math.max(parseNaiveMs(node.start), winStart);
+      const e = Math.min(parseNaiveMs(node.end), winEnd);
+      return Number.isFinite(s) && Number.isFinite(e) && s < e ? [[s, e]] : [];
+    }
+
+    case 'period': {
+      const offset = parseNaiveMs(node.offset_date);
+      const periodMs = showTimeDurationMs(node.period_length);
+      const rangeMs = showTimeDurationMs(node.range_length);
+      if (!Number.isFinite(offset) || periodMs <= 0 || rangeMs <= 0) return [];
+
+      const out: ShowTimeInterval[] = [];
+      let n = Math.floor((winStart - offset - rangeMs) / periodMs);
+      for (let i = 0; i < SHOWTIME_MAX_ITERATIONS; i++, n++) {
+        const s = offset + n * periodMs;
+        if (s >= winEnd) break;
+        const cs = Math.max(s, winStart);
+        const ce = Math.min(s + rangeMs, winEnd);
+        if (cs < ce) out.push([cs, ce]);
+      }
+      return normaliseIntervals(out);
+    }
+
+    case 'union':
+      return normaliseIntervals((node.children || []).flatMap(c => evaluateShowTimeNode(c, winStart, winEnd)));
+
+    case 'intersection': {
+      const children = node.children || [];
+      if (children.length === 0) return [];
+      return children
+        .map(c => evaluateShowTimeNode(c, winStart, winEnd))
+        .reduce((acc, cur) => intersectIntervals(acc, cur));
+    }
+
+    case 'difference': {
+      const children = node.children || [];
+      if (children.length === 0) return [];
+      const [first, ...rest] = children.map(c => evaluateShowTimeNode(c, winStart, winEnd));
+      return rest.reduce((acc, cur) => subtractIntervals(acc, cur), first);
+    }
+
+    case 'complement': {
+      const inner = normaliseIntervals(
+        (node.children || []).flatMap(c => evaluateShowTimeNode(c, winStart, winEnd)),
+      );
+      return subtractIntervals([[winStart, winEnd]], inner);
+    }
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * Evaluate a raw `ShowTimes` value for a single calendar day and return
+ * schema-ready LiveTimeSlot entries with timezone-correct ISO times.
+ *
+ * @param raw   Stringified ShowTimes JSON (or null/undefined).
+ * @param date  Target day "YYYY-MM-DD" in the park's local timezone.
+ * @param timezone  IANA timezone (e.g. "Europe/Berlin").
+ * @param type  Value for each slot's `type` field (defaults to "Showtime").
+ */
+export function showTimesForDate(
+  raw: string | null | undefined,
+  date: string,
+  timezone: string,
+  type: string = 'Showtime',
+): LiveTimeSlot[] {
+  const node = parseShowTimes(raw);
+  if (!node) return [];
+
+  const winStart = parseNaiveMs(`${date} 00:00:00`);
+  if (!Number.isFinite(winStart)) return [];
+  const winEnd = winStart + SHOWTIME_DAY_MS;
+
+  return evaluateShowTimeNode(node, winStart, winEnd).map(([s, e]) => {
+    // s/e are naive-local ms; read back the wall clock via UTC getters.
+    const startIso = new Date(s).toISOString();
+    const endIso = new Date(e).toISOString();
+    return {
+      type,
+      startTime: constructDateTime(startIso.slice(0, 10), startIso.slice(11, 19), timezone),
+      endTime: constructDateTime(endIso.slice(0, 10), endIso.slice(11, 19), timezone),
+    };
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -782,13 +1074,28 @@ class AttractionsIOV1 extends Destination {
     ];
   }
 
+  /**
+   * Build live data for every entity type the API exposes:
+   *   • attractions — operating status + standby wait time (live feed)
+   *   • restaurants — open/closed status + today's opening hours (live feed)
+   *   • the park itself — today's opening window (live Resort record)
+   *   • shows — today's performance times, evaluated from each show's recurring
+   *     ShowTimes schedule in the records data (there is no live show feed)
+   *
+   * Each block is driven by the entity IDs that actually exist for the park, so
+   * a park that has no restaurants/shows (or whose live feed omits the venue
+   * fields) simply contributes nothing for those blocks.
+   */
   protected async buildLiveData(): Promise<LiveData[]> {
-    // Get known attraction entity IDs
     const entities = await this.getEntities();
     const attractionIds = new Set(
-      entities
-        .filter(e => e.entityType === 'ATTRACTION')
-        .map(e => e.id)
+      entities.filter(e => e.entityType === 'ATTRACTION').map(e => e.id),
+    );
+    const restaurantIds = new Set(
+      entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id),
+    );
+    const showIds = new Set(
+      entities.filter(e => e.entityType === 'SHOW').map(e => e.id),
     );
 
     const resp = await this.fetchLiveData();
@@ -800,33 +1107,93 @@ class AttractionsIOV1 extends Destination {
 
     for (const record of records) {
       const id = String(record._id);
-      if (!attractionIds.has(id)) continue;
 
-      // Determine status
-      let status: 'OPERATING' | 'CLOSED' | 'DOWN' = record.IsOperational ? 'OPERATING' : 'CLOSED';
-      if (record.IsOpen === false) {
-        status = 'CLOSED';
-      }
+      // Attractions: operating status + standby wait time
+      if (attractionIds.has(id)) {
+        // Determine status
+        let status: 'OPERATING' | 'CLOSED' | 'DOWN' = record.IsOperational ? 'OPERATING' : 'CLOSED';
+        if (record.IsOpen === false) {
+          status = 'CLOSED';
+        }
 
-      const entry: LiveData = {
-        id,
-        status,
-      };
+        const entry: LiveData = {
+          id,
+          status,
+        };
 
-      // Wait time (in seconds from API – convert to minutes)
-      if (record.QueueTime !== undefined && record.QueueTime !== null) {
-        if (typeof record.QueueTime === 'number' && Number.isFinite(record.QueueTime)) {
+        // Wait time (in seconds from API – convert to minutes)
+        if (record.QueueTime !== undefined && record.QueueTime !== null) {
+          if (typeof record.QueueTime === 'number' && Number.isFinite(record.QueueTime)) {
+            entry.queue = {
+              STANDBY: {waitTime: Math.floor(record.QueueTime / 60)},
+            };
+          }
+        } else if (record.QueueTime === null) {
           entry.queue = {
-            STANDBY: {waitTime: Math.floor(record.QueueTime / 60)},
+            STANDBY: {waitTime: undefined},
           };
         }
-      } else if (record.QueueTime === null) {
-        entry.queue = {
-          STANDBY: {waitTime: undefined},
-        };
+
+        liveData.push(entry);
+        continue;
       }
 
-      liveData.push(entry);
+      // Restaurants: open/closed status + today's opening hours. Dining venues
+      // report IsOperational:false unconditionally (it flags running rides), so
+      // IsOpen is the real signal here.
+      if (restaurantIds.has(id)) {
+        const entry: LiveData = {
+          id,
+          status: record.IsOpen ? 'OPERATING' : 'CLOSED',
+        };
+
+        const hours = parseLiveOpeningTimes(record.OpeningTimes, this.timezone);
+        if (hours.length > 0) entry.operatingHours = hours;
+
+        liveData.push(entry);
+        continue;
+      }
+    }
+
+    // Park: today's actual opening window (from the Resort record)
+    const resort = raw?.entities?.Resort?.records?.[0];
+    const parkHours = parseLiveOpeningTimes(resort?.OpeningTimes, this.timezone);
+    if (parkHours.length > 0) {
+      liveData.push({
+        id: this.parkId,
+        status: 'OPERATING',
+        operatingHours: parkHours,
+      });
+    }
+
+    // Shows: today's performance times, evaluated from each show's recurring
+    // ShowTimes schedule in the records data (not the live feed)
+    if (showIds.size > 0) {
+      const today = formatDate(new Date(), this.timezone);
+      const poi = await this.getPOIData();
+      for (const item of poi.Item) {
+        const id = String(item._id);
+        if (!showIds.has(id)) continue;
+
+        const showtimes = showTimesForDate(item.ShowTimes, today, this.timezone);
+
+        // Status derives from the schedule (there is no live "running now" feed):
+        // OPERATING only while a performance is still upcoming or ongoing, then
+        // CLOSED once the day's last performance has ended. The full day's
+        // schedule stays published in `showtimes`.
+        const nowMs = Date.now();
+        const hasUpcoming = showtimes.some(s => {
+          const end = s.endTime ?? s.startTime;
+          return end != null && Date.parse(end) > nowMs;
+        });
+
+        const entry: LiveData = {
+          id,
+          status: hasUpcoming ? 'OPERATING' : 'CLOSED',
+        };
+        if (showtimes.length > 0) entry.showtimes = showtimes;
+        liveData.push(entry);
+      }
     }
 
     return liveData;
@@ -1152,308 +1519,6 @@ export class Gardaland extends AttractionsIOV1 {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// HeidePark — live-data opening hours
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * A live-data `Item` record as returned for HeidePark. Extends the base shape
- * with the venue fields (restaurants/shops carry these; rides leave them null).
- * `IsOperational` flags *rides that are running* — it is always false for
- * dining/retail venues, so `IsOpen` is the correct open/closed signal there.
- */
-type HeideLiveItemRecord = {
-  _id: number;
-  IsOpen?: boolean;
-  IsOperational?: boolean;
-  OpeningTimes?: string | null;
-};
-
-type HeideLiveResortRecord = {
-  _id: number;
-  OpeningTimes?: string | null;
-};
-
-type HeideLiveResponse = {
-  entities?: {
-    Item?: {records?: HeideLiveItemRecord[]};
-    Resort?: {records?: HeideLiveResortRecord[]};
-  };
-};
-
-/** Split "YYYY-MM-DD HH:MM[:SS]" into {date, time}; null if malformed. */
-function splitLiveDateTime(raw: string): {date: string; time: string} | null {
-  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2})?)/.exec(raw.trim());
-  return m ? {date: m[1], time: m[2]} : null;
-}
-
-/**
- * Parse an Attractions.io live-data `OpeningTimes` value into schema
- * LiveTimeSlot entries.
- *
- * The field is a *stringified* JSON blob, e.g.
- *   `{"type":"range","start":"2026-07-08 10:00:00","end":"2026-07-08 18:00:00"}`
- * (a single object, or defensively an array of them). Start/end are park-local
- * wall-clock times without an offset, so they are normalised to ISO+offset via
- * constructDateTime. Returns [] for null/blank/unparseable/non-range values.
- */
-function parseLiveOpeningTimes(raw: string | null | undefined, timezone: string): LiveTimeSlot[] {
-  if (typeof raw !== 'string' || raw.trim() === '') return [];
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return [];
-  }
-
-  const ranges = Array.isArray(parsed) ? parsed : [parsed];
-  const slots: LiveTimeSlot[] = [];
-
-  for (const r of ranges) {
-    if (
-      !r || typeof r !== 'object' ||
-      (r as any).type !== 'range' ||
-      typeof (r as any).start !== 'string' ||
-      typeof (r as any).end !== 'string'
-    ) continue;
-
-    const start = splitLiveDateTime((r as any).start);
-    const end = splitLiveDateTime((r as any).end);
-    if (!start || !end) continue;
-
-    slots.push({
-      type: 'OPERATING',
-      startTime: constructDateTime(start.date, start.time, timezone),
-      endTime: constructDateTime(end.date, end.time, timezone),
-    });
-  }
-
-  return slots;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// HeidePark — show schedules (`ShowTimes` recurring-schedule algebra)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Attractions.io encodes a show/animation's recurring schedule in the records
- * `ShowTimes` field as a nested set-algebra tree. Evaluating that tree against a
- * single day yields the concrete performance windows for that day.
- *
- * Node grammar (each node is a set of instants):
- *   • range         — a continuous span [start, end)
- *   • period        — a repeating window: from `offset_date`, every
- *                     `period_length`, a window `range_length` long is "on".
- *                     Daily period (offset 12:00 / range 30min) → "every day
- *                     12:00–12:30". Weekly period (period_length 7 days) with
- *                     range_length N days selects N consecutive weekdays;
- *                     offset_date's weekday picks the start day.
- *   • union         — set union of children
- *   • intersection  — set intersection of children
- *   • difference    — children[0] minus the union of the rest
- *   • complement    — the evaluation window minus its child
- *
- * Timestamps are naive park-local wall-clock; evaluation happens in that naive
- * space (so daily periods stay fixed across DST), then concrete date + time are
- * handed to constructDateTime for correctly-offset ISO output.
- */
-type ShowTimeDuration = {
-  week?: number;
-  day?: number;
-  hour?: number;
-  minute?: number;
-  second?: number;
-};
-
-export type ShowTimeNode =
-  | {type: 'range'; start: string; end: string}
-  | {type: 'period'; offset_date: string; period_length: ShowTimeDuration; range_length: ShowTimeDuration}
-  | {type: 'union' | 'intersection' | 'difference' | 'complement'; children: ShowTimeNode[]};
-
-/** A half-open interval [start, end) in naive-local milliseconds. */
-type ShowTimeInterval = [number, number];
-
-const SHOWTIME_DAY_MS = 24 * 60 * 60 * 1000;
-
-/** Guard against pathological period definitions producing unbounded loops. */
-const SHOWTIME_MAX_ITERATIONS = 100_000;
-
-/**
- * Parse a naive "YYYY-MM-DD HH:MM:SS" (or ISO) wall-clock string to ms, treating
- * it as UTC so UTC getters reproduce the wall clock. NaN for bad input.
- */
-function parseNaiveMs(raw: string): number {
-  return Date.parse(raw.trim().replace(' ', 'T') + 'Z');
-}
-
-function showTimeDurationMs(d: ShowTimeDuration | undefined): number {
-  if (!d || typeof d !== 'object') return 0;
-  return (
-    (d.week || 0) * 7 * SHOWTIME_DAY_MS +
-    (d.day || 0) * SHOWTIME_DAY_MS +
-    (d.hour || 0) * 60 * 60 * 1000 +
-    (d.minute || 0) * 60 * 1000 +
-    (d.second || 0) * 1000
-  );
-}
-
-/** Sort and merge overlapping/adjacent intervals into a normalised set. */
-function normaliseIntervals(list: ShowTimeInterval[]): ShowTimeInterval[] {
-  const sorted = list.filter(([s, e]) => s < e).sort((a, b) => a[0] - b[0]);
-  const out: ShowTimeInterval[] = [];
-  for (const [s, e] of sorted) {
-    const last = out[out.length - 1];
-    if (last && s <= last[1]) last[1] = Math.max(last[1], e);
-    else out.push([s, e]);
-  }
-  return out;
-}
-
-function intersectIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTimeInterval[] {
-  const out: ShowTimeInterval[] = [];
-  for (const [as, ae] of a) {
-    for (const [bs, be] of b) {
-      const s = Math.max(as, bs);
-      const e = Math.min(ae, be);
-      if (s < e) out.push([s, e]);
-    }
-  }
-  return normaliseIntervals(out);
-}
-
-/** Remove every part of `b` from `a`. */
-function subtractIntervals(a: ShowTimeInterval[], b: ShowTimeInterval[]): ShowTimeInterval[] {
-  let current = normaliseIntervals(a);
-  for (const [bs, be] of normaliseIntervals(b)) {
-    const next: ShowTimeInterval[] = [];
-    for (const [as, ae] of current) {
-      if (be <= as || bs >= ae) {
-        next.push([as, ae]); // no overlap
-        continue;
-      }
-      if (as < bs) next.push([as, bs]); // left remainder
-      if (be < ae) next.push([be, ae]); // right remainder
-    }
-    current = next;
-  }
-  return normaliseIntervals(current);
-}
-
-/**
- * Safely parse a raw `ShowTimes` field value into a node, or null when
- * absent/blank/unparseable.
- */
-export function parseShowTimes(raw: string | null | undefined): ShowTimeNode | null {
-  if (typeof raw !== 'string' || raw.trim() === '') return null;
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' && typeof parsed.type === 'string'
-      ? (parsed as ShowTimeNode)
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Evaluate a ShowTimes node against the window [winStart, winEnd) and return the
- * normalised set of active intervals within that window (naive-local ms).
- */
-export function evaluateShowTimeNode(
-  node: ShowTimeNode,
-  winStart: number,
-  winEnd: number,
-): ShowTimeInterval[] {
-  switch (node.type) {
-    case 'range': {
-      const s = Math.max(parseNaiveMs(node.start), winStart);
-      const e = Math.min(parseNaiveMs(node.end), winEnd);
-      return Number.isFinite(s) && Number.isFinite(e) && s < e ? [[s, e]] : [];
-    }
-
-    case 'period': {
-      const offset = parseNaiveMs(node.offset_date);
-      const periodMs = showTimeDurationMs(node.period_length);
-      const rangeMs = showTimeDurationMs(node.range_length);
-      if (!Number.isFinite(offset) || periodMs <= 0 || rangeMs <= 0) return [];
-
-      const out: ShowTimeInterval[] = [];
-      let n = Math.floor((winStart - offset - rangeMs) / periodMs);
-      for (let i = 0; i < SHOWTIME_MAX_ITERATIONS; i++, n++) {
-        const s = offset + n * periodMs;
-        if (s >= winEnd) break;
-        const cs = Math.max(s, winStart);
-        const ce = Math.min(s + rangeMs, winEnd);
-        if (cs < ce) out.push([cs, ce]);
-      }
-      return normaliseIntervals(out);
-    }
-
-    case 'union':
-      return normaliseIntervals((node.children || []).flatMap(c => evaluateShowTimeNode(c, winStart, winEnd)));
-
-    case 'intersection': {
-      const children = node.children || [];
-      if (children.length === 0) return [];
-      return children
-        .map(c => evaluateShowTimeNode(c, winStart, winEnd))
-        .reduce((acc, cur) => intersectIntervals(acc, cur));
-    }
-
-    case 'difference': {
-      const children = node.children || [];
-      if (children.length === 0) return [];
-      const [first, ...rest] = children.map(c => evaluateShowTimeNode(c, winStart, winEnd));
-      return rest.reduce((acc, cur) => subtractIntervals(acc, cur), first);
-    }
-
-    case 'complement': {
-      const inner = normaliseIntervals(
-        (node.children || []).flatMap(c => evaluateShowTimeNode(c, winStart, winEnd)),
-      );
-      return subtractIntervals([[winStart, winEnd]], inner);
-    }
-
-    default:
-      return [];
-  }
-}
-
-/**
- * Evaluate a raw `ShowTimes` value for a single calendar day and return
- * schema-ready LiveTimeSlot entries with timezone-correct ISO times.
- *
- * @param raw   Stringified ShowTimes JSON (or null/undefined).
- * @param date  Target day "YYYY-MM-DD" in the park's local timezone.
- * @param timezone  IANA timezone (e.g. "Europe/Berlin").
- * @param type  Value for each slot's `type` field (defaults to "Showtime").
- */
-export function showTimesForDate(
-  raw: string | null | undefined,
-  date: string,
-  timezone: string,
-  type: string = 'Showtime',
-): LiveTimeSlot[] {
-  const node = parseShowTimes(raw);
-  if (!node) return [];
-
-  const winStart = parseNaiveMs(`${date} 00:00:00`);
-  if (!Number.isFinite(winStart)) return [];
-  const winEnd = winStart + SHOWTIME_DAY_MS;
-
-  return evaluateShowTimeNode(node, winStart, winEnd).map(([s, e]) => {
-    // s/e are naive-local ms; read back the wall clock via UTC getters.
-    const startIso = new Date(s).toISOString();
-    const endIso = new Date(e).toISOString();
-    return {
-      type,
-      startTime: constructDateTime(startIso.slice(0, 10), startIso.slice(11, 19), timezone),
-      endTime: constructDateTime(endIso.slice(0, 10), endIso.slice(11, 19), timezone),
-    };
-  });
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // HeidePark — destination (custom v2 opening-times API)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1492,98 +1557,6 @@ class HeideParkBase extends AttractionsIOV1 {
       options: {json: true},
       tags: ['calendar'],
     } as any as HTTPObj;
-  }
-
-  /**
-   * HeidePark live data.
-   *
-   * Reuses the base implementation for attraction wait times, then augments it
-   * with what the base drops on the floor:
-   *   • restaurant open/closed status + today's opening hours (from the venue
-   *     `OpeningTimes` field, which the base never reads)
-   *   • the park's actual opening window for today (from the Resort record)
-   *   • show performance times for today, evaluated from each show's recurring
-   *     `ShowTimes` schedule in the records data (not the live feed)
-   */
-  protected async buildLiveData(): Promise<LiveData[]> {
-    // Base handles attraction wait times & status.
-    const liveData = await super.buildLiveData();
-
-    let raw: HeideLiveResponse;
-    try {
-      const resp = await this.fetchLiveData();
-      raw = await resp.json();
-    } catch {
-      return liveData;
-    }
-
-    // Restaurants: open/closed status + today's opening hours
-    const entities = await this.getEntities();
-    const restaurantIds = new Set(
-      entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id),
-    );
-
-    const records = raw?.entities?.Item?.records ?? [];
-    for (const record of records) {
-      const id = String(record._id);
-      if (!restaurantIds.has(id)) continue;
-
-      // Dining venues report IsOperational:false unconditionally (it flags
-      // running rides), so IsOpen is the real signal.
-      const entry: LiveData = {
-        id,
-        status: record.IsOpen ? 'OPERATING' : 'CLOSED',
-      };
-
-      const hours = parseLiveOpeningTimes(record.OpeningTimes, this.timezone);
-      if (hours.length > 0) entry.operatingHours = hours;
-
-      liveData.push(entry);
-    }
-
-    // Park: today's actual opening window (from the Resort record)
-    const resort = raw?.entities?.Resort?.records?.[0];
-    const parkHours = parseLiveOpeningTimes(resort?.OpeningTimes, this.timezone);
-    if (parkHours.length > 0) {
-      liveData.push({
-        id: this.parkId,
-        status: 'OPERATING',
-        operatingHours: parkHours,
-      });
-    }
-
-    // Shows: today's performance times, evaluated from each show's recurring
-    // ShowTimes schedule in the records data (not the live feed)
-    const showIds = new Set(entities.filter(e => e.entityType === 'SHOW').map(e => e.id));
-    if (showIds.size > 0) {
-      const today = formatDate(new Date(), this.timezone);
-      const poi = await this.getPOIData();
-      for (const item of poi.Item) {
-        const id = String(item._id);
-        if (!showIds.has(id)) continue;
-
-        const showtimes = showTimesForDate(item.ShowTimes, today, this.timezone);
-
-        // Status derives from the schedule (there is no live "running now" feed):
-        // OPERATING only while a performance is still upcoming or ongoing, then
-        // CLOSED once the day's last performance has ended. The full day's
-        // schedule stays published in `showtimes`.
-        const nowMs = Date.now();
-        const hasUpcoming = showtimes.some(s => {
-          const end = s.endTime ?? s.startTime;
-          return end != null && Date.parse(end) > nowMs;
-        });
-
-        const entry: LiveData = {
-          id,
-          status: hasUpcoming ? 'OPERATING' : 'CLOSED',
-        };
-        if (showtimes.length > 0) entry.showtimes = showtimes;
-        liveData.push(entry);
-      }
-    }
-
-    return liveData;
   }
 
   protected async buildSchedules(): Promise<EntitySchedule[]> {

--- a/src/parks/efteling/__tests__/efteling.test.ts
+++ b/src/parks/efteling/__tests__/efteling.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the Efteling live-data build.
+ *
+ * These pin the restaurant-hours fix: dining venues must publish their opening
+ * hours under the schema key `operatingHours` (camelCase). It was previously
+ * written as `operatinghours`, which the base class never normalises, so the
+ * hours never reached schema-compliant consumers. The raw fetch methods are
+ * stubbed so nothing hits the API; full integration runs via
+ * `npm run dev -- efteling`.
+ */
+
+import {describe, test, expect} from 'vitest';
+import {Efteling} from '../efteling.js';
+
+/** A restaurant POI hit that passes buildLiveData's location/type filter. */
+const DINING_POI = {fields: {id: 'rest1', category: 'restaurant', latlon: '51.65,5.05'}};
+
+const DINING_WAITTIME = {
+  Id: 'rest1',
+  Type: 'Eten en Drinken',
+  State: 'open',
+  OpeningTimes: [{HourFrom: '2026-07-08T10:00:00', HourTo: '2026-07-08T20:00:00'}],
+};
+
+function mockedEfteling(poiHits: any[], waitTimes: any[]): Efteling {
+  const park = new Efteling();
+  (park as any).getPOIData = async () => poiHits;
+  (park as any).getWaitTimes = async () => waitTimes;
+  return park;
+}
+
+describe('Efteling buildLiveData — restaurant hours', () => {
+  test('publishes dining hours under the schema key operatingHours (camelCase)', async () => {
+    const park = mockedEfteling([DINING_POI], [DINING_WAITTIME]);
+    const live = await (park as any).buildLiveData();
+
+    const entry = live.find((l: any) => l.id === 'rest1');
+    expect(entry).toBeDefined();
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.operatingHours).toEqual([
+      {startTime: '2026-07-08T10:00:00', endTime: '2026-07-08T20:00:00', type: 'OPERATING'},
+    ]);
+    // Guard against the regression: the misspelled lowercase key must not exist.
+    expect(entry.operatinghours).toBeUndefined();
+  });
+
+  test('a closed dining venue is CLOSED but still publishes its hours', async () => {
+    const park = mockedEfteling(
+      [DINING_POI],
+      [{...DINING_WAITTIME, State: 'closed'}],
+    );
+    const live = await (park as any).buildLiveData();
+
+    const entry = live.find((l: any) => l.id === 'rest1');
+    expect(entry.status).toBe('CLOSED');
+    expect(entry.operatingHours).toHaveLength(1);
+  });
+});

--- a/src/parks/efteling/efteling.ts
+++ b/src/parks/efteling/efteling.ts
@@ -490,7 +490,10 @@ export class Efteling extends Destination {
         ld.status = (state === 'open' ? 'OPERATING' : 'CLOSED') as any;
 
         if (entry.OpeningTimes && entry.OpeningTimes.length > 0) {
-          (ld as any).operatinghours = entry.OpeningTimes.map((ot: any) => ({
+          // Schema field is `operatingHours` (camelCase). It was previously
+          // written as `operatinghours`, which the base class never normalises,
+          // so the hours never reached schema-compliant consumers.
+          ld.operatingHours = entry.OpeningTimes.map((ot: any) => ({
             startTime: ot.HourFrom,
             endTime: ot.HourTo,
             type: 'OPERATING',


### PR DESCRIPTION
## Summary

The Attractions.io v1 adapter previously emitted **only attraction wait times** as live data. Restaurants, the park itself and shows existed as entities but carried no live data at all, and one park (Heide Park) had a bespoke implementation for venue hours / show times that the other 15 parks did not share.

This branch **generalises venue opening hours, park opening hours and show times from Heide Park into the shared `AttractionsIOV1` base class**, fixes the show-time evaluator so instantaneous ("point") show starts are no longer dropped, and **widens category coverage** so shows and dining venues surface for parks that label those categories differently.

The result: across all 16 Merlin / Legoland parks, live data now includes restaurant status + hours, today's park opening window, and per-show performance times — with attraction wait-time behaviour completely unchanged.

## What's new

For every inheriting park, `buildLiveData()` now produces, in addition to attraction status + standby wait time:

- **Restaurants** — open/closed status (from the live `IsOpen` signal, with a   fallback to the opening-hours window when the feed omits it) plus today's   opening hours (from the live `OpeningTimes` blob).
- **The park** — today's actual opening window (from the live Resort record).
- **Shows** — today's performance times, evaluated from each show's recurring   `ShowTimes` schedule in the records data (there is no live show feed), with a   schedule-derived status (OPERATING while a performance is still upcoming,   otherwise CLOSED; the full day's schedule always stays published).

The Heide Park–specific opening-hours parser and `ShowTimes` evaluator moved ahead of the base class; `HeideParkBase` now keeps only its custom v2 schedule endpoint.

## The `ShowTimes` point-start-time fix

`ShowTimes` encodes a show's recurring schedule as a temporal set-algebra tree. A `period` node normally defines a repeating **window** (`offset_date` + n×`period_length`, each `range_length` long). A `period` **without** a `range_length` encodes an *instantaneous* show start time (e.g. "13:30 daily"), not a window.

The evaluator's guard `rangeMs <= 0 → []` silently dropped these, so **every park except Heide Park** (whose shows all carry a `range_length`) produced zero show times. The fix treats a range-less period as a zero-length interval `[s, s]`, carries points through the interval algebra with half-open `[start, end)` semantics, and emits them as **start-only** `LiveTimeSlot`s (`{type, startTime}`, no `endTime` — the schema only requires `type`).

## Wider category coverage

Some parks label their shows and food venues with category names the base lists did not recognise, so those items were dropped entirely. This branch adds the category labels observed across parks:

- **Shows:** `Entertainment`, `Shows & 4D Movies`, `4D Movies` — surfacing shows for Chessington, Legoland Windsor, Legoland California, Legoland Deutschland and Knoebels. (`Entertainment` is now part of the base list, so Heide Park's override was removed.)
- **Restaurants:** a curated set of clearly-dining labels (e.g. `Food & Drinks`, `Fast food`, `Café & Snacks`, `Beverages`, `Buffet`, `Ice cream, coffee & treats`, `Snacks & Sweets`) — surfacing restaurants for Legoland Billund, Legoland Deutschland, Knoebels and Djurs Sommerland.

Ambiguous mixed labels (e.g. Legoland Korea's `Dining/Shopping`, Knoebels' `Pavilions`) and non-dining/non-show categories carrying schedule fields (e.g. `SEA LIFE`, `Meet & Greet`, `Season Content`, `Hotel`, `Rides`) are deliberately **left out** to avoid misclassification.

## Verification (live feeds, 2026-07-08)

**Generalisation** — before/after across all 16 parks: `getEntities` Δ=0 and `getSchedules` Δ=0 (no regression), and Heide Park output byte-identical (72 live / 20 opening-hour / 7 show-time entries unchanged). Restaurant/park hours and show times appeared for the other parks.

**Category expansion** — before/after across all 16 parks: **attraction counts unchanged for every park (Δ=0)** and **zero malformed times** (no `start > end` in any restaurant / park / show slot). Only SHOW and RESTAURANT counts grew, and only where expected.

Final per-park entity counts:

| Park | Attractions | Shows | Restaurants | Park hours today |
|---|---|---|---|---|
| Alton Towers | 47 | 4 | 35 | 10:00–18:00 |
| Thorpe Park | 25 | 0 | 36 | 10:00–18:00 |
| Chessington | 31 | 2 | 19 | 10:00–17:00 |
| Legoland Windsor | 44 | 8 | 19 | 10:00–17:00 |
| Legoland Orlando | 48 | 3 | 32 | 10:00–18:00 |
| Legoland California | 26 | 9 | 4 | 10:00–19:00 |
| Legoland Billund | 49 | 9 | 46 | 10:00–19:00 |
| Legoland Deutschland | 65 | 4 | 3 | 10:00–18:00 |
| Gardaland | 36 | 6 | 25 | 10:00–23:00 |
| Heide Park | 43 | 8 | 20 | 10:00–18:00 |
| Knoebels | 69 | 6 | 19 | 12:00–21:00 |
| Djurs Sommerland | 68 | 0 | 31 | 10:00–20:00 |
| Legoland Japan | 45 | 5 | 22 | 10:00–17:00 |
| Legoland New York | 51 | 2 | 24 | 10:00–17:00 |
| Legoland Korea | 36 | 0 | 0 | 10:00–17:00 |
| Peppa Pig Florida | 16 | 2 | 2 | 10:00–17:00 |

Sample show times (plausibility): Gardaland *Gardaland Night Beats* 22:45 (park open until 23:00), *Aloha* 18:15; Legoland New York *Daily Park Opening Ceremony!* 09:55 (CLOSED — already passed); Heide Park emits real windows (11:15–11:35) while point-based parks emit start-only times.

`npm run dev -- <park>` passes 4/4 for the checked parks; the `showtimes` unit suite is green (23 tests, incl. the new boundary cases).

## Adversarial review

The branch was put through a multi-lens review (conventions, ShowTimes algebra, live-data integration, regression risk, test coverage), each finding then adversarially verified. Of 14 raw findings, 7 were confirmed and 7 refuted; all 7 confirmed were addressed in the `harden` commit:

- Half-open point containment in the interval algebra (a point on a span's exclusive end / a subtracted span's inclusive start was mishandled).
- Restaurant status falling back to CLOSED when the live feed omits `IsOpen`.
- Duplicate live-data entries for an item classified into more than one type.
- Base-class JSDoc naming a specific park; `•` JSDoc bullets vs the house `-`.
- Test coverage for the point/boundary algebra branches.

## Known limitations / future work

- **Legoland Korea** surfaces no restaurants: its only dining label is the mixed `Dining/Shopping` category, excluded to avoid emitting shops as restaurants.
- **Legoland California** has ~7 rides under an uppercase `ATTRACTIONS` category that the (case-sensitive) attraction list does not match — an attraction-side coverage gap out of scope here.
- Non-dining venues with opening hours (shops, facilities) are not surfaced; only restaurants among venues are emitted.
- `Meet & Greet` / `SEA LIFE` style categories carry schedule fields but are not treated as shows.

## Commits

1. **fix(efteling): emit restaurant hours under schema `operatingHours` key** — restaurant hours were written under the non-schema key `operatinghours`.
2. **feat(heidepark): live venue hours, park hours & show times** — the original Heide Park implementation.
3. **feat(attractionsio): surface venue & park hours and show times for all parks** — generalise (2) into the shared base class.
4. **fix(attractionsio): evaluate range_length-less ShowTimes as point start times** — the point-start-time fix.
5. **feat(attractionsio): recognise more show & dining category labels** — wider category coverage.
6. **fix(attractionsio): harden against a multi-lens review of the venue/show rewrite** — the confirmed review findings above.