### PR TITLE
fix(plopsa): report DOWN instead of OPERATING for temporarily-closed rides at 0 wait

### DIFF
--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -1,40 +1,48 @@
 /**
  * Plopsa decision-logic regression tests.
  *
- * The full decision matrix for whether a ride emits OPERATING vs CLOSED.
- * The interesting case is row 3: a numeric wait time + a stale
- * `temporarily_closed: true` from POI must NOT downgrade to CLOSED, or
- * multi-collector deployments will flap any ride whose POI snapshot
- * disagrees between instances.
+ * The full decision matrix for the status a ride emits: OPERATING, DOWN,
+ * or CLOSED. The interesting cases are:
+ *  - a *positive* wait time + a stale `temporarily_closed: true` from POI
+ *    must NOT downgrade to DOWN, or multi-collector deployments will flap
+ *    any ride whose POI snapshot disagrees between instances.
+ *  - `temporarily_closed: true` + a `0` wait time (the feed's default/
+ *    no-signal value, present even for closed rides) MUST report DOWN,
+ *    not OPERATING — `0` is not evidence of a live reading.
  */
 import {describe, test, expect} from 'vitest';
 import type {Entity} from '@themeparks/typelib';
-import {plopsaDecideOperating, Plopsaland} from '../plopsa.js';
+import {plopsaDecideStatus, Plopsaland} from '../plopsa.js';
 
-describe('plopsaDecideOperating', () => {
+describe('plopsaDecideStatus', () => {
   test('park closed → ride always CLOSED regardless of other inputs', () => {
-    expect(plopsaDecideOperating(false, false, false)).toBe(false);
-    expect(plopsaDecideOperating(false, false, true)).toBe(false);
-    expect(plopsaDecideOperating(false, true,  false)).toBe(false);
-    expect(plopsaDecideOperating(false, true,  true)).toBe(false);
+    expect(plopsaDecideStatus(false, false, false)).toBe('CLOSED');
+    expect(plopsaDecideStatus(false, false, true)).toBe('CLOSED');
+    expect(plopsaDecideStatus(false, true,  false)).toBe('CLOSED');
+    expect(plopsaDecideStatus(false, true,  true)).toBe('CLOSED');
   });
 
   test('park open + ride open + has wait → OPERATING', () => {
-    expect(plopsaDecideOperating(true, false, true)).toBe(true);
+    expect(plopsaDecideStatus(true, false, true)).toBe('OPERATING');
   });
 
   test('park open + ride open + no wait → OPERATING (e.g. brand-new ride before first reading)', () => {
-    expect(plopsaDecideOperating(true, false, false)).toBe(true);
+    expect(plopsaDecideStatus(true, false, false)).toBe('OPERATING');
   });
 
   test('park open + POI says temp-closed + has wait → OPERATING (wait-times feed wins over stale POI hint)', () => {
-    // This is the case the bug report depends on: stale POI says closed,
-    // but the wait-times feed has a real number. Trust the live number.
-    expect(plopsaDecideOperating(true, true, true)).toBe(true);
+    // This is the case the earlier bug report depended on: stale POI says
+    // closed, but the wait-times feed has a real positive number. Trust
+    // the live number.
+    expect(plopsaDecideStatus(true, true, true)).toBe('OPERATING');
   });
 
-  test('park open + POI says temp-closed + no wait → CLOSED (the hint is authoritative when no live signal)', () => {
-    expect(plopsaDecideOperating(true, true, false)).toBe(false);
+  test('park open + POI says temp-closed + no wait → DOWN (the hint is authoritative when no live signal)', () => {
+    // Regression: the waiting-times feed returns `0` (not absence) for
+    // rides with no live reading, including temporarily_closed ones. `0`
+    // must not be treated as `hasWait`, or these rides wrongly show
+    // OPERATING instead of DOWN (e.g. SuperSplash at Plopsaland De Panne).
+    expect(plopsaDecideStatus(true, true, false)).toBe('DOWN');
   });
 });
 

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -98,25 +98,34 @@ function formatTodayInTimezone(tz: string): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
+export type PlopsaAttractionStatus = 'OPERATING' | 'DOWN' | 'CLOSED';
+
 /**
- * Decide whether a Plopsa ride should emit as OPERATING right now.
+ * Decide the live status of a Plopsa ride right now.
  *
  * Inputs are intentionally flat booleans + a primitive — pure function so
  * the matrix is easy to unit-test (see `__tests__/plopsa.test.ts`).
  *
- * The wait-times feed is treated as the ground truth: a numeric wait
- * means the ride is taking guests right now. POI's `temporarily_closed`
- * is a hint we use only when the wait-times feed has no number for the
- * ride. Without that priority, a stale 12h-cached POI snapshot on one
- * collector instance disagreeing with another instance's cached snapshot
- * causes lockstep OPERATING ↔ CLOSED flapping for the affected rides.
+ * A *positive* wait-times reading is treated as ground truth: it means the
+ * ride is taking guests right now, so it wins over a stale POI
+ * `temporarily_closed` hint. Without that priority, a stale 12h-cached POI
+ * snapshot on one collector instance disagreeing with another instance's
+ * cached snapshot causes lockstep OPERATING ↔ DOWN flapping for the
+ * affected rides.
+ *
+ * `hasWait` must only be true for a genuine positive reading — the
+ * waiting-times feed returns `0` for every ride (including ones POI marks
+ * `temporarily_closed`) whenever it has no live signal, so `0` is not
+ * evidence the ride is open and must not override the POI hint.
  */
-export function plopsaDecideOperating(
+export function plopsaDecideStatus(
   parkOpenNow: boolean,
   tempClosed: boolean,
   hasWait: boolean,
-): boolean {
-  return parkOpenNow && (hasWait || !tempClosed);
+): PlopsaAttractionStatus {
+  if (!parkOpenNow) return 'CLOSED';
+  if (hasWait || !tempClosed) return 'OPERATING';
+  return 'DOWN';
 }
 
 /** Is the park currently within an "open" timeslot from today's hours? */
@@ -499,17 +508,21 @@ class PlopsaBase extends Destination {
     return Object.entries(waitTimes).map(([attractionId, waitTime]) => {
       const id = String(attractionId);
       const tempClosed = closedById.get(id) === true;
-      const hasWait = typeof waitTime === 'number';
-      const operating = plopsaDecideOperating(parkOpenNow, tempClosed, hasWait);
+      // A raw `0` is the feed's default/no-signal value — it shows up for
+      // every ride, even ones POI marks temporarily_closed — so only a
+      // strictly positive reading counts as live evidence the ride is open.
+      const rawWait = typeof waitTime === 'number' ? waitTime : null;
+      const hasWait = rawWait !== null && rawWait > 0;
+      const status = plopsaDecideStatus(parkOpenNow, tempClosed, hasWait);
 
-      if (!operating) {
-        return {id, status: 'CLOSED', lastUpdated} as unknown as LiveData;
+      if (status !== 'OPERATING') {
+        return {id, status, lastUpdated} as unknown as LiveData;
       }
       return {
         id,
         status: 'OPERATING',
         queue: {
-          STANDBY: {waitTime: hasWait ? waitTime : null},
+          STANDBY: {waitTime: rawWait},
         },
         lastUpdated,
       } as unknown as LiveData;


### PR DESCRIPTION
## Summary

Plopsaland (De Panne and Deutschland) attractions marked `temporarily_closed` in the points-of-interest feed were being reported as `OPERATING` instead of `DOWN` in live data. Root cause: the waiting-times feed returns a numeric `0` — not an absence of the key — for every attraction whenever it has no live reading, and `buildLiveData` treated **any** numeric wait value as proof the ride was actively taking guests, silently overriding the `temporarily_closed` hint from the POI feed.

## How it was found

Querying the points-of-interest endpoint for Plopsaland De Panne:

```
GET https://api.pl.opsa.cloud/app-middleware/v1/api/points-of-interest?language=fr&park=plopsaland-de-panne
```

shows several attractions flagged as closed, e.g. SuperSplash (`plopsa_id: "90"`):

```json
{
  "title": "SuperSplash",
  "contains": [{
    "plopsa_id": "90",
    "title": "SuperSplash",
    "type": "attraction",
    "schedule_info": {
      "temporarily_closed": true,
      "temporarily_closed_message": "<p>Temporairement fermé</p>",
      "schedule": []
    }
  }]
}
```

Cross-referencing the waiting-times endpoint for the same park:

```
GET https://api.pl.opsa.cloud/app-middleware/v1/api/attractions/waiting-times?language=fr&park=plopsaland-de-panne
```

```json
{"427":0,"19":0,"1927":0,"3386":0,"144":0, ... ,"90":0, ... }
```

`"90": 0` is present — the feed always emits every attraction id with a numeric value, defaulting to `0` when it has nothing real to report. The previous code (`hasWait = typeof waitTime === 'number'`) treated this default `0` exactly the same as a genuine live reading, so it always won over the `temporarily_closed` flag and the ride showed `OPERATING` with a `0`-minute wait.

## The fix

`src/parks/plopsa/plopsa.ts`:

- `hasWait` is now `rawWait !== null && rawWait > 0` — only a **strictly positive** reading counts as live evidence the ride is dispatching guests. A `0` is treated as "no signal," matching what the feed actually means.
- The pure decision function was renamed `plopsaDecideOperating` → `plopsaDecideStatus` and now returns the full tri-state status directly (`OPERATING` / `DOWN` / `CLOSED`) instead of a boolean, so the "hint is authoritative when there's no live signal" case reports `DOWN` (ride down while park is open) rather than being conflated with `CLOSED` (park not open):

```ts
export function plopsaDecideStatus(
  parkOpenNow: boolean,
  tempClosed: boolean,
  hasWait: boolean,
): PlopsaAttractionStatus {
  if (!parkOpenNow) return 'CLOSED';
  if (hasWait || !tempClosed) return 'OPERATING';
  return 'DOWN';
}
```

- The existing anti-flapping design is preserved: a **genuine positive** wait time still wins over a stale `temporarily_closed` POI hint (this was the fix for a previous multi-collector lockstep-flapping bug — see the code comments/tests it replaces). Only the definition of "genuine" changed, from "any number" to "a number greater than zero."
- When a ride is confirmed `OPERATING`, the real wait value (including a real `0`-minute wait) is still surfaced in `queue.STANDBY.waitTime` — this change only affects which rides get classified as down, not the displayed wait time for rides that are actually running.

`src/parks/plopsa/__tests__/plopsa.test.ts`:

- Updated the full decision-matrix regression test to the renamed `plopsaDecideStatus` and its tri-state return value.
- Added a regression case pinning `temporarily_closed: true` + no live signal → `DOWN`, with a comment referencing the SuperSplash case above so future changes don't reintroduce the bug.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Park open, POI `temporarily_closed: true`, wait feed reports `0` | `OPERATING` (wait time shown as `0`) | `DOWN` |
| Park open, POI `temporarily_closed: true`, wait feed reports a real positive number | `OPERATING` | `OPERATING` (unchanged — live number still wins) |
| Park open, POI `temporarily_closed: false`, wait feed reports `0` (a genuine 0-min queue) | `OPERATING`, wait `0` | `OPERATING`, wait `0` (unchanged) |
| Park closed | `CLOSED` | `CLOSED` (unchanged) |

## Test plan

- [x] `npx vitest run src/parks/plopsa` — all 9 tests pass, including the new `temporarily_closed` + no-signal → `DOWN` regression case.
- [x] `npm run build` — no type errors.
- [x] Ran the harness against the **live** Plopsaland De Panne API (`npm run dev -- plopsaland`) before and after the fix:
  - Before: SuperSplash (id `90`) reported `OPERATING`.
  - After: `getLiveData()` returns SuperSplash as `DOWN`, and 6 attractions total are now correctly reported `DOWN` instead of `OPERATING` at 0 wait (`90`, `154`, `420`, `428`, `429`, `1327`) — all of which are flagged `temporarily_closed` in the POI feed.
  - `getEntities()` / `getSchedules()` unaffected: 102 entities, 10 schedules, still passing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
