### PR TITLE
fix(parcsreunidos): extract shared Stay-App bearer from Weex bundle, fix status mapping

### DIFF
--- a/src/__tests__/frameworkContract.test.ts
+++ b/src/__tests__/frameworkContract.test.ts
@@ -97,15 +97,15 @@ describe('@destinationController auto-applies @config', () => {
   });
 
   test('config prefix resolution works for registered parks', async () => {
-    process.env.STAYAPP_AUTHTOKEN = 'test-token-123';
+    process.env.STAYAPP_BEARERBUNDLEURL = 'https://token.example/bundle.js';
 
     const entry = await getDestinationById('movieparkgermany');
     const park = new entry!.DestinationClass();
 
     // Should resolve via STAYAPP prefix (shared)
-    expect((park as any).authToken).toBe('test-token-123');
+    expect((park as any).bearerBundleUrl).toBe('https://token.example/bundle.js');
 
-    delete process.env.STAYAPP_AUTHTOKEN;
+    delete process.env.STAYAPP_BEARERBUNDLEURL;
   });
 });
 

--- a/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
+++ b/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
@@ -1,4 +1,5 @@
-import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
+import {describe, test, expect, vi, beforeEach, afterEach, beforeAll, afterAll} from 'vitest';
+import {createServer, IncomingMessage, ServerResponse} from 'http';
 import {MovieParkGermany} from '../parcsreunidos.js';
 import {CacheLib} from '../../../cache.js';
 import type {HTTPObj} from '../../../http.js';
@@ -109,6 +110,55 @@ describe('ParcsReunidosDestination — Weex bundle bearer extraction', () => {
 
     expect(token).toBe('eyJhbGc.eyJpYXQ.SIG');
   });
+
+  test('extracts the bearer even when it is not the first key in the bearerPWA object', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const reordered = 'i.environment="production";i.bearerPWA={someOtherField:"Y",bearer:"TOK123",another:"Z"};';
+    park.fetchBearerBundle = async () => ({text: async () => reordered} as any as HTTPObj);
+
+    expect(await park.getAccessToken()).toBe('TOK123');
+  });
+
+  test('extracts the bearer when bearerPWA is emitted as an object-literal property (`:`) instead of an assignment (`=`)', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const objectLiteralShape = 'return{environment:"production",bearerPWA:{bearer:"TOK123"},baseCmsApiHost:{}}';
+    park.fetchBearerBundle = async () => ({text: async () => objectLiteralShape} as any as HTTPObj);
+
+    expect(await park.getAccessToken()).toBe('TOK123');
+  });
+
+  test('throws (rather than returning empty string) when bearerBundleUrl is unset, so the failure is never cached as a success', async () => {
+    const park = new MovieParkGermany();
+    await expect(park.getAccessToken()).rejects.toThrow('bearerBundleUrl not configured');
+  });
+
+  test('backs off for 5 minutes after a failed fetch instead of re-fetching the bundle on every call', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const fetchMock = vi.fn(async () => ({text: async () => 'no bearerPWA here'} as any as HTTPObj));
+    park.fetchBearerBundle = fetchMock;
+
+    await expect(park.getAccessToken()).rejects.toThrow();
+    await expect(park.getAccessToken()).rejects.toThrow('backing off');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('recovers after a failure once the backoff window is cleared', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const fetchMock = vi.fn(async () => ({text: async () => 'no bearerPWA here'} as any as HTTPObj));
+    park.fetchBearerBundle = fetchMock;
+
+    await expect(park.getAccessToken()).rejects.toThrow();
+    CacheLib.clear();
+    fetchMock.mockImplementation(async () => ({text: async () => bundleWith('TOK123')} as any as HTTPObj));
+
+    expect(await park.getAccessToken()).toBe('TOK123');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 /**
@@ -123,6 +173,49 @@ describe('ParcsReunidosDestination — Weex bundle bearer extraction', () => {
  * no reliable DOWN signal anywhere in this API. Every negative value maps
  * to CLOSED; only a non-negative number means OPERATING.
  */
+
+/**
+ * fetchBearerBundle() itself — real HTTP call against a local server,
+ * unstubbed, matching the pattern in src/__tests__/httpIntegration.test.ts.
+ * Every other bearer-extraction test stubs this method directly, so none
+ * of them would catch a regression that drops or typos the isBundleRequest
+ * header or user-agent — per Stay-App's own bundle server, those are what
+ * select the bundle variant carrying the bearerPWA constant at all.
+ */
+describe('ParcsReunidosDestination.fetchBearerBundle — real HTTP request shape', () => {
+  const TEST_PORT = 9993;
+  const TEST_URL = `http://localhost:${TEST_PORT}`;
+  let server: ReturnType<typeof createServer>;
+  let lastRequestHeaders: Record<string, string | string[] | undefined> = {};
+
+  beforeAll(async () => {
+    server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      lastRequestHeaders = req.headers;
+      res.writeHead(200, {'Content-Type': 'text/javascript'});
+      res.end('i.bearerPWA={bearer:"TOK123"};');
+    });
+    await new Promise<void>(resolve => server.listen(TEST_PORT, resolve));
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(err => err ? reject(err) : resolve()));
+  });
+
+  beforeEach(() => CacheLib.clear());
+  afterEach(() => CacheLib.clear());
+
+  test('sends isBundleRequest and a WeexStayApp user-agent, and the real response round-trips through getAccessToken', async () => {
+    const park = new MovieParkGermany();
+    park.bearerBundleUrl = TEST_URL;
+
+    const token = await park.getAccessToken();
+
+    expect(token).toBe('TOK123');
+    expect(lastRequestHeaders['isbundlerequest']).toBe('true');
+    expect(String(lastRequestHeaders['user-agent'])).toMatch(/WeexStayApp/);
+  });
+});
+
 describe('ParcsReunidosDestination.buildLiveData — operating status mapping', () => {
   beforeEach(() => CacheLib.clear());
   afterEach(() => CacheLib.clear());
@@ -172,5 +265,17 @@ describe('ParcsReunidosDestination.buildLiveData — operating status mapping', 
     park.getAttractions = async () => [{id: 1} as any];
     const live = await park.getLiveData();
     expect(live.find(l => l.id === '1')).toBeUndefined();
+  });
+
+  test('a numeric-string waitingTime is coerced, not misclassified as CLOSED', async () => {
+    // Number.isFinite('5') is false (unlike global isFinite, it never
+    // coerces) — waitingTime is only typed `number` at the TS level over an
+    // unvalidated JSON response, so a numeric-string value must still
+    // resolve to OPERATING rather than silently falling through to CLOSED.
+    expect(await liveStatusFor('5' as any)).toEqual({status: 'OPERATING', waitTime: 5});
+  });
+
+  test('a numeric-string negative sentinel is still coerced and correctly maps to CLOSED', async () => {
+    expect((await liveStatusFor('-2' as any)).status).toBe('CLOSED');
   });
 });

--- a/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
+++ b/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
@@ -1,0 +1,112 @@
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
+import {MovieParkGermany} from '../parcsreunidos.js';
+import {CacheLib} from '../../../cache.js';
+import type {HTTPObj} from '../../../http.js';
+
+/**
+ * The Stay-App bearer is a static, long-lived service-account token baked
+ * into the Weex JS bundle's build-time config (`i.bearerPWA={bearer:"..."}`)
+ * — shared across every Parcs Reunidos park, not obtained via any login
+ * call. getAccessToken() fetches that bundle and regex-extracts the
+ * constant. These tests stub fetchBearerBundle() (the @http-decorated
+ * fetch) rather than global fetch, matching this repo's established
+ * pattern for testing @http methods.
+ */
+describe('ParcsReunidosDestination — Weex bundle bearer extraction', () => {
+  const ENV_KEYS = ['MOVIEPARKGERMANY_BEARERBUNDLEURL'];
+  const BUNDLE_URL = 'https://token.example/bundle.js';
+
+  beforeEach(() => {
+    CacheLib.clear();
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    CacheLib.clear();
+  });
+
+  function bundleWith(bearer: string): string {
+    return `!function(e){...}([function(e,t,o){var i={};i.environment="production";i.elastic="OS1.2";i.bearerPWA={bearer:"${bearer}"};i.baseCmsApiHost={production:"https://api.example/manager"}}]);`;
+  }
+
+  test('extracts the bearer from a realistic bundle and injects it as Authorization', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    park.stayEstablishment = 'mBv6';
+    park.fetchBearerBundle = async () => ({text: async () => bundleWith('TOK123')} as any as HTTPObj);
+
+    const req = {headers: {}} as HTTPObj;
+    await park.injectHeaders(req);
+
+    expect(req.headers!['Authorization']).toBe('Bearer TOK123');
+    expect(req.headers!['Stay-Establishment']).toBe('mBv6');
+  });
+
+  test('omits Authorization entirely when bearerBundleUrl is unset, rather than sending a malformed empty Bearer', async () => {
+    const park = new MovieParkGermany();
+    const fetchSpy = vi.spyOn(park, 'fetchBearerBundle');
+
+    const req = {headers: {}} as HTTPObj;
+    await park.injectHeaders(req);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(req.headers).not.toHaveProperty('Authorization');
+    expect(req.headers!['Stay-Establishment']).toBe('');
+  });
+
+  test('omits Authorization and logs a warning when the bearerPWA constant is not found in the bundle', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    park.fetchBearerBundle = async () => ({text: async () => 'some unrelated bundle content'} as any as HTTPObj);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const req = {headers: {}} as HTTPObj;
+    await park.injectHeaders(req);
+
+    expect(req.headers).not.toHaveProperty('Authorization');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bearerPWA constant not found'));
+    warnSpy.mockRestore();
+  });
+
+  test('caches the extracted bearer — a second call does not re-fetch the bundle', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const fetchMock = vi.fn(async () => ({text: async () => bundleWith('TOK123')} as any as HTTPObj));
+    park.fetchBearerBundle = fetchMock;
+
+    await park.getAccessToken();
+    await park.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('cached under a class-scoped key, reachable via CacheLib.clearByClassName', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const fetchMock = vi.fn(async () => ({text: async () => bundleWith('TOK123')} as any as HTTPObj));
+    park.fetchBearerBundle = fetchMock;
+
+    await park.getAccessToken();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const cleared = CacheLib.clearByClassName('MovieParkGermany');
+    expect(cleared).toBeGreaterThan(0);
+
+    await park.getAccessToken();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('parses a real-shaped bundle fragment matching the production config module structure', async () => {
+    process.env.MOVIEPARKGERMANY_BEARERBUNDLEURL = BUNDLE_URL;
+    const park = new MovieParkGermany();
+    const realShape = 'Object.defineProperty(t,"__esModule",{value:!0});var i={};i.environment="production";'
+      + 'i.elastic="OS1.2";i.development=!1,i.loggerEnabled=!0;i.bearerPWA={bearer:"eyJhbGc.eyJpYXQ.SIG"},'
+      + 'i.baseCmsApiHost={production:"https://api.example/manager",preproduction:"https://api-p';
+    park.fetchBearerBundle = async () => ({text: async () => realShape} as any as HTTPObj);
+
+    const token = await park.getAccessToken();
+
+    expect(token).toBe('eyJhbGc.eyJpYXQ.SIG');
+  });
+});

--- a/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
+++ b/src/parks/parcsreunidos/__tests__/parcsreunidos.test.ts
@@ -110,3 +110,67 @@ describe('ParcsReunidosDestination — Weex bundle bearer extraction', () => {
     expect(token).toBe('eyJhbGc.eyJpYXQ.SIG');
   });
 });
+
+/**
+ * Status mapping for buildLiveData(). The API expresses status entirely via
+ * `waitingTime` sentinels: no separate "is this ride down" field reliably
+ * distinguishes a broken ride from a closed one. Verified live across 5
+ * parks: -2 and -3 both behave as fresh, actively-updating, park-wide
+ * "not open" signals (different establishments use different sentinels for
+ * the same state) and the app's own UI shows "Geschlossen"/Closed for them
+ * — not "down". `temporaryClosed` correlates with the long-stale -1 bucket
+ * instead (removed/under-refurbishment rides), not with -2/-3, so there's
+ * no reliable DOWN signal anywhere in this API. Every negative value maps
+ * to CLOSED; only a non-negative number means OPERATING.
+ */
+describe('ParcsReunidosDestination.buildLiveData — operating status mapping', () => {
+  beforeEach(() => CacheLib.clear());
+  afterEach(() => CacheLib.clear());
+
+  async function liveStatusFor(waitingTime: number | undefined): Promise<{status: string; waitTime?: number | null}> {
+    const park = new MovieParkGermany();
+    park.getAttractions = async () => [{id: 1, waitingTime} as any];
+    const live = await park.getLiveData();
+    const entry = live.find(l => l.id === '1')!;
+    return {status: entry.status as string, waitTime: entry.queue?.STANDBY?.waitTime};
+  }
+
+  test('a non-negative waitingTime maps to OPERATING with that wait time', async () => {
+    expect(await liveStatusFor(12)).toEqual({status: 'OPERATING', waitTime: 12});
+  });
+
+  test('waitingTime 0 maps to OPERATING with a 0-minute wait, not CLOSED', async () => {
+    expect(await liveStatusFor(0)).toEqual({status: 'OPERATING', waitTime: 0});
+  });
+
+  test('waitingTime -1 maps to CLOSED', async () => {
+    expect((await liveStatusFor(-1)).status).toBe('CLOSED');
+  });
+
+  test('waitingTime -2 maps to CLOSED, not DOWN', async () => {
+    expect((await liveStatusFor(-2)).status).toBe('CLOSED');
+  });
+
+  test('waitingTime -3 maps to CLOSED', async () => {
+    expect((await liveStatusFor(-3)).status).toBe('CLOSED');
+  });
+
+  test('no live entry is ever emitted with status DOWN', async () => {
+    const park = new MovieParkGermany();
+    park.getAttractions = async () => [
+      {id: 1, waitingTime: -1} as any,
+      {id: 2, waitingTime: -2} as any,
+      {id: 3, waitingTime: -3} as any,
+      {id: 4, waitingTime: 7} as any,
+    ];
+    const live = await park.getLiveData();
+    expect(live.some(l => l.status === 'DOWN')).toBe(false);
+  });
+
+  test('a missing waitingTime is skipped entirely, not emitted as any status', async () => {
+    const park = new MovieParkGermany();
+    park.getAttractions = async () => [{id: 1} as any];
+    const live = await park.getLiveData();
+    expect(live.find(l => l.id === '1')).toBeUndefined();
+  });
+});

--- a/src/parks/parcsreunidos/parcsreunidos.ts
+++ b/src/parks/parcsreunidos/parcsreunidos.ts
@@ -339,14 +339,17 @@ class ParcsReunidosDestination extends Destination {
       const entityId = String(attraction.id);
       const ld: LiveData = {id: entityId, status: 'CLOSED'} as LiveData;
 
-      if (waitingTime === -2) {
-        // Down / broken
-        ld.status = 'DOWN' as any;
-      } else if (waitingTime === -3 || waitingTime < 0) {
-        // Closed (including other negative values)
-        ld.status = 'CLOSED' as any;
-      } else {
-        // Operating with standby queue
+      // Negative sentinel values (-1, -2, -3, ...) all mean "not currently
+      // operating" — verified live against the app's own UI (shows
+      // "Geschlossen"/Closed) and cross-park data: -2 and -3 both behave
+      // identically (fresh, actively-updating, park-wide "not open" signals
+      // — different establishments apparently use different sentinel values
+      // for the same state). Nothing in the API distinguishes a genuine
+      // ride-is-down state from park/ride-not-open: `temporaryClosed`
+      // correlates with the long-stale -1 bucket (rides untouched for
+      // months/years — a removed/under-refurbishment signal), not with -2
+      // or -3, so there's no reliable DOWN signal here. Default to CLOSED.
+      if (Number.isFinite(waitingTime) && waitingTime >= 0) {
         ld.status = 'OPERATING' as any;
         ld.queue = {
           STANDBY: {waitTime: waitingTime},

--- a/src/parks/parcsreunidos/parcsreunidos.ts
+++ b/src/parks/parcsreunidos/parcsreunidos.ts
@@ -11,7 +11,7 @@
 import {Destination, type DestinationConstructor} from '../../destination.js';
 import config from '../../config.js';
 import {http, type HTTPObj} from '../../http.js';
-import {cache} from '../../cache.js';
+import {cache, CacheLib} from '../../cache.js';
 import {inject} from '../../injector.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
@@ -219,15 +219,41 @@ class ParcsReunidosDestination extends Destination {
    * than swallowing the error here — @cache/CacheLib.wrap doesn't cache a
    * thrown error, so a transient failure costs one retry, not the full
    * 24h TTL. injectHeaders() is responsible for tolerating the throw.
+   *
+   * Extraction is two-stage and order-independent: first isolate the
+   * `bearerPWA={...}` (or `bearerPWA:{...}`) sub-object, then find `bearer`
+   * within it regardless of key position — a single anchored regex on
+   * `bearerPWA={bearer:"..."` would silently stop matching the moment
+   * Stay-App's bundler reorders that object's keys or emits it as an
+   * object-literal property instead of an assignment.
+   *
+   * A short-lived failure backoff (separate from the 24h success cache,
+   * since CacheLib.wrap never caches a thrown error) prevents hammering
+   * the bundle with a fresh ~1MB fetch on every poll cycle across all 5
+   * parks if it becomes unreachable or changes shape.
    */
   @cache({ttlSeconds: 86400})
   async getAccessToken(): Promise<string> {
-    if (!this.bearerBundleUrl) return '';
-    const resp = await this.fetchBearerBundle();
-    const bundle = await resp.text();
-    const match = /bearerPWA\s*=\s*\{\s*bearer\s*:\s*"([^"]+)"/.exec(bundle);
-    if (!match) throw new Error('bearerPWA constant not found in Weex bundle');
-    return match[1];
+    if (!this.bearerBundleUrl) throw new Error('bearerBundleUrl not configured');
+
+    const failureCacheKey = `${this.constructor.name}:bearerBundleFetchFailed:${this.bearerBundleUrl}`;
+    if (CacheLib.get(failureCacheKey)) {
+      throw new Error('bearer bundle fetch recently failed, backing off');
+    }
+
+    try {
+      const resp = await this.fetchBearerBundle();
+      const bundle = await resp.text();
+      const objMatch = /bearerPWA\s*[:=]\s*\{([^}]*)\}/.exec(bundle);
+      const bearerMatch = objMatch ? /bearer\s*:\s*"([^"]+)"/.exec(objMatch[1]) : null;
+      if (!bearerMatch) throw new Error('bearerPWA constant not found in Weex bundle');
+      return bearerMatch[1];
+    } catch (err) {
+      // Back off 5 minutes before retrying a failing bundle fetch, rather
+      // than re-fetching ~1MB on every poll cycle during an outage.
+      CacheLib.set(failureCacheKey, true, 300);
+      throw err;
+    }
   }
 
   /**
@@ -331,13 +357,21 @@ class ParcsReunidosDestination extends Destination {
     const liveData: LiveData[] = [];
 
     for (const attraction of attractions) {
-      const waitingTime = attraction.waitingTime;
+      const rawWaitingTime = attraction.waitingTime;
 
       // Skip entities with no waitingTime data
-      if (waitingTime === undefined || waitingTime === null) continue;
+      if (rawWaitingTime === undefined || rawWaitingTime === null) continue;
 
       const entityId = String(attraction.id);
       const ld: LiveData = {id: entityId, status: 'CLOSED'} as LiveData;
+
+      // `waitingTime` is only typed `number` at the TS level (an assertion
+      // over an unvalidated JSON response) — coerce via Number() before
+      // Number.isFinite, since Number.isFinite doesn't coerce and a
+      // numeric-string wait time would otherwise silently misclassify an
+      // operating ride as CLOSED. Matches this repo's established pattern
+      // for the same field shape (te2.ts, nigloland.ts).
+      const waitingTime = Number(rawWaitingTime);
 
       // Negative sentinel values (-1, -2, -3, ...) all mean "not currently
       // operating" — verified live against the app's own UI (shows

--- a/src/parks/parcsreunidos/parcsreunidos.ts
+++ b/src/parks/parcsreunidos/parcsreunidos.ts
@@ -67,9 +67,18 @@ class ParcsReunidosDestination extends Destination {
   @config
   appId: string = '';
 
-  /** Shared auth token for API requests */
+  /**
+   * URL of the Stay-App Weex JS bundle that carries the shared PWA bearer
+   * as a build-time config constant (`i.bearerPWA={bearer:"..."}`) — a
+   * static, long-lived service-account token, not something obtained via
+   * login. Identical across every Parcs Reunidos / Stay-App-powered park
+   * (confirmed by comparing live captures from two different park apps);
+   * it only changes when Stay-App next rebuilds this shared bundle.
+   * Requires the `isBundleRequest: true` header — without it the server
+   * serves a different bundle variant that doesn't carry this constant.
+   */
   @config
-  authToken: string = '';
+  bearerBundleUrl: string = '';
 
   /** Per-park establishment identifier for API header */
   @config
@@ -122,9 +131,18 @@ class ParcsReunidosDestination extends Destination {
   async injectHeaders(requestObj: HTTPObj): Promise<void> {
     requestObj.headers = {
       ...requestObj.headers,
-      'Authorization': `Bearer ${this.authToken}`,
       'Stay-Establishment': this.stayEstablishment,
     };
+    // Every Stay-App endpoint requires this header, but the API rejects a
+    // malformed `Bearer ` (empty token) with AUTHORIZATION_HEADER_BAD_FORMED
+    // — worse than simply omitting the header and letting the request 401
+    // normally — so only set it when a real token was obtained.
+    try {
+      const token = await this.getAccessToken();
+      if (token) requestObj.headers['Authorization'] = `Bearer ${token}`;
+    } catch (err: any) {
+      console.warn(`[${this.constructor.name}] Stay-App bearer unavailable: ${err?.message ?? err}`);
+    }
   }
 
   // ============================================================================
@@ -169,9 +187,48 @@ class ParcsReunidosDestination extends Destination {
     } as any as HTTPObj;
   }
 
+  /**
+   * Fetch the Weex JS bundle carrying the shared PWA bearer. The
+   * `isBundleRequest` header and app-shaped user-agent are required —
+   * without them the server serves a different bundle variant that
+   * doesn't carry the `bearerPWA` config constant.
+   * Cached for 24 hours at HTTP level.
+   */
+  @http({cacheSeconds: 86400, retries: 2})
+  async fetchBearerBundle(): Promise<HTTPObj> {
+    return {
+      method: 'GET',
+      url: this.bearerBundleUrl,
+      headers: {
+        'isBundleRequest': 'true',
+        'user-agent': 'WeexStayApp(WeexStay/1.5.0) Weex/0.28.0.1',
+      },
+    } as any as HTTPObj;
+  }
+
   // ============================================================================
   // Cached Getter Methods
   // ============================================================================
+
+  /**
+   * Extract the shared PWA bearer from the Weex bundle's build-time config
+   * (`i.bearerPWA={bearer:"..."}`). Cached for 24 hours — this is a static,
+   * long-lived token that only changes when Stay-App rebuilds the bundle,
+   * not something needing frequent refresh. Throws on failure (missing
+   * bearerBundleUrl, fetch failure, or the constant not being found) rather
+   * than swallowing the error here — @cache/CacheLib.wrap doesn't cache a
+   * thrown error, so a transient failure costs one retry, not the full
+   * 24h TTL. injectHeaders() is responsible for tolerating the throw.
+   */
+  @cache({ttlSeconds: 86400})
+  async getAccessToken(): Promise<string> {
+    if (!this.bearerBundleUrl) return '';
+    const resp = await this.fetchBearerBundle();
+    const bundle = await resp.text();
+    const match = /bearerPWA\s*=\s*\{\s*bearer\s*:\s*"([^"]+)"/.exec(bundle);
+    if (!match) throw new Error('bearerPWA constant not found in Weex bundle');
+    return match[1];
+  }
 
   /**
    * Get park establishment info (cached 12 hours).


### PR DESCRIPTION
## What

Two fixes for Parcs Reunidos (5 parks: Movie Park Germany, Bobbejaanland, Mirabilandia, Parque de Atracciones Madrid, Parque Warner Madrid), both found and verified while re-investigating the auth failure from #245.

### 1. Auth: static `STAYAPP_AUTHTOKEN` → extracted from the Weex bundle

`STAYAPP_AUTHTOKEN` was a static value with no refresh path, going stale whenever Stay-App next rebuilds their app. #245's OAuth2/Keycloak design was solving the wrong problem — that flow only backs an unrelated survey feature, never the endpoints this adapter actually calls.

Traced the real mechanism via live device captures from two different Parcs Reunidos apps: the bearer these apps send to `api-manager.stay-app.com` is identical, static, and long-lived (same account, same signature, byte-for-byte, across both apps) — because it's not obtained via any login call at all. It's a build-time config constant (`i.bearerPWA={bearer:"..."}`) embedded directly in the shared Weex JS bundle every Stay-App-powered park app loads (`weex.stay-app.com/index.js`, requires the `isBundleRequest` header to get the variant that carries it).

`getAccessToken()` now fetches that bundle and regex-extracts the constant, cached 24h. No external secret needed — the bundle is public and unauthenticated; extraction is just parsing a documented, consistently-shaped config object out of it. `injectHeaders()` omits `Authorization` entirely on extraction failure rather than sending a malformed empty `Bearer`.

Verified end-to-end against the real production API for **all 5 parks**: real bearer extracted from the live bundle, used to fetch real establishment + attraction data successfully off one shared `STAYAPP_BEARERBUNDLEURL` config value.

### 2. Live data: `waitingTime -2` no longer maps to `DOWN`

Found while sanity-checking live output now that auth works: Movie Park's own app UI shows "Geschlossen" (Closed) for the rides this adapter was reporting as `DOWN`.

Checked raw API data across all 5 parks. `-2` and `-3` behave identically — both are fresh, actively-updating, park-wide "not open right now" signals (different establishments use different sentinel values for the same state: Movie Park uses `-2`, Parque Warner Madrid uses `-3` for the same "park isn't open" condition). Nothing in the API distinguishes a genuine ride-down state from park/ride-not-open — `temporaryClosed` correlates with the long-stale `-1` bucket instead (rides untouched for months/years, a removed/under-refurbishment signal), not with `-2`/`-3`.

Every negative `waitingTime` now maps to `CLOSED`; only non-negative means `OPERATING`. No `DOWN` status is emitted by this adapter anymore — there's no reliable signal for it in this data source.

## Testing

- 9 tests for `buildLiveData()` (first coverage this destination has ever had): the OPERATING/CLOSED boundary at 0, each sentinel value, an assertion DOWN is never emitted, missing-waitingTime skip path, numeric-string coercion.
- 11 tests for bearer extraction: realistic bundle parsing (including key-reordered and object-literal-property shapes), malformed-bundle handling, class-scoped caching (`clearByClassName` compatible), malformed-header-avoidance on failure, 5-minute failure backoff.
- 1 real-HTTP integration test (local server, unstubbed `fetchBearerBundle()`) proving the `isBundleRequest` header and user-agent are actually sent.
- 21 tests total. Full suite: 1403/1403 passing.
- Live-verified against real production APIs for all 5 parks: entities, live data, and schedules all fetched successfully off one shared `STAYAPP_BEARERBUNDLEURL` + `STAYAPP_BASEURL`.
- Status-mapping fix verified live: Movie Park Germany 29/29 CLOSED (was 27 DOWN + 2 CLOSED), Parque Warner Madrid 31/31 CLOSED (was 30 CLOSED + 1 DOWN), Bobbejaanland's 11 genuinely-operating rides unaffected.

## Update: self-reviewed via a 6-dimension adversarial pass, 4 real issues fixed

Ran the same fan-out review process against this PR before asking for human review. 72 raw findings across correctness/reliability/tests/conventions/security, 6 survived 3-skeptic adversarial verification. Fixed 4:

- **Bearer regex was order-dependent** — silently returned no match if Stay-App ever reorders the `bearerPWA` object's keys or emits it as `bearerPWA:{...}` instead of `bearerPWA={...}`. Since this is now the sole auth path for all 5 parks, that would've broken every park simultaneously with zero warning. Now a two-stage, order-independent extraction.
- **`Number.isFinite(waitingTime)` never coerced** — a numeric-string wait time would misclassify an operating ride as `CLOSED` (the old `< 0` comparison happened to tolerate strings; this was a latent regression from the status-mapping fix). Now coerces via `Number()` first, matching `te2.ts`/`nigloland.ts`'s existing pattern.
- **Missing `bearerBundleUrl` returned `''` instead of throwing** — got cached as a "success" for the full 24h under `@cache`. Now throws, consistent with the method's own "don't cache failures" contract.
- **No backoff on a failing bundle fetch** — an outage at `weex.stay-app.com` meant a fresh ~1MB(+2 retries) fetch on every poll cycle, indefinitely, across all 5 parks. Added a separate 5-minute failure cache.

Also added the test the review flagged as highest-value: every bearer test stubbed `fetchBearerBundle()` directly, so none would catch a regression dropping the `isBundleRequest` header — the thing that actually selects the bundle variant carrying the token. New test hits a real local server, unstubbed.

One review agent (independently reproduced by 2 more during adversarial verification) reported encountering fake `<system-reminder>`-formatted content in tool output while grepping ordinary repo files — a fabricated date-change notice and an "Auto Mode Active" nudge. Believed to be a benign harness artifact (matches legitimate session-level reminders I've received elsewhere this session, misread by context-less sub-agents) rather than an actual attack, but noting it here since it surfaced mid-review and is worth being aware of.

## Known unrelated issue, not fixed here

While sanity-checking, noticed the schedule day array from `buildSchedules()` isn't sorted chronologically (e.g. Movie Park Germany's array starts with 2027-01-02..01-05 then jumps back to 2026-03-27). Pre-existing, unrelated to either fix above — flagging separately rather than scope-creeping this PR.

## Deployment note

Needs `STAYAPP_BEARERBUNDLEURL` (pointing at the real Weex bundle URL) added to prod config in place of the old `STAYAPP_AUTHTOKEN`. No other secret required — this value is a public URL, not a credential.
