### PR TITLE
feat(plopsa): surface live show times & keep them when the calendar fails

### DIFF
--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -8,8 +8,8 @@
  * disagrees between instances.
  */
 import {describe, test, expect} from 'vitest';
-import type {Entity, EntitySchedule} from '@themeparks/typelib';
-import {plopsaDecideOperating, Plopsaland} from '../plopsa.js';
+import type {Entity, EntitySchedule, LiveData} from '@themeparks/typelib';
+import {plopsaDecideOperating, plopsaBuildShowtimes, plopsaShowStatus, Plopsaland} from '../plopsa.js';
 
 describe('plopsaDecideOperating', () => {
   test('park closed → ride always CLOSED regardless of other inputs', () => {
@@ -180,5 +180,109 @@ describe('buildSchedules feed independence', () => {
     park.fetchEntertainments = async () => jsonResponse({items: []}) as any;
 
     expect(await park.buildSchedulesForTest()).toEqual([]);
+  });
+});
+
+describe('plopsaBuildShowtimes', () => {
+  const tz = 'Europe/Brussels';
+  const schedule = [
+    {date: '2026-07-11', timeslots: [
+      {type: 'open', start_time: '14:00', end_time: null},
+      {type: 'open', start_time: '16:30', end_time: '17:00'},
+      {type: 'closed', start_time: '18:00', end_time: null},
+    ]},
+    {date: '2026-07-12', timeslots: [
+      {type: 'open', start_time: '11:00', end_time: null},
+    ]},
+  ];
+
+  test('returns [] for an undefined schedule or a date with no entry', () => {
+    expect(plopsaBuildShowtimes(undefined, '2026-07-11', tz)).toEqual([]);
+    expect(plopsaBuildShowtimes(schedule, '2026-07-13', tz)).toEqual([]);
+  });
+
+  test('builds ISO+offset slots for the matching date, skipping non-open slots', () => {
+    expect(plopsaBuildShowtimes(schedule, '2026-07-11', tz)).toEqual([
+      {type: 'Showtime', startTime: '2026-07-11T14:00:00+02:00', endTime: null},
+      {type: 'Showtime', startTime: '2026-07-11T16:30:00+02:00', endTime: '2026-07-11T17:00:00+02:00'},
+    ]);
+  });
+});
+
+describe('plopsaShowStatus', () => {
+  const ms = (iso: string) => Date.parse(iso);
+  const slots = [
+    {type: 'Showtime', startTime: '2026-07-11T14:00:00+02:00', endTime: null},
+    {type: 'Showtime', startTime: '2026-07-11T16:30:00+02:00', endTime: '2026-07-11T17:00:00+02:00'},
+  ];
+
+  test('CLOSED when there are no showtimes', () => {
+    expect(plopsaShowStatus([], ms('2026-07-11T12:00:00+02:00'))).toBe('CLOSED');
+  });
+
+  test('OPERATING until the last performance ends', () => {
+    expect(plopsaShowStatus(slots, ms('2026-07-11T12:00:00+02:00'))).toBe('OPERATING');
+    expect(plopsaShowStatus(slots, ms('2026-07-11T16:59:00+02:00'))).toBe('OPERATING');
+  });
+
+  test('CLOSED once the last performance has passed', () => {
+    expect(plopsaShowStatus(slots, ms('2026-07-11T17:30:00+02:00'))).toBe('CLOSED');
+  });
+
+  test('falls back to the start time when a slot has no end time', () => {
+    const pointOnly = [{type: 'Showtime', startTime: '2026-07-11T14:00:00+02:00', endTime: null}];
+    expect(plopsaShowStatus(pointOnly, ms('2026-07-11T13:59:00+02:00'))).toBe('OPERATING');
+    expect(plopsaShowStatus(pointOnly, ms('2026-07-11T14:01:00+02:00'))).toBe('CLOSED');
+  });
+});
+
+describe('buildLiveData shows', () => {
+  class LiveProbe extends Plopsaland {
+    public buildLiveDataForTest(): Promise<LiveData[]> {
+      return this.buildLiveData();
+    }
+  }
+
+  function jsonResponse(payload: unknown) {
+    return {json: async () => payload};
+  }
+
+  function todayIn(tz: string): string {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date());
+  }
+
+  test('emits show live data independently of the wait-times feed', async () => {
+    const park = new LiveProbe();
+    const date = todayIn('Europe/Brussels');
+
+    park.fetchWaitTimes = async () => jsonResponse({}) as any;
+    park.fetchPOI = async () => jsonResponse({items: []}) as any;
+    park.fetchTodayHours = async () =>
+      jsonResponse({date, timeslots: [{type: 'open', start_time: '00:00', end_time: '23:59'}]}) as any;
+    park.fetchEntertainments = async () => jsonResponse({items: [
+      {id: 'a', plopsa_id: '700', title: 'Show A', type: {label: 'Show'},
+        schedule_info: {schedule: [{date, timeslots: [{type: 'open', start_time: '23:59', end_time: null}]}]}},
+      {id: 'b', plopsa_id: '701', title: 'Meet B', type: {label: 'Meet&Greet'},
+        schedule_info: {schedule: [{date: '2000-01-01', timeslots: [{type: 'open', start_time: '10:00', end_time: null}]}]}},
+      {id: 'c', plopsa_id: '702', title: 'Parade C', type: {label: 'Parade'},
+        schedule_info: {schedule: [{date, timeslots: [{type: 'open', start_time: '12:00', end_time: null}]}]}},
+    ]}) as any;
+
+    const live = await park.buildLiveDataForTest();
+
+    // Show with a performance today → present with today's showtimes.
+    const a = live.find((l) => l.id === '700');
+    expect(a).toBeDefined();
+    expect(a?.showtimes).toHaveLength(1);
+
+    // Meet-and-greet whose only performance is on a past date → CLOSED, no showtimes.
+    const b = live.find((l) => l.id === '701');
+    expect(b?.status).toBe('CLOSED');
+    expect(b?.showtimes).toBeUndefined();
+
+    // Parades are not mapped as entities, so they must not appear in live data.
+    expect(live.find((l) => l.id === '702')).toBeUndefined();
   });
 });

--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -181,6 +181,27 @@ describe('buildSchedules feed independence', () => {
 
     expect(await park.buildSchedulesForTest()).toEqual([]);
   });
+
+  test('still returns the park schedule when the entertainments fetch fails', async () => {
+    const park = new ScheduleProbe();
+    park.fetchCalendar = async () => jsonResponse({schedule: {
+      '2026-07': {
+        '2026-07-11': {slots: [{
+          type: 'open',
+          start_time: '2026-07-11T10:00:00+02:00',
+          end_time: '2026-07-11T18:00:00+02:00',
+        }]},
+      },
+    }}) as any;
+    park.fetchEntertainments = async () => { throw new Error('entertainments 500'); };
+
+    const schedules = await park.buildSchedulesForTest();
+
+    // Entertainments failed, so no show schedules — but the park calendar survives.
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].id).toBe('plopsaland');
+    expect(schedules[0].schedule).toHaveLength(1);
+  });
 });
 
 describe('plopsaBuildShowtimes', () => {
@@ -284,5 +305,27 @@ describe('buildLiveData shows', () => {
 
     // Parades are not mapped as entities, so they must not appear in live data.
     expect(live.find((l) => l.id === '702')).toBeUndefined();
+  });
+
+  test('a failing entertainments feed drops only the shows, never the ride live data', async () => {
+    const park = new LiveProbe();
+    const date = todayIn('Europe/Brussels');
+
+    park.fetchWaitTimes = async () => jsonResponse({'42': 15}) as any;
+    park.fetchPOI = async () => jsonResponse({items: [{
+      id: 'poi-1',
+      title: 'Rides',
+      type: {label: 'Attraction'},
+      contains: [{id: '42', title: 'Some Coaster', type: 'attraction'}],
+    }]}) as any;
+    park.fetchTodayHours = async () =>
+      jsonResponse({date, timeslots: [{type: 'open', start_time: '00:00', end_time: '23:59'}]}) as any;
+    park.fetchEntertainments = async () => { throw new Error('entertainments 500'); };
+
+    // buildLiveData() is not wrapped in a try/catch by the base class, so an
+    // unguarded rejection here would take the ride data down with it.
+    const live = await park.buildLiveDataForTest();
+
+    expect(live.map((l) => l.id)).toEqual(['42']);
   });
 });

--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -8,7 +8,7 @@
  * disagrees between instances.
  */
 import {describe, test, expect} from 'vitest';
-import type {Entity} from '@themeparks/typelib';
+import type {Entity, EntitySchedule} from '@themeparks/typelib';
 import {plopsaDecideOperating, Plopsaland} from '../plopsa.js';
 
 describe('plopsaDecideOperating', () => {
@@ -132,5 +132,53 @@ describe('De Panne POI location wiring', () => {
     expect(entities.find((e) => e.id === 'missing-title')).toBeUndefined();
     expect(entities.find((e) => e.id === 'null-title')).toBeUndefined();
     expect(entities.find((e) => e.id === 'anubis')).toBeDefined();
+  });
+});
+
+describe('buildSchedules feed independence', () => {
+  class ScheduleProbe extends Plopsaland {
+    public buildSchedulesForTest(): Promise<EntitySchedule[]> {
+      return this.buildSchedules();
+    }
+  }
+
+  function jsonResponse(payload: unknown) {
+    return {json: async () => payload};
+  }
+
+  const showItems = [{
+    id: 'show-1',
+    plopsa_id: '900',
+    title: 'Test Show',
+    type: {label: 'Show'},
+    schedule_info: {
+      temporarily_closed: false,
+      schedule: [{
+        date: '2026-07-11',
+        timeslots: [{type: 'open', start_time: '14:00', end_time: null}],
+      }],
+    },
+  }];
+
+  test('still returns show schedules when the park calendar fetch fails', async () => {
+    const park = new ScheduleProbe();
+    park.fetchCalendar = async () => { throw new Error('calendar 500'); };
+    park.fetchEntertainments = async () => jsonResponse({items: showItems}) as any;
+
+    const schedules = await park.buildSchedulesForTest();
+
+    // Calendar failed, so no park entry — but the show schedule survives.
+    expect(schedules.find((s) => s.id === 'plopsaland')).toBeUndefined();
+    const show = schedules.find((s) => s.id === '900');
+    expect(show?.schedule).toHaveLength(1);
+    expect(show?.schedule?.[0]?.date).toBe('2026-07-11');
+  });
+
+  test('omits the park entry when the calendar yields no operating days', async () => {
+    const park = new ScheduleProbe();
+    park.fetchCalendar = async () => jsonResponse({schedule: {}}) as any;
+    park.fetchEntertainments = async () => jsonResponse({items: []}) as any;
+
+    expect(await park.buildSchedulesForTest()).toEqual([]);
   });
 });

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -519,6 +519,23 @@ class PlopsaBase extends Destination {
   // ── Schedules ─────────────────────────────────────────────────
 
   protected async buildSchedules(): Promise<EntitySchedule[]> {
+    const schedules: EntitySchedule[] = [];
+
+    // The park calendar and the show schedules come from separate feeds, so
+    // they are built independently: a failure fetching one must not discard
+    // the other. The park entry is only emitted when the calendar yields days.
+    const parkSchedule = await this.buildParkSchedule();
+    if (parkSchedule.length > 0) {
+      schedules.push({id: this.parkId, schedule: parkSchedule} as EntitySchedule);
+    }
+
+    schedules.push(...await this.buildShowSchedules());
+
+    return schedules;
+  }
+
+  /** Park operating hours for the next ~90 days from the calendar endpoint. */
+  private async buildParkSchedule(): Promise<EntitySchedule['schedule']> {
     const now = new Date();
     const startDate = formatDate(now, this.timezone);
     const endDate = formatDate(addDays(now, 90), this.timezone);
@@ -557,7 +574,11 @@ class PlopsaBase extends Destination {
       }
     }
 
-    // Also build show schedules from entertainments
+    return schedule;
+  }
+
+  /** Per-show operating schedules from the entertainments feed. */
+  private async buildShowSchedules(): Promise<EntitySchedule[]> {
     const entResp = await this.fetchEntertainments();
     const entData = (await entResp.json()) as PlopsaEntertainmentResponse;
     const showSchedules: EntitySchedule[] = [];
@@ -589,10 +610,7 @@ class PlopsaBase extends Destination {
       }
     }
 
-    return [
-      {id: this.parkId, schedule} as EntitySchedule,
-      ...showSchedules,
-    ];
+    return showSchedules;
   }
 }
 

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -487,13 +487,13 @@ class PlopsaBase extends Destination {
       this.fetchWaitTimes(),
       this.fetchPOI(),
       this.fetchTodayHours(today).catch(() => null),
-      this.fetchEntertainments(),
+      this.fetchEntertainments().catch(() => null),
     ]);
 
     const waitTimes = (await waitResp.json()) as PlopsaWaitTimesResponse;
     const poiData = (await poiResp.json()) as PlopsaPOIResponse;
     const hoursData = hoursResp ? (await hoursResp.json()) as PlopsaTodayHours : null;
-    const entData = (await entResp.json()) as PlopsaEntertainmentResponse;
+    const entData = entResp ? (await entResp.json()) as PlopsaEntertainmentResponse : null;
 
     // Per-attraction temporarily-closed flag from POI.
     const closedById = new Map<string, boolean>();
@@ -565,10 +565,12 @@ class PlopsaBase extends Destination {
       } as unknown as LiveData;
     });
 
-    // Show / meet-and-greet live data. The entertainments feed is independent
-    // of the wait-times feed above, so these surface even when a ride feed
-    // hiccups. Today's performances are attached as showtimes and the show is
-    // CLOSED once the last one has passed.
+    // Show / meet-and-greet live data. The entertainments fetch is gated by its
+    // own catch above: this method is not wrapped in a try/catch by the base
+    // class, so an unguarded rejection here would reject the whole poll and take
+    // the ride live data down with it. A failing entertainments feed therefore
+    // drops only the shows. Today's performances are attached as showtimes and
+    // the show is CLOSED once the last one has passed.
     const nowMs = Date.now();
     const showLiveData: LiveData[] = [];
     for (const item of entData?.items ?? []) {
@@ -653,8 +655,14 @@ class PlopsaBase extends Destination {
 
   /** Per-show operating schedules from the entertainments feed. */
   private async buildShowSchedules(): Promise<EntitySchedule[]> {
-    const entResp = await this.fetchEntertainments();
-    const entData = (await entResp.json()) as PlopsaEntertainmentResponse;
+    let entData: PlopsaEntertainmentResponse;
+    try {
+      const entResp = await this.fetchEntertainments();
+      entData = (await entResp.json()) as PlopsaEntertainmentResponse;
+    } catch {
+      return [];
+    }
+
     const showSchedules: EntitySchedule[] = [];
 
     for (const item of entData?.items ?? []) {

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -19,8 +19,8 @@ import config from '../../config.js';
 import {http, HTTPObj} from '../../http.js';
 import {CacheLib} from '../../cache.js';
 import {destinationController} from '../../destinationRegistry.js';
-import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
-import {formatDate, addDays, formatInTimezone} from '../../datetime.js';
+import type {Entity, LiveData, EntitySchedule, LiveTimeSlot} from '@themeparks/typelib';
+import {formatDate, addDays, formatInTimezone, constructDateTime} from '../../datetime.js';
 import dePanneLocations from './locations/plopsaland-de-panne.json' with {type: 'json'};
 
 // ── API response types ──────────────────────────────────────────
@@ -56,6 +56,18 @@ interface PlopsaPOIResponse {
   items: PlopsaPOIItem[];
 }
 
+interface PlopsaScheduleTimeslot {
+  type: string;
+  start_time: string;
+  end_time: string | null;
+}
+
+interface PlopsaScheduleDay {
+  date: string;
+  timeslots: PlopsaScheduleTimeslot[];
+  reserved?: boolean;
+}
+
 interface PlopsaEntertainmentItem {
   id: string;
   plopsa_id?: string;
@@ -65,14 +77,7 @@ interface PlopsaEntertainmentItem {
   };
   schedule_info?: {
     temporarily_closed?: boolean;
-    schedule?: Array<{
-      date: string;
-      timeslots: Array<{
-        type: string;
-        start_time: string;
-        end_time: string | null;
-      }>;
-    }>;
+    schedule?: PlopsaScheduleDay[];
   };
   poi?: {
     id: string;
@@ -130,6 +135,49 @@ function isParkOpenNow(hours: PlopsaTodayHours | null, tz: string): boolean {
     if (slot.start_time <= nowHM && nowHM < slot.end_time) return true;
   }
   return false;
+}
+
+/**
+ * Build the live showtimes for a single entertainment item on a given date.
+ *
+ * The entertainments feed lists per-day `open` timeslots as HH:MM start times
+ * with no end (point-in-time performances). Start times are normalised to
+ * ISO+offset for the park timezone; end times are only emitted when the feed
+ * provides one, otherwise null. Slots for other dates or non-`open` types are
+ * ignored.
+ */
+export function plopsaBuildShowtimes(
+  schedule: PlopsaScheduleDay[] | undefined,
+  date: string,
+  timezone: string,
+): LiveTimeSlot[] {
+  const day = (schedule ?? []).find((d) => d.date === date);
+  const showtimes: LiveTimeSlot[] = [];
+
+  for (const slot of day?.timeslots ?? []) {
+    if (slot.type !== 'open' || !slot.start_time) continue;
+    showtimes.push({
+      type: 'Showtime',
+      startTime: constructDateTime(date, slot.start_time, timezone),
+      endTime: slot.end_time ? constructDateTime(date, slot.end_time, timezone) : null,
+    });
+  }
+
+  return showtimes;
+}
+
+/**
+ * Decide a show's live status from today's performances: OPERATING while a
+ * performance is still upcoming or ongoing, then CLOSED once the day's last
+ * one has ended. The feed omits end times, so each slot's end falls back to
+ * its start. The full day's schedule stays published in `showtimes`.
+ */
+export function plopsaShowStatus(showtimes: LiveTimeSlot[], nowMs: number): 'OPERATING' | 'CLOSED' {
+  const hasUpcoming = showtimes.some((slot) => {
+    const end = slot.endTime ?? slot.startTime;
+    return end != null && Date.parse(end) > nowMs;
+  });
+  return hasUpcoming ? 'OPERATING' : 'CLOSED';
 }
 
 interface CalendarDaySlot {
@@ -435,17 +483,17 @@ class PlopsaBase extends Destination {
   protected async buildLiveData(): Promise<LiveData[]> {
     const today = formatTodayInTimezone(this.timezone);
 
-    const [waitResp, poiResp, hoursResp] = await Promise.all([
+    const [waitResp, poiResp, hoursResp, entResp] = await Promise.all([
       this.fetchWaitTimes(),
       this.fetchPOI(),
       this.fetchTodayHours(today).catch(() => null),
+      this.fetchEntertainments(),
     ]);
 
     const waitTimes = (await waitResp.json()) as PlopsaWaitTimesResponse;
-    if (!waitTimes) return [];
-
     const poiData = (await poiResp.json()) as PlopsaPOIResponse;
     const hoursData = hoursResp ? (await hoursResp.json()) as PlopsaTodayHours : null;
+    const entData = (await entResp.json()) as PlopsaEntertainmentResponse;
 
     // Per-attraction temporarily-closed flag from POI.
     const closedById = new Map<string, boolean>();
@@ -496,7 +544,9 @@ class PlopsaBase extends Destination {
     }
 
     const lastUpdated = new Date().toISOString();
-    return Object.entries(waitTimes).map(([attractionId, waitTime]) => {
+
+    // Attraction live data, keyed off the wait-times feed.
+    const rideLiveData = Object.entries(waitTimes ?? {}).map(([attractionId, waitTime]) => {
       const id = String(attractionId);
       const tempClosed = closedById.get(id) === true;
       const hasWait = typeof waitTime === 'number';
@@ -514,6 +564,30 @@ class PlopsaBase extends Destination {
         lastUpdated,
       } as unknown as LiveData;
     });
+
+    // Show / meet-and-greet live data. The entertainments feed is independent
+    // of the wait-times feed above, so these surface even when a ride feed
+    // hiccups. Today's performances are attached as showtimes and the show is
+    // CLOSED once the last one has passed.
+    const nowMs = Date.now();
+    const showLiveData: LiveData[] = [];
+    for (const item of entData?.items ?? []) {
+      const label = item.type?.label ?? '';
+      if (label !== 'Show' && label !== 'Meet&Greet') continue;
+
+      const showtimes = plopsaBuildShowtimes(item.schedule_info?.schedule, today, this.timezone);
+      const ld = {
+        id: this.entityId({id: item.id, plopsa_id: item.plopsa_id}),
+        status: plopsaShowStatus(showtimes, nowMs),
+        lastUpdated,
+      } as unknown as LiveData;
+      if (showtimes.length > 0) {
+        (ld as {showtimes?: LiveTimeSlot[]}).showtimes = showtimes;
+      }
+      showLiveData.push(ld);
+    }
+
+    return [...rideLiveData, ...showLiveData];
   }
 
   // ── Schedules ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Shows and meet-and-greets at both Plopsa parks (De Panne and Deutschland) were
only exposed as **entities** — they never appeared in **live data**, so consumers
saw no status and no today's performance times for them. Their **schedules were
also silently dropped** whenever the park-calendar fetch failed, even though the
show times come from a completely separate feed.

This PR fixes both, entirely within the shared `PlopsaBase` class (so both parks
benefit) and with no schema change:

1. **`fix`** — decouple the show schedules from the park-calendar fetch.
2. **`feat`** — emit each show/meet-and-greet in live data with today's
   performances as `showtimes` and an `OPERATING` / `CLOSED` status.
3. **`fix`** — guard the entertainments fetch so a failure there can never take
   down the ride live data or the park calendar (from review, see below).

## Problem 1 — a calendar failure discarded the show schedules

`buildSchedules` fetched the park calendar first and **early-returned `[]`** the
moment that fetch threw — *before* it built the per-show schedules from the
independent `entertainments` feed. A single transient calendar hiccup (or a
missing `*_CALENDARURL`) therefore took the park hours **and** all show times
down together.

Split into `buildParkSchedule()` (calendar feed) and `buildShowSchedules()`
(entertainments feed), combined at the end, so a failure in one never discards
the other.

## Problem 2 — shows/meet-and-greets had no live data

`buildLiveData` mapped **only** the wait-times feed, which lists attractions. It
now also reads the `entertainments` feed and emits a live entry per
show/meet-and-greet, via two exported, unit-tested pure helpers:

- **`plopsaBuildShowtimes(schedule, date, tz)`** — picks today's day entry, keeps
  only `open` slots, normalises HH:MM start times to ISO+offset via
  `constructDateTime` (DST-correct). The feed has no end time (point-in-time
  performances), so `endTime` is `null` unless the feed provides one.
- **`plopsaShowStatus(showtimes, nowMs)`** — `OPERATING` while a performance is
  still upcoming or ongoing, `CLOSED` once the day's last one has ended.

| Today's performances | `status` | `showtimes` |
|---|---|---|
| none listed for today | `CLOSED` | *(omitted)* |
| last one still upcoming/ongoing | `OPERATING` | today's slots |
| last one already passed | `CLOSED` | today's slots (kept for reference) |

### Consistency with the codebase

This is the **same rule the AttractionsIO parks use for shows** (see
`src/parks/attractionsio/attractionsiov1.ts`) — deliberately mirrored so the same
concept is expressed the same way: same `end = endTime ?? startTime` fallback,
same `Date.parse(end) > nowMs` predicate, same `type: 'Showtime'` slot label, same
"attach `showtimes` only when non-empty" rule.

## Problem 3 — an entertainments outage could take down unrelated data (from review)

Thanks to @cubehouse for catching this. Neither `getLiveData()` nor
`getSchedules()` wraps its `build*` method in a try/catch, so an unguarded
rejection propagates out and drops **everything** that method would have
returned.

- `buildLiveData`'s new `fetchEntertainments()` call had no guard, so a failing
  entertainments feed rejected the whole `Promise.all` and took the **ride
  wait-time live data** down with it — data this endpoint could not affect at all
  before this branch. Now gated with `.catch(() => null)`, matching
  `fetchTodayHours` right above it.
- `buildShowSchedules()` had the **mirror image** of the same defect: an
  entertainments failure rejected `buildSchedules()` and discarded the **park
  calendar** too. Now wrapped in the same try/catch `buildParkSchedule()` uses.

Both paths have regression tests, each verified to **fail without its guard**
(`Error: entertainments 500`) rather than passing vacuously.

## Merge with #249

`main` picked up #249 (*treat 0-wait as no signal, report DOWN not OPERATING*),
which rewrote the same `buildLiveData` ride-mapping block and renamed
`plopsaDecideOperating` → `plopsaDecideStatus`. Merged and resolved keeping
**both** sides:

- **#249's ride semantics** — `plopsaDecideStatus`, `rawWait` (only a strictly
  positive reading counts as a live signal), `DOWN` for park-open +
  `temporarily_closed` + no signal, and `STANDBY.waitTime = rawWait`.
- **This branch** — show/meet-and-greet live data, the `waitTimes ?? {}`
  relaxation, and the entertainments-fetch guards.

Verified live that both coexist correctly (see below).

## Verification (live feeds)

| Park | Harness | Attractions (live) | Shows (live) | Schedules |
|---|---|---|---|---|
| Plopsaland Deutschland | ✅ 4/4 | 47/47 — 46 OPERATING, **1 DOWN** | 17/17 — 14 with showtimes | 17 |
| Plopsaland De Panne | ✅ 4/4 | 53/53 — 47 OPERATING, **6 DOWN** (incl. SuperSplash) | 13/13 — 6 with showtimes | 10 |

#249's `DOWN` semantics and this branch's show live data work side by side.

Real emitted show data, spot-checked against the official app:

```
Plopsaland Deutschland (park 10:00–22:30)
  [OPERATING] Meet Holly                     16:50          ← still upcoming
  [CLOSED   ] Meet Vic & Halvar              13:25, 15:10   ← last one passed, times kept
  [CLOSED   ] Meet the Easter Bunny Happy    (none today)   ← seasonal, correct

Plopsaland De Panne (park 10:00–19:00)
  [OPERATING] Bumba Show                     13:00, 17:15
  [CLOSED   ] Maya Show                      12:00
  [CLOSED   ] Meet the Christmas Gnome       (none today)   ← seasonal, correct
```

Seasonal characters (Easter / Pumpkin / Christmas) correctly report `CLOSED` with
no performances in July; the "last performance passed → CLOSED, showtimes kept"
rule is visible on *Meet Vic & Halvar* vs *Meet Holly*.

### Tests

`src/parks/plopsa/__tests__/plopsa.test.ts` — **20/20 passing** (#249's rewritten
`plopsaDecideStatus` matrix retained, plus four new blocks):

- `plopsaBuildShowtimes` — date matching, non-`open` slot filtering, ISO+offset
  construction, `null` end times.
- `plopsaShowStatus` — empty → `CLOSED`; upcoming → `OPERATING`; last performance
  passed → `CLOSED`; start-time fallback when no end time.
- `buildSchedules` feed independence — show schedules survive a calendar failure;
  the park schedule survives an entertainments failure.
- `buildLiveData` — shows emit independently of the wait-times feed; a failing
  entertainments feed drops only the shows, never the ride live data; parades
  (not mapped as entities) are excluded.

## Deployment / configuration

No hardcoded URLs (per `CLAUDE.md`, these live in `.env`). Show times and the park
calendar only work when configured:

| Env var | Purpose |
|---|---|
| `PLOPSALANDDEUTSCHLAND_BASEURL` | Deutschland middleware base |
| `PLOPSALANDDEUTSCHLAND_CALENDARURL` | Deutschland opening-hours calendar |
| `PLOPSALAND_BASEURL` | De Panne middleware base |
| `PLOPSALAND_CALENDARURL` | De Panne opening-hours calendar |

`*_CALENDARURL` is the calendar endpoint **without** `start`/`end` —
`fetchCalendar` appends those itself. De Panne's `/en/plopsaland-de-panne/` slug
301-redirects to `/en/plopsaland-belgium/`; configure the redirect target directly.

## Out of scope

- **De Panne "Merry-go-Round" POI location** — left untouched. It is documented as
  *intentionally absent* in `locations/README.md` (not shown on the park map), and
  the map is not affine-clean enough to derive a hand-verified coordinate (median
  ~10 m, max ~106 m error across 86 control points).
- **Restaurant live data** — Plopsa has never emitted it; the POI feed exposes only
  a `temporarily_closed` flag, no hours. Unchanged here.
