### PR TITLE
feat(plopsa): merge attractions/shows across languages (NL+EN, DE+EN)

### DIFF
--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -337,3 +337,81 @@ describe('buildLiveData shows', () => {
     expect(live.map((l) => l.id)).toEqual(['42']);
   });
 });
+
+describe('multi-language POI/entertainment merge', () => {
+  // Regression coverage for the case that motivated cross-language merging:
+  // a new attraction (e.g. Draconis) lands in the Dutch feed before the
+  // English translation catches up. buildEntityList must still surface it.
+  class Probe extends Plopsaland {
+    public byLanguage: Record<string, unknown[]> = {};
+    public entByLanguage: Record<string, unknown[]> = {};
+
+    override async fetchPOI(language: string = this.apiLanguage): Promise<any> {
+      return {json: async () => ({items: this.byLanguage[language] ?? []})};
+    }
+
+    override async fetchEntertainments(language: string = this.apiLanguage): Promise<any> {
+      return {json: async () => ({items: this.entByLanguage[language] ?? []})};
+    }
+
+    public buildEntitiesForTest(): Promise<Entity[]> {
+      return this.buildEntityList();
+    }
+  }
+
+  test('surfaces an attraction present only in the secondary language feed', async () => {
+    const park = new Probe();
+    park.byLanguage = {
+      en: [{
+        id: 'poi-1',
+        title: 'Attracties',
+        type: {label: 'Attractions'},
+        contains: [
+          {id: 'existing', title: 'Existing Ride', type: 'attraction'},
+        ],
+      }],
+      nl: [{
+        id: 'poi-1',
+        title: 'Attracties',
+        type: {label: 'Attractions'},
+        contains: [
+          {id: 'existing', title: 'Bestaande Rit', type: 'attraction'},
+          {id: 'draconis', title: 'Draconis', type: 'attraction'},
+        ],
+      }],
+    };
+
+    const entities = await park.buildEntitiesForTest();
+
+    // English feed wins the name for an id present in both.
+    expect(entities.find((e) => e.id === 'existing')?.name).toBe('Existing Ride');
+    // Draconis only exists in the Dutch feed — it must still be added, using
+    // the Dutch title since no English one is available.
+    const draconis = entities.find((e) => e.id === 'draconis');
+    expect(draconis).toBeDefined();
+    expect(draconis?.name).toBe('Draconis');
+    expect(draconis?.entityType).toBe('ATTRACTION');
+  });
+
+  test('surfaces a show present only in the secondary language feed', async () => {
+    const park = new Probe();
+    park.byLanguage = {en: [], nl: []};
+    park.entByLanguage = {
+      en: [
+        {id: 'show-1', title: 'Parade', type: {label: 'Show'}},
+      ],
+      nl: [
+        {id: 'show-1', title: 'Optocht', type: {label: 'Show'}},
+        {id: 'show-2', title: 'Nieuwe Show', type: {label: 'Show'}},
+      ],
+    };
+
+    const entities = await park.buildEntitiesForTest();
+
+    expect(entities.find((e) => e.id === 'show-1')?.name).toBe('Parade');
+    const newShow = entities.find((e) => e.id === 'show-2');
+    expect(newShow).toBeDefined();
+    expect(newShow?.name).toBe('Nieuwe Show');
+    expect(newShow?.entityType).toBe('SHOW');
+  });
+});

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -228,8 +228,22 @@ class PlopsaBase extends Destination {
     return url.endsWith('/api') ? url.slice(0, -4) : url;
   }
 
-  /** Language to use for all API calls */
+  /** Language to use for all single-language API calls (wait times, hours, calendar) */
   apiLanguage: string = 'en';
+
+  /**
+   * Languages to query when building the entity list, in preference order.
+   * The middleware's translated POI/entertainment feeds are maintained
+   * independently per language and can drift out of sync — a newly added
+   * attraction sometimes lands in the native-language feed weeks before the
+   * English translation catches up (e.g. Draconis at Plopsaland De Panne,
+   * present in `nl` but absent from `en` for a while). We fetch every
+   * language in this list and merge: the first language that has a given
+   * attraction/show wins for its name, later languages only fill in
+   * entities missing from earlier ones. Defaults to just `apiLanguage`;
+   * subclasses add their native language as a second source.
+   */
+  languages: string[] = ['en'];
 
   /** park= query parameter for the middleware API */
   parkParam: string = '';
@@ -265,11 +279,11 @@ class PlopsaBase extends Destination {
   // ── HTTP methods ──────────────────────────────────────────────
 
   @http({cacheSeconds: 60 * 60 * 12})
-  async fetchPOI(): Promise<HTTPObj> {
+  async fetchPOI(language: string = this.apiLanguage): Promise<HTTPObj> {
     return {
       method: 'GET',
       url: `${this.apiBase}/api/points-of-interest`,
-      queryParams: {language: this.apiLanguage, park: this.parkParam},
+      queryParams: {language, park: this.parkParam},
       options: {json: true},
     } as any as HTTPObj;
   }
@@ -285,11 +299,11 @@ class PlopsaBase extends Destination {
   }
 
   @http({cacheSeconds: 60 * 60 * 6})
-  async fetchEntertainments(): Promise<HTTPObj> {
+  async fetchEntertainments(language: string = this.apiLanguage): Promise<HTTPObj> {
     return {
       method: 'GET',
       url: `${this.apiBase}/api/entertainments`,
-      queryParams: {language: this.apiLanguage, park: this.parkParam},
+      queryParams: {language, park: this.parkParam},
       options: {json: true},
     } as any as HTTPObj;
   }
@@ -331,6 +345,18 @@ class PlopsaBase extends Destination {
   /** Extract a stable entity ID for an item: prefer plopsa_id, fall back to id. */
   protected entityId(item: {id: string; plopsa_id?: string}): string {
     return String(item.plopsa_id || item.id);
+  }
+
+  /** Fetch the POI feed for every language in `this.languages`, in order. */
+  protected async fetchPOIAllLanguages(): Promise<PlopsaPOIResponse[]> {
+    const responses = await Promise.all(this.languages.map((lang) => this.fetchPOI(lang)));
+    return Promise.all(responses.map((resp) => resp.json() as Promise<PlopsaPOIResponse>));
+  }
+
+  /** Fetch the entertainments feed for every language in `this.languages`, in order. */
+  protected async fetchEntertainmentsAllLanguages(): Promise<PlopsaEntertainmentResponse[]> {
+    const responses = await Promise.all(this.languages.map((lang) => this.fetchEntertainments(lang)));
+    return Promise.all(responses.map((resp) => resp.json() as Promise<PlopsaEntertainmentResponse>));
   }
 
   /**
@@ -396,13 +422,10 @@ class PlopsaBase extends Destination {
   // ── Entity building ───────────────────────────────────────────
 
   protected async buildEntityList(): Promise<Entity[]> {
-    const [poiResp, entResp] = await Promise.all([
-      this.fetchPOI(),
-      this.fetchEntertainments(),
+    const [poiByLanguage, entByLanguage] = await Promise.all([
+      this.fetchPOIAllLanguages(),
+      this.fetchEntertainmentsAllLanguages(),
     ]);
-
-    const poiData = (await poiResp.json()) as PlopsaPOIResponse;
-    const entData = (await entResp.json()) as PlopsaEntertainmentResponse;
 
     const entities: Entity[] = [];
 
@@ -420,20 +443,30 @@ class PlopsaBase extends Destination {
     }
     entities.push(parkEntity);
 
-    // Attractions and restaurants from POI
-    for (const poi of poiData?.items ?? []) {
-      // Fallback pixel→geo coords for the whole POI (Deutschland only).
-      const poiCoords = this.mapCoordinates(poi.map_coordinates);
+    // Attractions and restaurants from POI. Iterate languages in preference
+    // order and skip any id already seen — the first (preferred) language
+    // that carries a given attraction/restaurant wins its name/coords, and
+    // later languages only contribute entities missing from earlier ones
+    // (see `languages` doc comment for why translated feeds can drift).
+    const seenPoiIds = new Set<string>();
+    for (const poiData of poiByLanguage) {
+      for (const poi of poiData?.items ?? []) {
+        // Fallback pixel→geo coords for the whole POI (Deutschland only).
+        const poiCoords = this.mapCoordinates(poi.map_coordinates);
 
-      for (const item of poi.contains ?? []) {
-        const title = typeof item.title === 'string' ? item.title : '';
-        if (!title) continue;
+        for (const item of poi.contains ?? []) {
+          const title = typeof item.title === 'string' ? item.title : '';
+          if (!title) continue;
+          if (item.type !== 'attraction' && item.type !== 'foods_and_drinks') continue;
 
-        if (item.type === 'attraction') {
+          const id = this.entityId(item);
+          if (seenPoiIds.has(id)) continue;
+          seenPoiIds.add(id);
+
           const entity: Entity = {
-            id: this.entityId(item),
+            id,
             name: title,
-            entityType: 'ATTRACTION',
+            entityType: item.type === 'attraction' ? 'ATTRACTION' : 'RESTAURANT',
             parentId: this.parkId,
             destinationId: this.destinationId,
             timezone: this.timezone,
@@ -444,44 +477,37 @@ class PlopsaBase extends Destination {
             (entity as any).location = coords;
           }
           entities.push(entity);
-        } else if (item.type === 'foods_and_drinks') {
-          const entity: Entity = {
-            id: this.entityId(item),
-            name: title,
-            entityType: 'RESTAURANT',
-            parentId: this.parkId,
-            destinationId: this.destinationId,
-            timezone: this.timezone,
-          } as Entity;
-          const coords = this.lookupPoiLocation(title) ?? poiCoords;
-          if (coords) {
-            (entity as any).location = coords;
-          }
-          entities.push(entity);
         }
       }
     }
 
-    // Shows / Meet-and-greets from entertainments list
-    for (const item of entData?.items ?? []) {
-      const label = item.type?.label ?? '';
-      if (label !== 'Show' && label !== 'Meet&Greet') continue;
+    // Shows / Meet-and-greets from entertainments list — same first-language-wins merge.
+    const seenShowIds = new Set<string>();
+    for (const entData of entByLanguage) {
+      for (const item of entData?.items ?? []) {
+        const label = item.type?.label ?? '';
+        if (label !== 'Show' && label !== 'Meet&Greet') continue;
 
-      const entity: Entity = {
-        id: this.entityId({id: item.id, plopsa_id: item.plopsa_id}),
-        name: item.title,
-        entityType: 'SHOW',
-        parentId: this.parkId,
-        destinationId: this.destinationId,
-        timezone: this.timezone,
-      } as Entity;
+        const id = this.entityId({id: item.id, plopsa_id: item.plopsa_id});
+        if (seenShowIds.has(id)) continue;
+        seenShowIds.add(id);
 
-      // Use park location as fallback for shows
-      if (this.parkLat && this.parkLng) {
-        (entity as any).location = {latitude: this.parkLat, longitude: this.parkLng};
+        const entity: Entity = {
+          id,
+          name: item.title,
+          entityType: 'SHOW',
+          parentId: this.parkId,
+          destinationId: this.destinationId,
+          timezone: this.timezone,
+        } as Entity;
+
+        // Use park location as fallback for shows
+        if (this.parkLat && this.parkLng) {
+          (entity as any).location = {latitude: this.parkLat, longitude: this.parkLng};
+        }
+
+        entities.push(entity);
       }
-
-      entities.push(entity);
     }
 
     return entities;
@@ -492,26 +518,31 @@ class PlopsaBase extends Destination {
   protected async buildLiveData(): Promise<LiveData[]> {
     const today = formatTodayInTimezone(this.timezone);
 
-    const [waitResp, poiResp, hoursResp, entResp] = await Promise.all([
+    const [waitResp, poiByLanguage, hoursResp, entByLanguage] = await Promise.all([
       this.fetchWaitTimes(),
-      this.fetchPOI(),
+      this.fetchPOIAllLanguages(),
       this.fetchTodayHours(today).catch(() => null),
-      this.fetchEntertainments().catch(() => null),
+      this.fetchEntertainmentsAllLanguages().catch(() => [] as PlopsaEntertainmentResponse[]),
     ]);
 
     const waitTimes = (await waitResp.json()) as PlopsaWaitTimesResponse;
-    const poiData = (await poiResp.json()) as PlopsaPOIResponse;
-    const hoursData = hoursResp ? (await hoursResp.json()) as PlopsaTodayHours : null;
-    const entData = entResp ? (await entResp.json()) as PlopsaEntertainmentResponse : null;
+    if (!waitTimes) return [];
 
-    // Per-attraction temporarily-closed flag from POI.
+    const hoursData = hoursResp ? (await hoursResp.json()) as PlopsaTodayHours : null;
+
+    // Per-attraction temporarily-closed flag from POI, merged across
+    // languages (first language wins, same preference order as
+    // buildEntityList) so a ride missing from the primary-language feed
+    // still gets its closed flag from whichever language does carry it.
     const closedById = new Map<string, boolean>();
-    for (const poi of poiData?.items ?? []) {
-      for (const item of poi.contains ?? []) {
-        if (item.type !== 'attraction') continue;
-        const id = this.entityId(item);
-        const flag = !!item.schedule_info?.temporarily_closed;
-        closedById.set(id, flag);
+    for (const poiData of poiByLanguage) {
+      for (const poi of poiData?.items ?? []) {
+        for (const item of poi.contains ?? []) {
+          if (item.type !== 'attraction') continue;
+          const id = this.entityId(item);
+          if (closedById.has(id)) continue;
+          closedById.set(id, !!item.schedule_info?.temporarily_closed);
+        }
       }
     }
 
@@ -586,20 +617,27 @@ class PlopsaBase extends Destination {
     // the show is CLOSED once the last one has passed.
     const nowMs = Date.now();
     const showLiveData: LiveData[] = [];
-    for (const item of entData?.items ?? []) {
-      const label = item.type?.label ?? '';
-      if (label !== 'Show' && label !== 'Meet&Greet') continue;
+    const seenLiveShowIds = new Set<string>();
+    for (const entData of entByLanguage) {
+      for (const item of entData?.items ?? []) {
+        const label = item.type?.label ?? '';
+        if (label !== 'Show' && label !== 'Meet&Greet') continue;
 
-      const showtimes = plopsaBuildShowtimes(item.schedule_info?.schedule, today, this.timezone);
-      const ld = {
-        id: this.entityId({id: item.id, plopsa_id: item.plopsa_id}),
-        status: plopsaShowStatus(showtimes, nowMs),
-        lastUpdated,
-      } as unknown as LiveData;
-      if (showtimes.length > 0) {
-        (ld as {showtimes?: LiveTimeSlot[]}).showtimes = showtimes;
+        const id = this.entityId({id: item.id, plopsa_id: item.plopsa_id});
+        if (seenLiveShowIds.has(id)) continue;
+        seenLiveShowIds.add(id);
+
+        const showtimes = plopsaBuildShowtimes(item.schedule_info?.schedule, today, this.timezone);
+        const ld = {
+          id,
+          status: plopsaShowStatus(showtimes, nowMs),
+          lastUpdated,
+        } as unknown as LiveData;
+        if (showtimes.length > 0) {
+          (ld as {showtimes?: LiveTimeSlot[]}).showtimes = showtimes;
+        }
+        showLiveData.push(ld);
       }
-      showLiveData.push(ld);
     }
 
     return [...rideLiveData, ...showLiveData];
@@ -666,42 +704,51 @@ class PlopsaBase extends Destination {
     return schedule;
   }
 
-  /** Per-show operating schedules from the entertainments feed. */
+  /**
+   * Per-show operating schedules from the entertainments feed, merged
+   * across languages (first-wins, same as buildEntityList) so a show
+   * whose schedule only appears in a secondary-language feed isn't dropped.
+   */
   private async buildShowSchedules(): Promise<EntitySchedule[]> {
-    let entData: PlopsaEntertainmentResponse;
+    let entByLanguage: PlopsaEntertainmentResponse[];
     try {
-      const entResp = await this.fetchEntertainments();
-      entData = (await entResp.json()) as PlopsaEntertainmentResponse;
+      entByLanguage = await this.fetchEntertainmentsAllLanguages();
     } catch {
       return [];
     }
 
     const showSchedules: EntitySchedule[] = [];
+    const seenShowScheduleIds = new Set<string>();
 
-    for (const item of entData?.items ?? []) {
-      const label = item.type?.label ?? '';
-      if (label !== 'Show' && label !== 'Meet&Greet') continue;
+    for (const entData of entByLanguage) {
+      for (const item of entData?.items ?? []) {
+        const label = item.type?.label ?? '';
+        if (label !== 'Show' && label !== 'Meet&Greet') continue;
 
-      const showId = this.entityId({id: item.id, plopsa_id: item.plopsa_id});
-      const showSchedule: EntitySchedule['schedule'] = [];
+        const showId = this.entityId({id: item.id, plopsa_id: item.plopsa_id});
+        if (seenShowScheduleIds.has(showId)) continue;
 
-      for (const day of item.schedule_info?.schedule ?? []) {
-        for (const slot of day.timeslots ?? []) {
-          if (slot.type !== 'open') continue;
-          showSchedule.push({
-            date: day.date,
-            type: 'OPERATING',
-            // Show timeslots use HH:MM strings, not full ISO — build with constructDateTime
-            openingTime: `${day.date}T${slot.start_time}:00`,
-            closingTime: slot.end_time
-              ? `${day.date}T${slot.end_time}:00`
-              : `${day.date}T${slot.start_time}:00`,
-          } as any);
+        const showSchedule: EntitySchedule['schedule'] = [];
+
+        for (const day of item.schedule_info?.schedule ?? []) {
+          for (const slot of day.timeslots ?? []) {
+            if (slot.type !== 'open') continue;
+            showSchedule.push({
+              date: day.date,
+              type: 'OPERATING',
+              // Show timeslots use HH:MM strings, not full ISO — build with constructDateTime
+              openingTime: `${day.date}T${slot.start_time}:00`,
+              closingTime: slot.end_time
+                ? `${day.date}T${slot.end_time}:00`
+                : `${day.date}T${slot.start_time}:00`,
+            } as any);
+          }
         }
-      }
 
-      if (showSchedule.length > 0) {
-        showSchedules.push({id: showId, schedule: showSchedule} as EntitySchedule);
+        if (showSchedule.length > 0) {
+          seenShowScheduleIds.add(showId);
+          showSchedules.push({id: showId, schedule: showSchedule} as EntitySchedule);
+        }
       }
     }
 
@@ -724,6 +771,10 @@ export class Plopsaland extends PlopsaBase {
     this.timezone = 'Europe/Brussels';
     this.parkLat = 51.0808363;
     this.parkLng = 2.5957221;
+    // English is preferred for names; Dutch is the park's native feed and
+    // sometimes carries attractions/shows before the English translation
+    // catches up (see `languages` doc comment).
+    this.languages = ['en', 'nl'];
     // Hand-verified per-POI coordinates: the middleware feed has no ride-level
     // lat/lng and De Panne has no pixel→geo transform. See locations/README.
     this.poiLocations = dePanneLocations as Record<string, {latitude: number; longitude: number}>;
@@ -849,6 +900,10 @@ export class PlopsalandDeutschland extends PlopsaBase {
     this.timezone = 'Europe/Berlin';
     this.parkLat = 49.317914992075146;
     this.parkLng = 8.300217955490842;
+    // English is preferred for names; German is the park's native feed and
+    // sometimes carries attractions/shows before the English translation
+    // catches up (see `languages` doc comment).
+    this.languages = ['en', 'de'];
     // calendarUrl set via PLOPSALANDDEUTSCHLAND_CALENDARURL env var
   }
 


### PR DESCRIPTION
## Summary

Plopsa's translated POI/entertainment feeds (points-of-interest, entertainments) are maintained independently per language and can drift out of sync with each other. In practice, a newly added attraction or show sometimes lands in the park's native-language feed *before* the English translation catches up — for example, the new **Draconis** coaster at Plopsaland De Panne was present in the `nl` (Dutch) feed but completely absent from the `en` (English) feed for a while. Since `buildEntityList()` only ever queried a single hardcoded language (`en`), any attraction/show missing from that language's feed was silently dropped from the entity list entirely — it never appeared in the wiki, had no live data, and no schedule, even though the park's own native-language site listed it as open.

This PR makes both Plopsa destinations (Plopsaland De Panne and Plopsaland Deutschland) query **multiple languages** and merge the results, so nothing present in *any* language feed is silently lost.

- **Plopsaland De Panne**: queries `en` then `nl` (its native language).
- **Plopsaland Deutschland**: queries `en` then `de` (its native language).

English always remains the **primary/preferred language** — it wins the name/details for any attraction, restaurant, or show present in both feeds. The secondary (native) language is only used to **fill gaps**: an entity missing from the English feed is added using whatever data the native-language feed provides, rather than being dropped.

## What changed

In `src/parks/plopsa/plopsa.ts`:

- Added a `languages: string[]` property to `PlopsaBase` (documented with the motivating Draconis case), defaulting to `['en']`. `Plopsaland` sets it to `['en', 'nl']`, `PlopsalandDeutschland` sets it to `['en', 'de']`.
- `fetchPOI()` and `fetchEntertainments()` now accept an explicit `language` parameter (defaulting to `apiLanguage` for backward compatibility). Each language is cached independently — the `@http` cache key already incorporates the full URL including query params, so this required no cache-layer changes.
- Added two helpers, `fetchPOIAllLanguages()` and `fetchEntertainmentsAllLanguages()`, which fetch every configured language in parallel and return the parsed responses in preference order.
- `buildEntityList()` now iterates `poiByLanguage` / `entByLanguage` (instead of a single-language response) and merges attractions, restaurants, and shows with **first-language-wins** semantics: the first language in the list that has a given entity id wins its name/coordinates; later languages only contribute ids that weren't already seen.
- `buildLiveData()`'s per-attraction `temporarily_closed` flag (`closedById`) is now merged the same way across all configured languages, so a ride missing from the primary-language POI feed still gets a correct closed/open hint from whichever language does carry it. It also now merges live show/showtime data (`entByLanguage`) the same way, instead of a single-language `fetchEntertainments()` call.
- `buildShowSchedules()` (used by `buildSchedules()`) merges show operating schedules across languages too, with a small twist: an id is only marked "seen" once a *non-empty* schedule has been found for it, so a show whose primary-language entry exists but has an empty schedule can still pick up a populated schedule from a secondary language.
- No changes to `apiLanguage` itself (still `'en'`), and no changes to the single-language endpoints that don't need cross-referencing (`fetchWaitTimes`, `fetchTodayHours`, `fetchCalendar`) — those are keyed by attraction ID, not by translated text, so there was nothing to merge there.

In `src/parks/plopsa/__tests__/plopsa.test.ts`:

- Added a new `describe('multi-language POI/entertainment merge', ...)` block with two regression tests built around the motivating Draconis scenario:
  - an attraction present only in the secondary-language (`nl`) feed is still added to the entity list, using the `nl` title, while an id present in both feeds keeps its English name.
  - the same behavior for a show/entertainment entry.

## Why this approach

- **First-language-wins, not a smarter merge** (e.g. no attempt to pick the "freshest" or "most complete" language per field) — this keeps the change small and predictable, and matches the existing codebase convention of plain-string entity names (no `MultilangString` usage exists elsewhere in the repo, so this avoids introducing a new pattern for names).
- **English stays primary** everywhere it has data, per the existing behavior and consumer expectations (entity names are expected to read in English where available) — the secondary language is purely a gap-filler, not a preference override.
- **Per-language caching is free**: since the `@http` decorator's cache key is derived from the full request URL (which includes `language` as a query param), fetching `en` and `nl`/`de` in parallel simply produces two independently-cached entries — no cache versioning or invalidation changes were needed.

## Manual verification

Since this touches live scraping behavior rather than pure UI, I ran the actual `Plopsaland` class against the real (public, unauthenticated) Plopsa middleware API to confirm the fix resolves the motivating case end-to-end:

- **Draconis is now found**: `{ id: '158', name: 'Draconis', entityType: 'ATTRACTION', ... }` — previously absent when only querying `en`.
- **DOWN attractions are still correctly reported** (unaffected by this change): 3 rides currently down (The Animal Farm, Nachtwacht-Flyer, The Pedal Boats).
- **Show live data still includes showtimes** where the feed provides them, e.g. Bumba Show (OPERATING, 13:00 & 17:15), Grand Finale Show (OPERATING, 14:00), Meet a princess (OPERATING, 4 showtimes).

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npx vitest run src/parks/plopsa` — all Plopsa unit tests pass (22/22), including the 2 new regression tests
- [x] `npx vitest run` — full suite passes (1475/1475), no regressions elsewhere
- [x] `npm run dev -- plopsaland` against the live API — entity/live-data/schedule counts look sane (111 entities, 73 live data entries, 15 schedules)
- [x] Manual script against the live `Plopsaland` class confirming Draconis is present, DOWN attractions are reported, and show showtimes are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)