### PR TITLE
fix(attractionsio): stop emitting live data for the park entity

### DIFF
--- a/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
+++ b/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
@@ -4,8 +4,7 @@
  * Unlike showtimes.test.ts (which unit-tests the pure ShowTimes helpers), these
  * drive the real `buildEntityList()` and `buildLiveData()` on a live subclass —
  * the entity classification (including the wider category coverage), the
- * restaurant `IsOpen` fallback, the Resort park-hours extraction, the
- * time-derived park status, and the malformed-ShowTimes containment. The raw
+ * restaurant `IsOpen` fallback, and the malformed-ShowTimes containment. The raw
  * network methods (`getPOIData` / `fetchLiveData`) are stubbed with fixtures so
  * nothing hits the API. Full integration is exercised via `npm run dev -- <park>`.
  */
@@ -17,9 +16,8 @@ import {CacheLib} from '../../../cache.js';
 const TZ = 'Europe/Berlin';
 const DATE = '2026-07-08';
 
-// Berlin is +02:00 in July, so 12:00 local == 10:00Z and 23:00 local == 21:00Z.
+// Berlin is +02:00 in July, so 12:00 local == 10:00Z.
 const NOON = new Date('2026-07-08T10:00:00Z');
-const NIGHT = new Date('2026-07-08T21:00:00Z');
 
 const range = (open: string, close: string) =>
   JSON.stringify({type: 'range', start: `${DATE} ${open}`, end: `${DATE} ${close}`});
@@ -70,9 +68,6 @@ function mkLive(): any {
           {_id: 301, OpeningTimes: range('10:00:00', '20:00:00')}, // no IsOpen → window fallback
           {_id: 302, OpeningTimes: range('10:00:00', '11:00:00')}, // no IsOpen, already closed by noon
         ],
-      },
-      Resort: {
-        records: [{_id: 1, OpeningTimes: range('10:00:00', '18:00:00')}],
       },
     },
   };
@@ -157,24 +152,6 @@ describe('buildLiveData', () => {
     expect(entry.queue.STANDBY.waitTime).toBe(30);
   });
 
-  test('the park status is OPERATING when now is inside the live opening window', async () => {
-    const live = await new Probe().live();
-    const park = live.find(l => l.id === 'probe-park');
-    expect(park).toBeDefined();
-    expect(park.status).toBe('OPERATING');
-    expect(park.operatingHours).toHaveLength(1);
-  });
-
-  test('the park status is CLOSED at night, not a hardcoded OPERATING', async () => {
-    vi.setSystemTime(NIGHT);
-    const live = await new Probe().live();
-    const park = live.find(l => l.id === 'probe-park');
-    expect(park).toBeDefined();
-    expect(park.status).toBe('CLOSED');
-    // The hours are still published even though the park is currently closed.
-    expect(park.operatingHours).toHaveLength(1);
-  });
-
   test('a restaurant with a live IsOpen:true is OPERATING regardless of the window', async () => {
     const live = await new Probe().live();
     expect(live.find(l => l.id === '300').status).toBe('OPERATING');
@@ -206,9 +183,8 @@ describe('buildLiveData', () => {
     const broken = live.find(l => l.id === '202');
     expect(broken.showtimes).toBeUndefined();
     expect(broken.status).toBe('CLOSED');
-    // The sibling attraction, park and restaurants still came through.
+    // The sibling attraction and restaurants still came through.
     expect(live.find(l => l.id === '100')).toBeDefined();
-    expect(live.find(l => l.id === 'probe-park')).toBeDefined();
     expect(live.find(l => l.id === '300')).toBeDefined();
   });
 });

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -149,18 +149,10 @@ type LiveDataRecord = {
   OpeningTimes?: string | null;
 };
 
-type LiveDataResortRecord = {
-  _id: number;
-  OpeningTimes?: string | null;
-};
-
 type LiveDataResponse = {
   entities: {
     Item: {
       records: LiveDataRecord[];
-    };
-    Resort?: {
-      records?: LiveDataResortRecord[];
     };
   };
 };
@@ -303,7 +295,7 @@ export function parseLiveOpeningTimes(raw: string | null | undefined, timezone: 
 /**
  * Whether `nowMs` sits inside any of the given opening-hour slots, under
  * half-open [start, end) containment. Slots whose bounds are missing or
- * unparseable are ignored. Shared by the restaurant and park live-status logic.
+ * unparseable are ignored. Drives the restaurant live-status fallback.
  */
 function isOpenNow(hours: LiveTimeSlot[], nowMs: number): boolean {
   return hours.some(h => {
@@ -1149,7 +1141,6 @@ class AttractionsIOV1 extends Destination {
    * Build live data for every entity type the API exposes:
    *   - attractions — operating status + standby wait time (live feed)
    *   - restaurants — open/closed status + today's opening hours (live feed)
-   *   - the park itself — today's opening window (live Resort record)
    *   - shows — today's performance times, evaluated from each show's recurring
    *     ShowTimes schedule in the records data (there is no live show feed)
    *
@@ -1234,20 +1225,6 @@ class AttractionsIOV1 extends Destination {
       }
     }
 
-    // Park: today's actual opening window (from the Resort record). Status is
-    // derived from whether "now" sits inside that window — the Resort record
-    // carries the same hours every day, so a fixed OPERATING would report the
-    // park open all night, every night, after close and before open.
-    const resort = raw?.entities?.Resort?.records?.[0];
-    const parkHours = parseLiveOpeningTimes(resort?.OpeningTimes, this.timezone);
-    if (parkHours.length > 0) {
-      liveData.push({
-        id: this.parkId,
-        status: isOpenNow(parkHours, Date.now()) ? 'OPERATING' : 'CLOSED',
-        operatingHours: parkHours,
-      });
-    }
-
     // Shows: today's performance times, evaluated from each show's recurring
     // ShowTimes schedule in the records data (not the live feed)
     if (showIds.size > 0) {
@@ -1262,7 +1239,7 @@ class AttractionsIOV1 extends Destination {
         if (attractionIds.has(id) || restaurantIds.has(id)) continue;
 
         // A single malformed ShowTimes record must not take down live data for
-        // the whole park (attraction/restaurant/park entries are already on the
+        // the whole park (attraction/restaurant entries are already on the
         // array). Contain the failure to this one show and keep the rest.
         let showtimes: LiveTimeSlot[];
         try {


### PR DESCRIPTION
## Summary

`AttractionsIOV1.buildLiveData()` turned the live feed's `Resort` opening times into a `LiveData` entry for the **park entity itself**:

```json
{
  "id": "66e12a41-…",
  "name": "Heide Park",
  "entityType": "PARK",
  "status": "OPERATING",
  "operatingHours": [{"type": "OPERATING", "startTime": "…T10:00:00+02:00", "endTime": "…T18:00:00+02:00"}]
}
```

No other destination in the repo publishes live data for its own `PARK` entity, and the park's opening hours are already served through `buildSchedules()` — where every other park puts them and where consumers look for them. The entry was therefore both unconventional and redundant. It affected all 16 Attractions.io parks, not just the one above.

## Changes

- Remove the `Resort` block from `buildLiveData()`.
- Remove `LiveDataResortRecord` and the `Resort` field on `LiveDataResponse` — they only existed to feed that block.
- `isOpenNow()` stays: the restaurant status fallback (venues whose live record omits `IsOpen`) still uses it.
- Drop the two unit tests that asserted the park live entry and its time-derived status.

No schema change; attractions, restaurants, shows and schedules are untouched.

## Verification

- `npm run build` clean, `npx vitest run src/parks/attractionsio` green (78 tests).
- `npm run dev -- heidepark` — 72 live entries = 43 attractions + 8 shows + 21 restaurants, no `PARK` entry; schedules unchanged at 86 days.
- `npm run dev -- altontowers` — 4/4, 86 live entries, no `PARK` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)