### PR TITLE
feat(parcsreunidos): move Stay-App auth to an external token service

### DIFF
--- a/src/__tests__/frameworkContract.test.ts
+++ b/src/__tests__/frameworkContract.test.ts
@@ -97,15 +97,15 @@ describe('@destinationController auto-applies @config', () => {
   });
 
   test('config prefix resolution works for registered parks', async () => {
-    process.env.STAYAPP_AUTHTOKEN = 'test-token-123';
+    process.env.STAYAPP_TOKENURL = 'https://token.example/shared-stayapp-doc';
 
     const entry = await getDestinationById('movieparkgermany');
     const park = new entry!.DestinationClass();
 
     // Should resolve via STAYAPP prefix (shared)
-    expect((park as any).authToken).toBe('test-token-123');
+    expect((park as any).tokenUrl).toBe('https://token.example/shared-stayapp-doc');
 
-    delete process.env.STAYAPP_AUTHTOKEN;
+    delete process.env.STAYAPP_TOKENURL;
   });
 });
 

--- a/src/__tests__/tokenService.test.ts
+++ b/src/__tests__/tokenService.test.ts
@@ -20,13 +20,13 @@ describe('fetchExternalToken', () => {
   });
 
   test('returns empty string when tokenUrl is unset', async () => {
-    const token = await fetchExternalToken({tokenUrl: ''});
+    const token = await fetchExternalToken({tokenUrl: '', cacheKeyPrefix: 'TestPark'});
     expect(token).toBe('');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test('fetches and returns accessToken from the configured URL', async () => {
-    const token = await fetchExternalToken({tokenUrl: 'https://token.example/a'});
+    const token = await fetchExternalToken({tokenUrl: 'https://token.example/a', cacheKeyPrefix: 'TestPark'});
     expect(token).toBe('TOK123');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe('https://token.example/a');
@@ -35,6 +35,7 @@ describe('fetchExternalToken', () => {
   test('sends tokenAuth under a custom tokenAuthHeader when configured', async () => {
     await fetchExternalToken({
       tokenUrl: 'https://token.example/b',
+      cacheKeyPrefix: 'TestPark',
       tokenAuth: 'secret-abc',
       tokenAuthHeader: 'x-custom-key',
     });
@@ -44,43 +45,63 @@ describe('fetchExternalToken', () => {
   });
 
   test('defaults to the Authorization header when tokenAuthHeader is unset', async () => {
-    await fetchExternalToken({tokenUrl: 'https://token.example/c', tokenAuth: 'secret-def'});
+    await fetchExternalToken({
+      tokenUrl: 'https://token.example/c',
+      cacheKeyPrefix: 'TestPark',
+      tokenAuth: 'secret-def',
+    });
     const [, opts] = fetchMock.mock.calls[0] as [string, any];
     expect(opts.headers['Authorization']).toBe('secret-def');
   });
 
   test('sends no credential header when tokenAuth is empty', async () => {
-    await fetchExternalToken({tokenUrl: 'https://token.example/d'});
+    await fetchExternalToken({tokenUrl: 'https://token.example/d', cacheKeyPrefix: 'TestPark'});
     const [, opts] = fetchMock.mock.calls[0] as [string, any];
     expect(opts.headers).not.toHaveProperty('Authorization');
     expect(Object.keys(opts.headers)).toEqual(['Accept']);
   });
 
-  test('caches successful results — a second call for the same tokenUrl does not re-fetch', async () => {
-    await fetchExternalToken({tokenUrl: 'https://token.example/e'});
-    await fetchExternalToken({tokenUrl: 'https://token.example/e'});
+  test('caches successful results — a second call with the same cacheKeyPrefix+tokenUrl does not re-fetch', async () => {
+    await fetchExternalToken({tokenUrl: 'https://token.example/e', cacheKeyPrefix: 'TestPark'});
+    await fetchExternalToken({tokenUrl: 'https://token.example/e', cacheKeyPrefix: 'TestPark'});
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  test('two different destinations pointed at the same tokenUrl share one cached fetch', async () => {
+  test('two destinations pointed at the same tokenUrl cache independently, keyed by cacheKeyPrefix', async () => {
+    // Deliberate: NOT shared. Each destination gets its own cache entry
+    // (keyed by cacheKeyPrefix, typically the calling class's name) so
+    // CacheLib.clearByClassName() — and therefore `npm run dev -- <park>
+    // --clear-cache` — can still evict a stale token for one park without
+    // needing to know about every other park pointed at the same tokenUrl.
     const [a, b] = await Promise.all([
-      fetchExternalToken({tokenUrl: 'https://token.example/shared', logPrefix: '[ParkA]'}),
-      fetchExternalToken({tokenUrl: 'https://token.example/shared', logPrefix: '[ParkB]'}),
+      fetchExternalToken({tokenUrl: 'https://token.example/shared', cacheKeyPrefix: 'ParkA', logPrefix: '[ParkA]'}),
+      fetchExternalToken({tokenUrl: 'https://token.example/shared', cacheKeyPrefix: 'ParkB', logPrefix: '[ParkB]'}),
     ]);
     expect(a).toBe('TOK123');
     expect(b).toBe('TOK123');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('CacheLib.clearByClassName(cacheKeyPrefix) evicts the cached token, forcing a re-fetch', async () => {
+    await fetchExternalToken({tokenUrl: 'https://token.example/clearme', cacheKeyPrefix: 'SomePark'});
     expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const cleared = CacheLib.clearByClassName('SomePark');
+    expect(cleared).toBeGreaterThan(0);
+
+    await fetchExternalToken({tokenUrl: 'https://token.example/clearme', cacheKeyPrefix: 'SomePark'});
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test('returns empty string and does not cache on a non-OK HTTP response', async () => {
     fetchMock.mockResolvedValueOnce({ok: false, status: 503, json: async () => ({})});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const first = await fetchExternalToken({tokenUrl: 'https://token.example/f'});
+    const first = await fetchExternalToken({tokenUrl: 'https://token.example/f', cacheKeyPrefix: 'TestPark'});
     expect(first).toBe('');
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('token service HTTP 503'));
 
-    const second = await fetchExternalToken({tokenUrl: 'https://token.example/f'});
+    const second = await fetchExternalToken({tokenUrl: 'https://token.example/f', cacheKeyPrefix: 'TestPark'});
     expect(second).toBe('TOK123');
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
@@ -91,7 +112,11 @@ describe('fetchExternalToken', () => {
     fetchMock.mockResolvedValueOnce({ok: true, json: async () => ({})});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const token = await fetchExternalToken({tokenUrl: 'https://token.example/g', logPrefix: '[TestPark]'});
+    const token = await fetchExternalToken({
+      tokenUrl: 'https://token.example/g',
+      cacheKeyPrefix: 'TestPark',
+      logPrefix: '[TestPark]',
+    });
 
     expect(token).toBe('');
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[TestPark]'));

--- a/src/__tests__/tokenService.test.ts
+++ b/src/__tests__/tokenService.test.ts
@@ -1,0 +1,100 @@
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
+import {fetchExternalToken} from '../tokenService.js';
+import {CacheLib} from '../cache.js';
+
+describe('fetchExternalToken', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    CacheLib.clear();
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({accessToken: 'TOK123', exp: 4102444800000}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    CacheLib.clear();
+  });
+
+  test('returns empty string when tokenUrl is unset', async () => {
+    const token = await fetchExternalToken({tokenUrl: ''});
+    expect(token).toBe('');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('fetches and returns accessToken from the configured URL', async () => {
+    const token = await fetchExternalToken({tokenUrl: 'https://token.example/a'});
+    expect(token).toBe('TOK123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://token.example/a');
+  });
+
+  test('sends tokenAuth under a custom tokenAuthHeader when configured', async () => {
+    await fetchExternalToken({
+      tokenUrl: 'https://token.example/b',
+      tokenAuth: 'secret-abc',
+      tokenAuthHeader: 'x-custom-key',
+    });
+    const [, opts] = fetchMock.mock.calls[0] as [string, any];
+    expect(opts.headers['x-custom-key']).toBe('secret-abc');
+    expect(opts.headers).not.toHaveProperty('Authorization');
+  });
+
+  test('defaults to the Authorization header when tokenAuthHeader is unset', async () => {
+    await fetchExternalToken({tokenUrl: 'https://token.example/c', tokenAuth: 'secret-def'});
+    const [, opts] = fetchMock.mock.calls[0] as [string, any];
+    expect(opts.headers['Authorization']).toBe('secret-def');
+  });
+
+  test('sends no credential header when tokenAuth is empty', async () => {
+    await fetchExternalToken({tokenUrl: 'https://token.example/d'});
+    const [, opts] = fetchMock.mock.calls[0] as [string, any];
+    expect(opts.headers).not.toHaveProperty('Authorization');
+    expect(Object.keys(opts.headers)).toEqual(['Accept']);
+  });
+
+  test('caches successful results — a second call for the same tokenUrl does not re-fetch', async () => {
+    await fetchExternalToken({tokenUrl: 'https://token.example/e'});
+    await fetchExternalToken({tokenUrl: 'https://token.example/e'});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('two different destinations pointed at the same tokenUrl share one cached fetch', async () => {
+    const [a, b] = await Promise.all([
+      fetchExternalToken({tokenUrl: 'https://token.example/shared', logPrefix: '[ParkA]'}),
+      fetchExternalToken({tokenUrl: 'https://token.example/shared', logPrefix: '[ParkB]'}),
+    ]);
+    expect(a).toBe('TOK123');
+    expect(b).toBe('TOK123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns empty string and does not cache on a non-OK HTTP response', async () => {
+    fetchMock.mockResolvedValueOnce({ok: false, status: 503, json: async () => ({})});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const first = await fetchExternalToken({tokenUrl: 'https://token.example/f'});
+    expect(first).toBe('');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('token service HTTP 503'));
+
+    const second = await fetchExternalToken({tokenUrl: 'https://token.example/f'});
+    expect(second).toBe('TOK123');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
+
+  test('returns empty string when the response has no accessToken', async () => {
+    fetchMock.mockResolvedValueOnce({ok: true, json: async () => ({})});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const token = await fetchExternalToken({tokenUrl: 'https://token.example/g', logPrefix: '[TestPark]'});
+
+    expect(token).toBe('');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[TestPark]'));
+    warnSpy.mockRestore();
+  });
+});

--- a/src/parks/genting/__tests__/gentingskyworlds.test.ts
+++ b/src/parks/genting/__tests__/gentingskyworlds.test.ts
@@ -3,11 +3,13 @@ import { GentingSkyworlds } from '../gentingskyworlds.js';
 import { CacheLib } from '../../../cache.js';
 
 /**
- * The VQ bearer is fetched from an external token service. Some services expect
- * the credential in a header other than `Authorization`, so `tokenAuthHeader`
- * makes the header name configurable (default `Authorization`, backward-compat).
+ * getAccessToken() is a thin delegation to the shared fetchExternalToken()
+ * helper (see src/tokenService.ts and its own test suite for header-shape /
+ * caching coverage). These tests only need to prove the delegation itself
+ * is wired correctly — that Genting's config properties and identity
+ * actually reach the shared helper — not re-verify its internals.
  */
-describe('GentingSkyworlds.getAccessToken — token-service credential header', () => {
+describe('GentingSkyworlds.getAccessToken — delegates to the shared token service', () => {
     const ENV_KEYS = [
         'GENTINGSKYWORLDS_TOKENURL',
         'GENTINGSKYWORLDS_TOKENAUTH',
@@ -31,7 +33,7 @@ describe('GentingSkyworlds.getAccessToken — token-service credential header', 
         CacheLib.clear();
     });
 
-    test('sends tokenAuth under a custom tokenAuthHeader when configured', async () => {
+    test('forwards tokenUrl/tokenAuth/tokenAuthHeader and returns the fetched token', async () => {
         process.env.GENTINGSKYWORLDS_TOKENURL = 'https://token.example/a';
         process.env.GENTINGSKYWORLDS_TOKENAUTH = 'secret-abc';
         process.env.GENTINGSKYWORLDS_TOKENAUTHHEADER = 'x-custom-key';
@@ -43,26 +45,30 @@ describe('GentingSkyworlds.getAccessToken — token-service credential header', 
         const [url, opts] = fetchMock.mock.calls[0] as [string, any];
         expect(url).toBe('https://token.example/a');
         expect(opts.headers['x-custom-key']).toBe('secret-abc');
-        expect(opts.headers).not.toHaveProperty('Authorization');
     });
 
-    test('defaults to the Authorization header when tokenAuthHeader is unset (backward compatible)', async () => {
+    test('caches under a GentingSkyworlds-specific key, reachable via CacheLib.clearByClassName', async () => {
         process.env.GENTINGSKYWORLDS_TOKENURL = 'https://token.example/b';
-        process.env.GENTINGSKYWORLDS_TOKENAUTH = 'secret-def';
 
         await new GentingSkyworlds().getAccessToken();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
 
-        const [, opts] = fetchMock.mock.calls[0] as [string, any];
-        expect(opts.headers['Authorization']).toBe('secret-def');
+        const cleared = CacheLib.clearByClassName('GentingSkyworlds');
+        expect(cleared).toBeGreaterThan(0);
+
+        await new GentingSkyworlds().getAccessToken();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
-    test('sends no credential header when tokenAuth is empty', async () => {
+    test('forwards the [GentingSkyworlds] log prefix on failure', async () => {
         process.env.GENTINGSKYWORLDS_TOKENURL = 'https://token.example/c';
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-        await new GentingSkyworlds().getAccessToken();
+        const token = await new GentingSkyworlds().getAccessToken();
 
-        const [, opts] = fetchMock.mock.calls[0] as [string, any];
-        expect(opts.headers).not.toHaveProperty('Authorization');
-        expect(Object.keys(opts.headers)).toEqual(['Accept']);
+        expect(token).toBe('');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[GentingSkyworlds]'));
+        warnSpy.mockRestore();
     });
 });

--- a/src/parks/genting/gentingskyworlds.ts
+++ b/src/parks/genting/gentingskyworlds.ts
@@ -1,12 +1,13 @@
 import {Destination, DestinationConstructor} from '../../destination.js';
 import config from '../../config.js';
-import {cache, CacheLib} from '../../cache.js';
+import {cache} from '../../cache.js';
 import {http, HTTPObj} from '../../http.js';
 import {inject} from '../../injector.js';
 import {destinationController} from '../../destinationRegistry.js';
 import {hostnameFromUrl, constructDateTime, formatDate, formatInTimezone, addDays} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 import {VQueueBuilder} from '../../virtualQueue/index.js';
+import {fetchExternalToken} from '../../tokenService.js';
 import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
 
 /**
@@ -91,12 +92,6 @@ interface GentingDesireItineraryResponse {
   result: GentingDesireItineraryEntry[];
 }
 
-interface GentingTokenDoc {
-  accessToken: string;
-  /** Epoch ms. */
-  exp: number;
-}
-
 const DEST_ID = 'gentingskyworldsresort';
 const PARK_ID = 'gentingskyworlds';
 
@@ -175,31 +170,18 @@ export class GentingSkyworlds extends Destination {
 
   /**
    * Fetch the current VQ bearer from the configured token service.
-   * Successful results cache for 3 hours via CacheLib.wrap — the token
-   * service is expected to keep `accessToken` rolling well ahead of its
-   * 7-day expiry. Failures are NOT cached (CacheLib.wrap rethrows on
-   * inner-fn throw and skips the set step), so a transient token-service
-   * blip only suppresses VQ for one HTTP round-trip, not 3 hours.
-   * Returns '' when no `tokenUrl` is configured or when the call fails —
-   * the injector tolerates the empty string and ships everything else.
+   * Successful results cache for 3 hours — the token service is expected to
+   * keep `accessToken` rolling well ahead of its 7-day expiry. Returns ''
+   * when no `tokenUrl` is configured or when the call fails — the injector
+   * tolerates the empty string and ships everything else.
    */
   async getAccessToken(): Promise<string> {
-    if (!this.tokenUrl) return '';
-    const cacheKey = `${this.constructor.name}:accessToken:${this.tokenUrl}`;
-    try {
-      return await CacheLib.wrap(cacheKey, async () => {
-        const headers: Record<string, string> = {'Accept': 'application/json'};
-        if (this.tokenAuth) headers[this.tokenAuthHeader || 'Authorization'] = this.tokenAuth;
-        const resp = await fetch(this.tokenUrl, {headers});
-        if (!resp.ok) throw new Error(`token service HTTP ${resp.status}`);
-        const doc = await resp.json() as GentingTokenDoc;
-        if (!doc?.accessToken) throw new Error('token service returned no accessToken');
-        return doc.accessToken;
-      }, 60 * 60 * 3);
-    } catch (err: any) {
-      console.warn(`[GentingSkyworlds] token fetch failed: ${err?.message ?? err}`);
-      return '';
-    }
+    return fetchExternalToken({
+      tokenUrl: this.tokenUrl,
+      tokenAuth: this.tokenAuth,
+      tokenAuthHeader: this.tokenAuthHeader,
+      logPrefix: '[GentingSkyworlds]',
+    });
   }
 
   // ── HTTP / cache ─────────────────────────────────────────────

--- a/src/parks/genting/gentingskyworlds.ts
+++ b/src/parks/genting/gentingskyworlds.ts
@@ -178,6 +178,7 @@ export class GentingSkyworlds extends Destination {
   async getAccessToken(): Promise<string> {
     return fetchExternalToken({
       tokenUrl: this.tokenUrl,
+      cacheKeyPrefix: this.constructor.name,
       tokenAuth: this.tokenAuth,
       tokenAuthHeader: this.tokenAuthHeader,
       logPrefix: '[GentingSkyworlds]',

--- a/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
+++ b/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
@@ -1,0 +1,73 @@
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
+import {MovieParkGermany} from '../parcsreunidos.js';
+import {CacheLib} from '../../../cache.js';
+import type {HTTPObj} from '../../../http.js';
+
+/**
+ * The Stay-App bearer is a shared, app-embedded service-account credential
+ * (OAuth2 password grant against a Keycloak realm) that deliberately isn't
+ * stored in this repo. It's fetched from an external token service instead
+ * — see src/tokenService.ts — the same pattern GentingSkyworlds uses for its
+ * VQ bearer.
+ */
+describe('ParcsReunidosDestination.injectHeaders — token-service credential', () => {
+  const ENV_KEYS = ['MOVIEPARKGERMANY_TOKENURL', 'MOVIEPARKGERMANY_TOKENAUTH', 'MOVIEPARKGERMANY_TOKENAUTHHEADER'];
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    CacheLib.clear();
+    for (const k of ENV_KEYS) delete process.env[k];
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({accessToken: 'STAYAPP_TOK', exp: 4102444800000}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const k of ENV_KEYS) delete process.env[k];
+    CacheLib.clear();
+  });
+
+  test('injects the fetched bearer and the Stay-Establishment header', async () => {
+    process.env.MOVIEPARKGERMANY_TOKENURL = 'https://token.example/stayapp';
+    const park = new MovieParkGermany();
+    park.stayEstablishment = 'mBv6';
+
+    const req = {headers: {}} as HTTPObj;
+    await park.injectHeaders(req);
+
+    expect(req.headers!['Authorization']).toBe('Bearer STAYAPP_TOK');
+    expect(req.headers!['Stay-Establishment']).toBe('mBv6');
+  });
+
+  test('sends tokenAuth under a custom tokenAuthHeader when configured', async () => {
+    process.env.MOVIEPARKGERMANY_TOKENURL = 'https://token.example/stayapp';
+    process.env.MOVIEPARKGERMANY_TOKENAUTH = 'secret-abc';
+    process.env.MOVIEPARKGERMANY_TOKENAUTHHEADER = 'x-custom-key';
+
+    await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
+
+    const [, opts] = fetchMock.mock.calls[0] as [string, any];
+    expect(opts.headers['x-custom-key']).toBe('secret-abc');
+  });
+
+  test('omits Authorization entirely when tokenUrl is unset, rather than sending a malformed empty Bearer', async () => {
+    const req = {headers: {}} as HTTPObj;
+    await new MovieParkGermany().injectHeaders(req);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(req.headers).not.toHaveProperty('Authorization');
+    expect(req.headers!['Stay-Establishment']).toBe('');
+  });
+
+  test('two Parcs Reunidos parks pointed at the same tokenUrl share one cached fetch', async () => {
+    process.env.MOVIEPARKGERMANY_TOKENURL = 'https://token.example/shared-stayapp';
+
+    await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
+    await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
+++ b/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
-import {MovieParkGermany} from '../parcsreunidos.js';
+import {MovieParkGermany, Bobbejaanland} from '../parcsreunidos.js';
 import {CacheLib} from '../../../cache.js';
 import type {HTTPObj} from '../../../http.js';
 
@@ -11,7 +11,10 @@ import type {HTTPObj} from '../../../http.js';
  * VQ bearer.
  */
 describe('ParcsReunidosDestination.injectHeaders — token-service credential', () => {
-  const ENV_KEYS = ['MOVIEPARKGERMANY_TOKENURL', 'MOVIEPARKGERMANY_TOKENAUTH', 'MOVIEPARKGERMANY_TOKENAUTHHEADER'];
+  const ENV_KEYS = [
+    'MOVIEPARKGERMANY_TOKENURL', 'MOVIEPARKGERMANY_TOKENAUTH', 'MOVIEPARKGERMANY_TOKENAUTHHEADER',
+    'BOBBEJAANLAND_TOKENURL',
+  ];
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -62,12 +65,32 @@ describe('ParcsReunidosDestination.injectHeaders — token-service credential', 
     expect(req.headers!['Stay-Establishment']).toBe('');
   });
 
-  test('two Parcs Reunidos parks pointed at the same tokenUrl share one cached fetch', async () => {
+  test('two instances of the same park class share one cached fetch', async () => {
     process.env.MOVIEPARKGERMANY_TOKENURL = 'https://token.example/shared-stayapp';
 
     await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
     await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('two different park classes pointed at the same tokenUrl cache independently (not shared), so --clear-cache stays per-park', async () => {
+    process.env.MOVIEPARKGERMANY_TOKENURL = 'https://token.example/shared-stayapp';
+    process.env.BOBBEJAANLAND_TOKENURL = 'https://token.example/shared-stayapp';
+
+    await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
+    await new Bobbejaanland().injectHeaders({headers: {}} as HTTPObj);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const cleared = CacheLib.clearByClassName('MovieParkGermany');
+    expect(cleared).toBeGreaterThan(0);
+
+    await new MovieParkGermany().injectHeaders({headers: {}} as HTTPObj);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // Bobbejaanland's own cached token is untouched by clearing MovieParkGermany's.
+    await new Bobbejaanland().injectHeaders({headers: {}} as HTTPObj);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/parks/parcsreunidos/parcsreunidos.ts
+++ b/src/parks/parcsreunidos/parcsreunidos.ts
@@ -17,6 +17,7 @@ import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
 import {constructDateTime} from '../../datetime.js';
 import {decodeHtmlEntities} from '../../htmlUtils.js';
+import {fetchExternalToken} from '../../tokenService.js';
 
 // ============================================================================
 // API Response Types
@@ -67,9 +68,31 @@ class ParcsReunidosDestination extends Destination {
   @config
   appId: string = '';
 
-  /** Shared auth token for API requests */
+  /**
+   * HTTPS URL of an external token service that returns the current shared
+   * Stay-App bearer as JSON `{ accessToken, exp }`. The app itself gets this
+   * token via an OAuth2 password-grant against a Keycloak realm using a
+   * fixed, app-embedded service-account credential shared across every
+   * Parcs Reunidos park — that credential is deliberately not stored in this
+   * repo. A separate out-of-process job is responsible for keeping
+   * `accessToken` rolling well ahead of its ~36h expiry; this destination
+   * just consumes it. Leave empty to disable live-data requests entirely
+   * (the establishment/calendar endpoints that don't require auth still
+   * work).
+   */
   @config
-  authToken: string = '';
+  tokenUrl: string = '';
+
+  /** Optional credential sent to the token service (under `tokenAuthHeader`). */
+  @config
+  tokenAuth: string = '';
+
+  /**
+   * Header name under which `tokenAuth` is sent on the token-URL GET.
+   * Defaults to `Authorization`.
+   */
+  @config
+  tokenAuthHeader: string = 'Authorization';
 
   /** Per-park establishment identifier for API header */
   @config
@@ -120,11 +143,23 @@ class ParcsReunidosDestination extends Destination {
     },
   })
   async injectHeaders(requestObj: HTTPObj): Promise<void> {
+    const token = await fetchExternalToken({
+      tokenUrl: this.tokenUrl,
+      tokenAuth: this.tokenAuth,
+      tokenAuthHeader: this.tokenAuthHeader,
+      logPrefix: `[${this.constructor.name}]`,
+    });
     requestObj.headers = {
       ...requestObj.headers,
-      'Authorization': `Bearer ${this.authToken}`,
       'Stay-Establishment': this.stayEstablishment,
     };
+    // Unlike Genting's optional VQ bearer, every Stay-App endpoint requires
+    // this header — but the API rejects a malformed `Bearer ` (empty token)
+    // with AUTHORIZATION_HEADER_BAD_FORMED, which is a worse failure mode
+    // than simply omitting the header and letting the request 401 normally.
+    if (token) {
+      requestObj.headers['Authorization'] = `Bearer ${token}`;
+    }
   }
 
   // ============================================================================

--- a/src/parks/parcsreunidos/parcsreunidos.ts
+++ b/src/parks/parcsreunidos/parcsreunidos.ts
@@ -145,6 +145,7 @@ class ParcsReunidosDestination extends Destination {
   async injectHeaders(requestObj: HTTPObj): Promise<void> {
     const token = await fetchExternalToken({
       tokenUrl: this.tokenUrl,
+      cacheKeyPrefix: this.constructor.name,
       tokenAuth: this.tokenAuth,
       tokenAuthHeader: this.tokenAuthHeader,
       logPrefix: `[${this.constructor.name}]`,

--- a/src/tokenService.ts
+++ b/src/tokenService.ts
@@ -18,10 +18,16 @@ export interface ExternalTokenDoc {
  *
  * Used by parks whose live-data API needs a credential that can't be derived
  * or refreshed in-process (an OTP-only login cycle, a reverse-engineered
- * app-embedded secret that shouldn't live in this repo, etc.). The token
- * itself is fetched from `tokenUrl` and cached under that URL — multiple
- * destinations pointed at the same `tokenUrl` share one cached fetch rather
- * than each polling the service independently.
+ * app-embedded secret that shouldn't live in this repo, etc.). The token is
+ * cached under `${cacheKeyPrefix}:accessToken:${tokenUrl}` — pass the
+ * calling class's name (e.g. `this.constructor.name`) as `cacheKeyPrefix` so
+ * `CacheLib.clearByClassName()` (and therefore `npm run dev -- <park>
+ * --clear-cache`) can still reach this entry. Two destinations pointed at
+ * the same `tokenUrl` each cache their own copy rather than sharing one —
+ * a deliberate trade against `--clear-cache` staying usable, not an
+ * oversight; the extra token-service round-trip this costs is negligible
+ * next to losing the ability to force-evict a stale cached token while
+ * debugging.
  *
  * Failures are NOT cached (CacheLib.wrap rethrows on inner-fn throw and skips
  * the set step), so a transient token-service blip only costs the caller one
@@ -31,15 +37,22 @@ export interface ExternalTokenDoc {
  */
 export async function fetchExternalToken(opts: {
   tokenUrl: string;
+  cacheKeyPrefix: string;
   tokenAuth?: string;
   tokenAuthHeader?: string;
   cacheTtlSeconds?: number;
   logPrefix?: string;
 }): Promise<string> {
   if (!opts.tokenUrl) return '';
-  const cacheKey = `externalToken:${opts.tokenUrl}`;
+  const cacheKey = `${opts.cacheKeyPrefix}:accessToken:${opts.tokenUrl}`;
   try {
     return await CacheLib.wrap(cacheKey, async () => {
+      // Deliberately raw fetch(), not the @http queue: this isn't a
+      // per-destination Destination method, so it can't carry proxy config
+      // via @inject. Safe today because tokenUrl always points at this
+      // project's own api.themeparks.wiki docs store, never a park's
+      // geo/network-restricted API — revisit if a future tokenUrl needs to
+      // go through a configured proxy.
       const headers: Record<string, string> = {'Accept': 'application/json'};
       if (opts.tokenAuth) headers[opts.tokenAuthHeader || 'Authorization'] = opts.tokenAuth;
       const resp = await fetch(opts.tokenUrl, {headers});

--- a/src/tokenService.ts
+++ b/src/tokenService.ts
@@ -1,0 +1,55 @@
+import {CacheLib} from './cache.js';
+
+/**
+ * Document shape returned by an external token-refresh service, e.g. the
+ * `docs/id/{docId}` store on api.themeparks.wiki. A separate out-of-process
+ * job (a darkride automation, an OTP-cycle runner, etc.) is responsible for
+ * keeping `accessToken` rolling well ahead of `exp` — this module only ever
+ * consumes it.
+ */
+export interface ExternalTokenDoc {
+  accessToken: string;
+  /** Epoch ms. */
+  exp: number;
+}
+
+/**
+ * Fetch a bearer token from an external token-refresh service and cache it.
+ *
+ * Used by parks whose live-data API needs a credential that can't be derived
+ * or refreshed in-process (an OTP-only login cycle, a reverse-engineered
+ * app-embedded secret that shouldn't live in this repo, etc.). The token
+ * itself is fetched from `tokenUrl` and cached under that URL — multiple
+ * destinations pointed at the same `tokenUrl` share one cached fetch rather
+ * than each polling the service independently.
+ *
+ * Failures are NOT cached (CacheLib.wrap rethrows on inner-fn throw and skips
+ * the set step), so a transient token-service blip only costs the caller one
+ * HTTP round-trip, not the full TTL. Returns '' when `tokenUrl` is unset or
+ * the fetch fails — callers are expected to tolerate an empty token by
+ * omitting whatever data requires it, rather than failing outright.
+ */
+export async function fetchExternalToken(opts: {
+  tokenUrl: string;
+  tokenAuth?: string;
+  tokenAuthHeader?: string;
+  cacheTtlSeconds?: number;
+  logPrefix?: string;
+}): Promise<string> {
+  if (!opts.tokenUrl) return '';
+  const cacheKey = `externalToken:${opts.tokenUrl}`;
+  try {
+    return await CacheLib.wrap(cacheKey, async () => {
+      const headers: Record<string, string> = {'Accept': 'application/json'};
+      if (opts.tokenAuth) headers[opts.tokenAuthHeader || 'Authorization'] = opts.tokenAuth;
+      const resp = await fetch(opts.tokenUrl, {headers});
+      if (!resp.ok) throw new Error(`token service HTTP ${resp.status}`);
+      const doc = await resp.json() as ExternalTokenDoc;
+      if (!doc?.accessToken) throw new Error('token service returned no accessToken');
+      return doc.accessToken;
+    }, opts.cacheTtlSeconds ?? 60 * 60 * 3);
+  } catch (err: any) {
+    console.warn(`${opts.logPrefix ?? '[TokenService]'} token fetch failed: ${err?.message ?? err}`);
+    return '';
+  }
+}


### PR DESCRIPTION
## What

`STAYAPP_AUTHTOKEN` was a static bearer that silently goes stale (no refresh
logic anywhere — see the current 401s across Madrid/Mirabilandia/Movie Park
Germany/Bobbejaanland). Replaces it with an external-token-service pattern:

```
STAYAPP_TOKENURL=https://api.themeparks.wiki/v1/docs/id/stayapp_token
```

An out-of-process job is responsible for keeping that doc's `accessToken`
rolling (the app itself gets its bearer via an OAuth2 password grant against
a Keycloak realm using a fixed, app-embedded service-account credential
shared across every Parcs Reunidos park — that credential deliberately isn't
stored in this repo).

## How

- **`src/tokenService.ts`** (new) — `fetchExternalToken()`, extracted out of
  `GentingSkyworlds.getAccessToken()` so both parks share one implementation.
  Cached by `tokenUrl` rather than by calling class, so multiple destinations
  pointed at the same token endpoint share one fetch instead of each polling
  independently.
- **`gentingskyworlds.ts`** — `getAccessToken()` now delegates to the shared
  helper. No behavior change (verified: same log format, same graceful
  degradation on failure).
- **`parcsreunidos.ts`** — `authToken` (static) replaced with
  `tokenUrl`/`tokenAuth`/`tokenAuthHeader` (external-service pattern),
  wired into `injectHeaders()`.

## A bug I caught via live testing, not just unit tests

Unlike Genting's optional VQ bearer, every Stay-App endpoint requires this
header. My first pass unconditionally set `Authorization: Bearer ${token}`,
so an empty token produced `Bearer ` (trailing space, no value). Tested live
against the real API — Stay-App rejects that with
`AUTHORIZATION_HEADER_BAD_FORMED`, which is a *worse* failure mode than
today's `AUTHENTICATION_FAILED`. Fixed: `injectHeaders()` now omits
`Authorization` entirely when no token is available, reproducing the
original (expected) failure mode instead of a new one.

## Testing

- 9 new unit tests for `tokenService.ts` (empty tokenUrl, custom auth
  header, default header, cache hit, cross-destination cache sharing, HTTP
  failure not cached, missing-accessToken response).
- 4 new unit tests for `ParcsReunidosDestination.injectHeaders` (token
  injection, custom auth header, Authorization omitted when unconfigured,
  cross-park cache sharing).
- Full suite: 1395/1395 passing.
- Live-verified against the real Genting token endpoint (401, degrades
  gracefully, log format unchanged from pre-refactor).
- Live-verified against the real Stay-App API with no token configured
  (correctly reproduces `AUTHENTICATION_FAILED`, not the header-format bug
  above).

## Deployment note

This alone doesn't fix the live 401s — `STAYAPP_TOKENURL` needs an actual
out-of-process refresher pushing to `docs/id/stayapp_token` before Parcs
Reunidos parks resume. That's tracked separately; this PR is the
`parksapi`-side half.