### PR TITLE
fix(enchantedparks): wire up missing attraction location snapshot for Valleyfair

### DIFF
--- a/src/parks/enchantedparks/__tests__/enchantedparks.test.ts
+++ b/src/parks/enchantedparks/__tests__/enchantedparks.test.ts
@@ -386,3 +386,30 @@ describe('attraction location lookup', () => {
     expect(p.lookup('Timber Wolf')).toBeUndefined();
   });
 });
+
+describe('attractionLocations wiring on every EnchantedParks subclass', () => {
+  // Each subclass MUST wire up a locations/<slug>.json snapshot in its
+  // constructor. Without it, updateSource() on the wiki does a full replace
+  // (not a merge) on every collector sync, silently wiping out any
+  // real lat/lng the entity previously had — this happened for real to
+  // Valleyfair (79 attractions/dining/shows lost their coordinates) because
+  // it was the one subclass missing the wiring the other 5 already had.
+  test('every subclass has a non-empty attractionLocations snapshot', async () => {
+    const modules = await Promise.all([
+      import('../valleyfair.js'),
+      import('../worldsoffun.js'),
+      import('../michigansadventure.js'),
+      import('../midamericaparks.js'),
+      import('../greatescapeparks.js'),
+      import('../galvestonislandwaterpark.js'),
+    ]);
+
+    for (const mod of modules) {
+      const ParkClass = Object.values(mod)[0] as new () => EnchantedParks;
+      const instance = new ParkClass();
+      const snapshot = (instance as any).attractionLocations;
+      expect(snapshot, `${ParkClass.name} has no attractionLocations snapshot wired up`).toBeDefined();
+      expect(Object.keys(snapshot).length, `${ParkClass.name}'s attractionLocations snapshot is empty`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/parks/enchantedparks/locations/valleyfair.json
+++ b/src/parks/enchantedparks/locations/valleyfair.json
@@ -1,0 +1,318 @@
+{
+  "Delirious": {
+    "latitude": 44.79758,
+    "longitude": -93.45123
+  },
+  "Northern Lights": {
+    "latitude": 44.797152,
+    "longitude": -93.451845
+  },
+  "Steel Venom": {
+    "latitude": 44.797809,
+    "longitude": -93.451445
+  },
+  "Tilter": {
+    "latitude": 44.79815,
+    "longitude": -93.453483
+  },
+  "North Star": {
+    "latitude": 44.798294,
+    "longitude": -93.453689
+  },
+  "Bumper Cars": {
+    "latitude": 44.79901,
+    "longitude": -93.45599
+  },
+  "Power Tower": {
+    "latitude": 44.799024,
+    "longitude": -93.456522
+  },
+  "Wheel of Fortune": {
+    "latitude": 44.800224,
+    "longitude": -93.459492
+  },
+  "High Roller": {
+    "latitude": 44.800206,
+    "longitude": -93.457816
+  },
+  "Kite Eating Tree": {
+    "latitude": 44.799829,
+    "longitude": -93.457636
+  },
+  "PEANUTS™ Road Rally": {
+    "latitude": 44.799792,
+    "longitude": -93.457445
+  },
+  "Lucy’s Tugboat": {
+    "latitude": 44.800284,
+    "longitude": -93.45687
+  },
+  "Antique Autos": {
+    "latitude": 44.79753,
+    "longitude": -93.45148
+  },
+  "Cosmic Coaster": {
+    "latitude": 44.79952,
+    "longitude": -93.45766
+  },
+  "Minnesota River Valley Railroad": {
+    "latitude": 44.800084,
+    "longitude": -93.4567
+  },
+  "Ripple Rapids": {
+    "latitude": 44.79936,
+    "longitude": -93.460766
+  },
+  "Linus’ Beetle Bugs": {
+    "latitude": 44.800215,
+    "longitude": -93.457461
+  },
+  "Renegade": {
+    "latitude": 44.800377,
+    "longitude": -93.460625
+  },
+  "The Wave": {
+    "latitude": 44.799487,
+    "longitude": -93.454702
+  },
+  "Ferris Wheel": {
+    "latitude": 44.799947,
+    "longitude": -93.45559
+  },
+  "Carousel": {
+    "latitude": 44.79876,
+    "longitude": -93.45467
+  },
+  "PEANUTS™ 500": {
+    "latitude": 44.799649,
+    "longitude": -93.457582
+  },
+  "Sound Cycle": {
+    "latitude": 44.79753,
+    "longitude": -93.45148
+  },
+  "Excalibur": {
+    "latitude": 44.79985,
+    "longitude": -93.46247
+  },
+  "Charlie Brown’s Wind-Up": {
+    "latitude": 44.79995,
+    "longitude": -93.45771
+  },
+  "Snoopy vs. Red Baron": {
+    "latitude": 44.799503,
+    "longitude": -93.457961
+  },
+  "Monster": {
+    "latitude": 44.799892,
+    "longitude": -93.455105
+  },
+  "SuperCat": {
+    "latitude": 44.79834,
+    "longitude": -93.45589
+  },
+  "Woodstock Whirlybirds": {
+    "latitude": 44.800417,
+    "longitude": -93.457573
+  },
+  "Mad Mouse": {
+    "latitude": 44.799678,
+    "longitude": -93.458992
+  },
+  "Xtreme Swing": {
+    "latitude": 44.798895,
+    "longitude": -93.456847
+  },
+  "Hoops 101": {
+    "latitude": 44.80022,
+    "longitude": -93.456616
+  },
+  "Scrambler": {
+    "latitude": 44.797761,
+    "longitude": -93.452125
+  },
+  "Flying Ace Balloon Race": {
+    "latitude": 44.799884,
+    "longitude": -93.457789
+  },
+  "Linus Launcher": {
+    "latitude": 44.800269,
+    "longitude": -93.457633
+  },
+  "Schooner’s Bar": {
+    "latitude": 44.79904,
+    "longitude": -93.46011
+  },
+  "Wild Thing": {
+    "latitude": 44.798644,
+    "longitude": -93.458286
+  },
+  "Boathouse Refreshments": {
+    "latitude": 44.79956,
+    "longitude": -93.45477
+  },
+  "Snack Shack": {
+    "latitude": 44.799582,
+    "longitude": -93.460226
+  },
+  "Superior Plunge": {
+    "latitude": 44.79932,
+    "longitude": -93.45917
+  },
+  "Corkscrew": {
+    "latitude": 44.799744,
+    "longitude": -93.45516
+  },
+  "Barefoot Beach": {
+    "latitude": 44.79952,
+    "longitude": -93.45998
+  },
+  "Fall River Run": {
+    "latitude": 44.799507,
+    "longitude": -93.460957
+  },
+  "21° & Colder": {
+    "latitude": 44.798465,
+    "longitude": -93.457164
+  },
+  "Beach Bites": {
+    "latitude": 44.79919,
+    "longitude": -93.46019
+  },
+  "PEANUTS™ Playhouse": {
+    "latitude": 44.8003,
+    "longitude": -93.456345
+  },
+  "Superior Bar": {
+    "latitude": 44.799807,
+    "longitude": -93.454869
+  },
+  "Summer Smash-Up": {
+    "latitude": 44.7997,
+    "longitude": -93.454987
+  },
+  "Great Lake Launchers": {
+    "latitude": 44.79932,
+    "longitude": -93.45917
+  },
+  "Roasted Corn": {
+    "latitude": 44.798656,
+    "longitude": -93.456542
+  },
+  "Breakers Bay Wave Pool": {
+    "latitude": 44.79904,
+    "longitude": -93.45933
+  },
+  "Thunder Canyon": {
+    "latitude": 44.800219,
+    "longitude": -93.462015
+  },
+  "Auntie Anne’s®": {
+    "latitude": 44.798583,
+    "longitude": -93.454408
+  },
+  "Fryer Tuck’s Home Made French Fries": {
+    "latitude": 44.798866,
+    "longitude": -93.456492
+  },
+  "Music Goes Round and Around": {
+    "latitude": 44.800235,
+    "longitude": -93.456583
+  },
+  "Splash Station": {
+    "latitude": 44.799218,
+    "longitude": -93.460885
+  },
+  "Northwoods Pizzeria": {
+    "latitude": 44.800075,
+    "longitude": -93.459483
+  },
+  "Renegade Smokehouse": {
+    "latitude": 44.80027,
+    "longitude": -93.45981
+  },
+  "Coasters": {
+    "latitude": 44.798426,
+    "longitude": -93.456878
+  },
+  "Popcorn": {
+    "latitude": 44.79846,
+    "longitude": -93.45568
+  },
+  "Cinnabon®": {
+    "latitude": 44.798583,
+    "longitude": -93.454408
+  },
+  "Coca-Cola® Refresh Stations": {
+    "latitude": 44.797705,
+    "longitude": -93.451751
+  },
+  "Subway®": {
+    "latitude": 44.79874,
+    "longitude": -93.4562
+  },
+  "Midway Fudge & Taffy": {
+    "latitude": 44.7984,
+    "longitude": -93.45423
+  },
+  "Planet Snoopy Grill": {
+    "latitude": 44.80021,
+    "longitude": -93.45736
+  },
+  "Xtreme Confections": {
+    "latitude": 44.79889,
+    "longitude": -93.45684
+  },
+  "Lucky Loon Kitchen": {
+    "latitude": 44.799356,
+    "longitude": -93.454416
+  },
+  "Panda Express®": {
+    "latitude": 44.79918,
+    "longitude": -93.45434
+  },
+  "Wild Thing Brews and Spirits": {
+    "latitude": 44.79912,
+    "longitude": -93.458
+  },
+  "Gateway Grounds": {
+    "latitude": 44.79864,
+    "longitude": -93.45418
+  },
+  "Superior Funnel Cake Co.": {
+    "latitude": 44.80018,
+    "longitude": -93.45568
+  },
+  "Surfside Bar": {
+    "latitude": 44.799411,
+    "longitude": -93.460423
+  },
+  "Dippin’ Dots Ice Cream": {
+    "latitude": 44.79883,
+    "longitude": -93.455828
+  },
+  "ICEE Mix It Up®": {
+    "latitude": 44.79955,
+    "longitude": -93.458035
+  },
+  "Sally’s Swing Set": {
+    "latitude": 44.800072,
+    "longitude": -93.457872
+  },
+  "Snoopy’s Deep Sea Divers": {
+    "latitude": 44.799503,
+    "longitude": -93.457547
+  },
+  "Snoopy’s Rocket Express": {
+    "latitude": 44.80047,
+    "longitude": -93.45746
+  },
+  "Happiness Is…": {
+    "latitude": 44.7997,
+    "longitude": -93.454987
+  },
+  "Flying Eagles": {
+    "latitude": 44.798059,
+    "longitude": -93.45334
+  }
+}

--- a/src/parks/enchantedparks/valleyfair.ts
+++ b/src/parks/enchantedparks/valleyfair.ts
@@ -1,6 +1,7 @@
 import {EnchantedParks} from './enchantedparks.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {DestinationConstructor} from '../../destination.js';
+import locations from './locations/valleyfair.json' with {type: 'json'};
 
 @destinationController({category: ['Enchanted Parks', 'Valleyfair']})
 export class Valleyfair extends EnchantedParks {
@@ -18,6 +19,7 @@ export class Valleyfair extends EnchantedParks {
     // assign them directly here. The base class also reads options.config for
     // these if a caller wants to supply different ones — only set defaults
     // when the caller hasn't.
+    this.attractionLocations = locations;
     this.destinationLocation ??= {latitude: 44.7977, longitude: -93.4399};
     this.themePark ??= {
       id: 'enchantedparks_park_VF',


### PR DESCRIPTION
## Summary
- Valleyfair was the only EnchantedParks subclass missing a `locations/<slug>.json` coordinate snapshot — all 5 sibling parks (Worlds of Fun, Michigan's Adventure, Mid-America Parks, Great Escape Parks, Galveston Island Waterpark) already had one.
- `EnchantedParks`'s WordPress scrape source has no ride-level lat/lng, so without this snapshot every attraction/dining/show entity synced with no `location` field at all.
- The wiki's EDIT approval path (`entity.updateSource()`) does a **full replace** of the entity document, not a merge — so this was silently proposing removal of real, already-live coordinate data on every collector sync.
- Confirmed live against the wiki API: all 79 pending EDITs for Valleyfair (47 attractions, 27 restaurants, 5 shows) were missing `location`, and all 79 currently have real coordinates live that would have been wiped on approval.

## Fix
- Generated `src/parks/enchantedparks/locations/valleyfair.json` from the currently-live wiki coordinates for all 79 affected entities.
- Wired it up in `valleyfair.ts` via `this.attractionLocations = locations`, matching the existing pattern in the other 5 subclasses exactly.
- Verified post-fix: freshly built entity list round-trips all 79 coordinates exactly (0 mismatches), only the genuinely-new entities (not yet in the wiki) still lack a location, which is expected/documented behavior.

## Test plan
- [x] `npx vitest run src/parks/enchantedparks` — 34/34 passed, including a new regression test asserting every EnchantedParks subclass has a non-empty `attractionLocations` snapshot (would have caught this exact gap)
- [x] `npx vitest run` — full suite, 1473/1473 passed
- [x] `npm run dev -- valleyfair` — live harness run, entity list now only missing location on the 7 genuinely-new entities (down from 79 pre-fix)