### PR TITLE
feat(enchantedparks): scrape dining and shows, wire up for Valleyfair

### DIFF
--- a/src/parks/enchantedparks/__tests__/enchantedparks.test.ts
+++ b/src/parks/enchantedparks/__tests__/enchantedparks.test.ts
@@ -2,6 +2,7 @@ import {describe, test, expect} from 'vitest';
 import {parseTribeEvents, type TribeEventsResponse, EnchantedParks} from '../enchantedparks.js';
 import {parseICalFeed} from '../enchantedparks.js';
 import {parseAttractionsPage} from '../enchantedparks.js';
+import {parseShowsPage} from '../enchantedparks.js';
 
 describe('parseTribeEvents', () => {
   const fixture: TribeEventsResponse = {
@@ -260,6 +261,77 @@ describe('parseAttractionsPage', () => {
 </div>`;
     const out = parseAttractionsPage(beforeHtml);
     expect(out).toEqual([{slug: 'renegade', name: 'Renegade'}]);
+  });
+
+  test('with linkPathSegment="dining", matches dining cards and skips attraction cards', () => {
+    const diningFixture = `<article>
+      <a href="https://valleyfair.enchantedparks.com/rides-and-experiences/dining/gateway-grounds/"><img /></a>
+      <div class="container"><h3>Gateway Grounds</h3></div>
+    </article>
+    <article>
+      <a href="https://valleyfair.enchantedparks.com/rides-and-experiences/attractions/wild-thing/"><img /></a>
+      <div class="container"><h3>Wild Thing</h3></div>
+    </article>`;
+    const out = parseAttractionsPage(diningFixture, 'dining');
+    expect(out).toEqual([{slug: 'gateway-grounds', name: 'Gateway Grounds'}]);
+  });
+});
+
+describe('parseShowsPage', () => {
+  const fixture = `<!doctype html><html><body>
+<article id="post-10106" class="item card passes col span4 post-10106 post type-post category-live-entertainment no-thumb">
+  <figure><img src="happiness.webp" alt="Happiness Is… background image" /></figure>
+  <div class="container">
+    <h4>Happiness Is…</h4>
+    <p>May 23-Aug 30</p>
+  </div>
+</article>
+<article id="post-10113" class="item card passes col span4 post-10113 post type-post category-live-entertainment no-thumb">
+  <figure><img src="peanuts.webp" /></figure>
+  <div class="container">
+    <h4>PEANUTS&#8482; Meet &#038; Greet</h4>
+  </div>
+</article>
+<article id="post-8016" class="item card post-8016 page type-page category-cta-box-footer no-thumb">
+  <figure><img src="cabana.jpg" /></figure>
+  <div class="container"><h4>Cabana Rentals</h4></div>
+</article>
+</body></html>`;
+
+  test('extracts show name per category-live-entertainment card', () => {
+    const out = parseShowsPage(fixture, 'live-entertainment');
+    expect(out.map(s => s.name)).toEqual(['Happiness Is…', 'PEANUTS™ Meet & Greet']);
+  });
+
+  test('ignores cards from other categories (e.g. footer CTAs)', () => {
+    const out = parseShowsPage(fixture, 'live-entertainment');
+    expect(out.map(s => s.name)).not.toContain('Cabana Rentals');
+  });
+
+  test('slugifies names with trademark glyphs and ampersands for the id', () => {
+    const out = parseShowsPage(fixture, 'live-entertainment');
+    const peanuts = out.find(s => s.name === 'PEANUTS™ Meet & Greet');
+    expect(peanuts?.slug).toBe('peanuts-meet-and-greet');
+  });
+
+  test('slugifies an ellipsis/trailing punctuation cleanly', () => {
+    const out = parseShowsPage(fixture, 'live-entertainment');
+    const happiness = out.find(s => s.name === 'Happiness Is…');
+    expect(happiness?.slug).toBe('happiness-is');
+  });
+
+  test('returns empty when no card matches the requested category', () => {
+    expect(parseShowsPage(fixture, 'special-events')).toEqual([]);
+  });
+
+  test('returns empty for HTML with no article cards', () => {
+    expect(parseShowsPage('<html><body>nothing here</body></html>', 'live-entertainment')).toEqual([]);
+  });
+
+  test('deduplicates cards that slugify to the same name', () => {
+    const dup = fixture + fixture;
+    const out = parseShowsPage(dup, 'live-entertainment');
+    expect(out).toHaveLength(2);
   });
 });
 

--- a/src/parks/enchantedparks/enchantedparks.ts
+++ b/src/parks/enchantedparks/enchantedparks.ts
@@ -97,18 +97,30 @@ export type AttractionStub = {slug: string; name: string};
  * Each entry has a slug (URL fragment) and a name (h3 heading text).
  *
  * The pages embed each ride as a card with a link
- *   <a href="…/rides-and-experiences/attractions/{slug}/">…</a>
+ *   <a href="…/rides-and-experiences/{linkPathSegment}/{slug}/">…</a>
  * and a heading `<h3>{name}</h3>`. Both appear inside the same card markup,
  * so we collect distinct slug→name pairs by walking the HTML in order.
+ *
+ * `linkPathSegment` is the category segment the detail-page links use —
+ * this is independent of whatever page is being scraped. Every attraction
+ * (including water-park ones, listed on a separate page) links back to
+ * `/rides-and-experiences/attractions/{slug}/`, so ride-listing scrapes
+ * always pass `'attractions'` regardless of which page they fetched. Dining
+ * cards link to `/rides-and-experiences/dining/{slug}/`, so dining scrapes
+ * pass `'dining'`.
  */
-export function parseAttractionsPage(html: string): AttractionStub[] {
+export function parseAttractionsPage(html: string, linkPathSegment: string = 'attractions'): AttractionStub[] {
   const seen = new Set<string>();
   const out: AttractionStub[] = [];
   // Two-phase h3 search: first look for the next <h3> within ~2KB after the
   // link (the common case — h3 inside or immediately after the card's <a>).
   // If none is found, fall back to the most-recent <h3> in the 2KB before the
   // link (for cards that put the heading above the anchor).
-  const linkRe = /href=["'][^"']*\/rides-and-experiences\/attractions\/([a-z0-9][a-z0-9-]*)\/?["'][^>]*>/gi;
+  const escapedSegment = linkPathSegment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const linkRe = new RegExp(
+    `href=["'][^"']*/rides-and-experiences/${escapedSegment}/([a-z0-9][a-z0-9-]*)/?["'][^>]*>`,
+    'gi',
+  );
   const h3Re = /<h3[^>]*>([\s\S]*?)<\/h3>/gi;
   for (const m of html.matchAll(linkRe)) {
     const slug = m[1];
@@ -145,6 +157,57 @@ export function parseAttractionsPage(html: string): AttractionStub[] {
   return out;
 }
 
+/**
+ * Slugify a name for use in an entity id. Shows have no detail-page URL to
+ * take a slug from (see {@link parseShowsPage}), so we derive one from the
+ * display name instead: strip trademark/ampersand glyphs, lowercase, and
+ * collapse everything else to single hyphens.
+ */
+function slugify(name: string): string {
+  return name
+    .replace(/[™®©]/g, '')
+    .replace(/&/g, ' and ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Extract show stubs from a `/rides-and-experiences/<path>/` page (e.g.
+ * `live-entertainment`). Unlike rides and dining, show cards have no
+ * individual detail-page link to take a slug from — they're inline content
+ * blocks:
+ *   <article class="… category-{categorySlug} …">
+ *     <figure>…</figure>
+ *     <div class="container"><h4>{name}</h4> … </div>
+ *   </article>
+ *
+ * `categorySlug` is the WordPress category class suffix (e.g.
+ * `live-entertainment`) that marks a card as a show rather than one of the
+ * other card types (footer CTAs, upsells, …) mixed into the same page.
+ */
+export function parseShowsPage(html: string, categorySlug: string): AttractionStub[] {
+  const seen = new Set<string>();
+  const out: AttractionStub[] = [];
+  const escapedCategory = categorySlug.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const cardRe = new RegExp(`<article\\b[^>]*\\bcategory-${escapedCategory}\\b[^>]*>`, 'gi');
+  const h4Re = /<h4[^>]*>([\s\S]*?)<\/h4>/i;
+  for (const m of html.matchAll(cardRe)) {
+    const cardStart = m.index! + m[0].length;
+    const cardEnd = Math.min(html.length, cardStart + 3000);
+    const window = html.slice(cardStart, cardEnd);
+    const h4 = h4Re.exec(window);
+    if (!h4) continue;
+    const name = decodeHtmlEntities(stripHtmlTags(h4[1]));
+    if (!name) continue;
+    const slug = slugify(name);
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push({slug, name});
+  }
+  return out;
+}
+
 export type ParkConfig = {
   /** Entity id, e.g. `enchantedparks_park_VF` */
   id: string;
@@ -154,6 +217,10 @@ export type ParkConfig = {
   name: string;
   /** Path under `/rides-and-experiences/` whose page lists this park's attractions */
   ridesPath: string;
+  /** Path under `/rides-and-experiences/` whose page lists this park's dining locations. Omit if not scraped. */
+  diningPath?: string;
+  /** Path/category under `/rides-and-experiences/` whose page lists this park's shows. Omit if not scraped. */
+  showsPath?: string;
   /** Tribe Events category name that flags this park's operating-hours events (e.g. `Park Hours`, `Waterpark Hours`) */
   scheduleCategory: string;
   /** Park-level geographic location (lat/lng). Required for the harness's anchor-entity check. */
@@ -348,6 +415,40 @@ class EnchantedParks extends Destination {
     }
   }
 
+  /**
+   * Fetch and parse the dining listing for one PARK. Same page shape as
+   * {@link scrapeAttractions} (the WP theme reuses its card markup for every
+   * `/rides-and-experiences/<category>/` listing), just pointed at the
+   * dining category and linking back to `/rides-and-experiences/dining/…`
+   * detail pages instead of `/attractions/…`.
+   */
+  @cache({ttlSeconds: 60 * 60 * 24})
+  async scrapeDining(diningPath: string): Promise<AttractionStub[]> {
+    try {
+      const resp = await this.fetchAttractionsPage(diningPath);
+      const html = await resp.text();
+      return parseAttractionsPage(html, 'dining');
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Fetch and parse the shows listing for one PARK. See
+   * {@link parseShowsPage} for why this needs its own parser rather than
+   * reusing {@link parseAttractionsPage}.
+   */
+  @cache({ttlSeconds: 60 * 60 * 24})
+  async scrapeShows(showsPath: string): Promise<AttractionStub[]> {
+    try {
+      const resp = await this.fetchAttractionsPage(showsPath);
+      const html = await resp.text();
+      return parseShowsPage(html, showsPath);
+    } catch {
+      return [];
+    }
+  }
+
   // ===== Public-API overrides =====
 
   async getDestinations(): Promise<Entity[]> {
@@ -432,6 +533,42 @@ class EnchantedParks extends Destination {
         const loc = this.lookupAttractionLocation(r.name);
         if (loc) (entity as any).location = loc;
         attractions.push(entity);
+      }
+
+      if (this.themePark.diningPath) {
+        const dining = await this.scrapeDining(this.themePark.diningPath);
+        for (const d of dining) {
+          const entity: Entity = {
+            id: `enchantedparks_restaurant_${this.themePark.code}_${d.slug}`,
+            name: d.name,
+            entityType: 'RESTAURANT',
+            parentId: this.themePark.id,
+            parkId: this.themePark.id,
+            destinationId: this.destinationId,
+            timezone: this.timezone,
+          } as Entity;
+          const loc = this.lookupAttractionLocation(d.name);
+          if (loc) (entity as any).location = loc;
+          attractions.push(entity);
+        }
+      }
+
+      if (this.themePark.showsPath) {
+        const shows = await this.scrapeShows(this.themePark.showsPath);
+        for (const s of shows) {
+          const entity: Entity = {
+            id: `enchantedparks_show_${this.themePark.code}_${s.slug}`,
+            name: s.name,
+            entityType: 'SHOW',
+            parentId: this.themePark.id,
+            parkId: this.themePark.id,
+            destinationId: this.destinationId,
+            timezone: this.timezone,
+          } as Entity;
+          const loc = this.lookupAttractionLocation(s.name);
+          if (loc) (entity as any).location = loc;
+          attractions.push(entity);
+        }
       }
     }
 

--- a/src/parks/enchantedparks/valleyfair.ts
+++ b/src/parks/enchantedparks/valleyfair.ts
@@ -24,6 +24,8 @@ export class Valleyfair extends EnchantedParks {
       code: 'VF',
       name: 'Valleyfair',
       ridesPath: 'attractions',
+      diningPath: 'dining',
+      showsPath: 'live-entertainment',
       scheduleCategory: 'Park Hours',
       location: {latitude: 44.7977, longitude: -93.4399},
     };

--- a/src/tools/migrate/server.ts
+++ b/src/tools/migrate/server.ts
@@ -126,11 +126,17 @@ export function startMigrationServer(config: ServerConfig): void {
 
     // Run commit in background
     try {
-      // Authenticate
+      // Authenticate. Prefer a fresh login via WIKI_USERNAME+WIKI_API_KEY
+      // whenever both are configured — a static WIKI_TOKEN in .env has no
+      // way to signal it's expired ahead of time, so trusting it blindly
+      // over available credentials means every commit silently 401s
+      // ("Token has expired") until someone notices and replaces it by
+      // hand. wikiToken is now only the fallback for setups that don't
+      // have login credentials at all.
       broadcast('status', {message: 'Authenticating...', progress: 0, total: toCommit.length});
 
-      let token = config.wikiToken;
-      if (!token) {
+      let token: string;
+      if (config.wikiUsername && config.wikiApiKey) {
         const authResp = await fetch(`${config.wikiApiUrl}/auth/login`, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
@@ -145,6 +151,12 @@ export function startMigrationServer(config: ServerConfig): void {
         }
 
         token = (await authResp.json() as {token: string}).token;
+      } else if (config.wikiToken) {
+        token = config.wikiToken;
+      } else {
+        broadcast('error', {message: 'No WIKI_USERNAME+WIKI_API_KEY or WIKI_TOKEN configured'});
+        commitInProgress = false;
+        return;
       }
       broadcast('status', {message: 'Authenticated', progress: 0, total: toCommit.length});
 

--- a/src/tools/migrate/server.ts
+++ b/src/tools/migrate/server.ts
@@ -109,8 +109,10 @@ export function startMigrationServer(config: ServerConfig): void {
     if (commitInProgress) {
       return res.status(409).json({error: 'Commit already in progress'});
     }
-    if (!config.wikiApiUrl || (!config.wikiToken && (!config.wikiUsername || !config.wikiApiKey))) {
-      return res.status(400).json({error: 'WIKI_API_URL and either WIKI_TOKEN or WIKI_USERNAME+WIKI_API_KEY must be configured in .env'});
+    const hasNewStyleKey = !!config.wikiApiKey?.trim().startsWith('tpw_');
+    const hasLoginCreds = !!(config.wikiUsername && config.wikiApiKey);
+    if (!config.wikiApiUrl || (!config.wikiToken && !hasLoginCreds && !hasNewStyleKey)) {
+      return res.status(400).json({error: 'WIKI_API_URL and one of: a tpw_-prefixed WIKI_API_KEY, WIKI_USERNAME+WIKI_API_KEY, or WIKI_TOKEN must be configured in .env'});
     }
 
     const toCommit = mappings.filter(
@@ -126,17 +128,34 @@ export function startMigrationServer(config: ServerConfig): void {
 
     // Run commit in background
     try {
-      // Authenticate. Prefer a fresh login via WIKI_USERNAME+WIKI_API_KEY
-      // whenever both are configured — a static WIKI_TOKEN in .env has no
-      // way to signal it's expired ahead of time, so trusting it blindly
-      // over available credentials means every commit silently 401s
-      // ("Token has expired") until someone notices and replaces it by
-      // hand. wikiToken is now only the fallback for setups that don't
-      // have login credentials at all.
+      // Authenticate. Three credential shapes, tried in order:
+      //
+      // 1. WIKI_API_KEY starting with `tpw_` — the current-generation API
+      //    key (services/apiKeys.ts on the wiki server), sent directly as
+      //    an X-Api-Key header on every request below. This does NOT go
+      //    through /auth/login: that endpoint's password-login handler
+      //    only checks the legacy single-column `user.apiKey` field
+      //    (auth.controller.ts loginWithPassword -> user.isValidApiKey),
+      //    which the new `tpw_` key system never touches — so a freshly
+      //    generated tpw_ key correctly, permanently 401s there with
+      //    "Invalid username or password" no matter how new it is. The
+      //    key only validates via validateApiKey() (auth.decorator.ts),
+      //    which route-level @auth() middleware calls for the X-Api-Key
+      //    header path, not the login endpoint.
+      // 2. WIKI_USERNAME + WIKI_API_KEY (legacy, non-`tpw_` key) — fresh
+      //    login via /auth/login to mint a JWT.
+      // 3. WIKI_TOKEN — static JWT fallback for setups without login
+      //    credentials at all. No way to detect expiry ahead of time, so
+      //    only used when nothing better is configured.
       broadcast('status', {message: 'Authenticating...', progress: 0, total: toCommit.length});
 
-      let token: string;
-      if (config.wikiUsername && config.wikiApiKey) {
+      let token: string | null = null;
+      let apiKeyHeader: string | null = null;
+
+      const trimmedApiKey = config.wikiApiKey?.trim();
+      if (trimmedApiKey?.startsWith('tpw_')) {
+        apiKeyHeader = trimmedApiKey;
+      } else if (config.wikiUsername && config.wikiApiKey) {
         const authResp = await fetch(`${config.wikiApiUrl}/auth/login`, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
@@ -169,7 +188,7 @@ export function startMigrationServer(config: ServerConfig): void {
             method: 'PUT',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': `Bearer ${token}`,
+              ...(apiKeyHeader ? {'X-Api-Key': apiKeyHeader} : {'Authorization': `Bearer ${token}`}),
             },
             body: JSON.stringify({_id: mapping.newExternalId}),
           });


### PR DESCRIPTION
## Summary

`buildEntityList()` only ever scraped the rides page, so `RESTAURANT` and `SHOW` entities were never emitted for any EnchantedParks destination. That's the direct cause of the pending-delete pile-up in Valleyfair's moderation queue (37 restaurants + 6 shows with old Cedar Fair-era `RESTAURANT-014-*`/`SHOW-014-*` ids and nothing on the new side to match against) — the park website does carry this data, it just wasn't being scraped.

## What changed

- `parseAttractionsPage()` now takes the detail-page link segment as a parameter (defaults to `'attractions'`, so every existing call site is unchanged). The dining page (`/rides-and-experiences/dining/`) shares the exact same card markup as the rides page, so it reuses this parser with `'dining'` passed in.
- Shows (`/rides-and-experiences/live-entertainment/`) use a completely different card shape — `category-live-entertainment`-tagged `<article>` blocks, `<h4>` names, and no per-show detail page to take a URL slug from. New `parseShowsPage()` + a `slugify()` helper derive an id from the display name instead (strips `™`/`®`/`©`, folds `&` to `and`, collapses everything else to hyphens).
- `ParkConfig` gets optional `diningPath` / `showsPath`. `buildEntityList()` scrapes and emits `RESTAURANT`/`SHOW` entities under the theme park when set — opt-in per park, no behavior change for parks that don't configure them.
- Valleyfair is wired up as the pilot (`diningPath: 'dining'`, `showsPath: 'live-entertainment'`). The other 5 EnchantedParks destinations (Worlds of Fun, Michigan's Adventure, Galveston, Mid-America Parks, Great Escape Parks) are untouched — same gap likely exists there, follow-up once this is proven out.

## Verification

Live run against the real site (`npm run dev -- valleyfair`), 4/4 tests pass:

| | Before | After |
|---|---|---|
| Entities | 55 (52 attractions) | 89 (52 attractions + **27 restaurants** + **7 shows**) |
| Live data | 0 (unchanged — no app yet) | 0 (unchanged — no app yet) |
| Schedules | 2 / 108 days (unchanged) | 2 / 108 days (unchanged) |

The 7 shows scraped match the current live-entertainment page exactly (Happiness Is…, Hoops 101, Live at Loon Landing, Music Goes Round and Around, PEANUTS™ Meet & Greet, Sound Cycle, Summer Smash-Up).

New entities land without location data (`⚠ Missing location` in the harness output) — expected, the static `attractionLocations` snapshot only covers what existed at migration time. Same pre-existing limitation as any new ride added after that snapshot; not something this PR needs to solve.

## Tests

`src/parks/enchantedparks/__tests__/enchantedparks.test.ts` — 33/33 passing (24 pre-existing + 9 new): dining-path parameterization, show extraction, category filtering (footer CTAs excluded), slugify edge cases (trademark glyphs, ampersands, ellipsis), dedup, empty-input handling.

Full suite: 1411/1411 passing.

## Context

Root-caused via a live moderation-queue audit — see conversation history. Not an ID-migration problem (Valleyfair's existing attraction ids already match 1:1, confirmed via `npm run migrate -- valleyfair --wiki-slug=enchantedparks_valleyfair`, 44/44 exact no-ops) — purely a missing-data-source gap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>