### PR TITLE
fix(plopsa): don't drop show live data on a null wait-times response

### DIFF
--- a/src/parks/plopsa/__tests__/plopsa.test.ts
+++ b/src/parks/plopsa/__tests__/plopsa.test.ts
@@ -336,6 +336,28 @@ describe('buildLiveData shows', () => {
 
     expect(live.map((l) => l.id)).toEqual(['42']);
   });
+
+  test('a null wait-times response drops only the ride data, never the shows', async () => {
+    const park = new LiveProbe();
+    const date = todayIn('Europe/Brussels');
+
+    // The wait-times feed occasionally returns a literal `null` body. That
+    // must not cascade into dropping show live data too — each feed's
+    // failure is isolated to its own entities (see the sibling test above
+    // for the mirror-image entertainments-feed failure).
+    park.fetchWaitTimes = async () => jsonResponse(null) as any;
+    park.fetchPOI = async () => jsonResponse({items: []}) as any;
+    park.fetchTodayHours = async () =>
+      jsonResponse({date, timeslots: [{type: 'open', start_time: '00:00', end_time: '23:59'}]}) as any;
+    park.fetchEntertainments = async () => jsonResponse({items: [
+      {id: 'a', plopsa_id: '700', title: 'Show A', type: {label: 'Show'},
+        schedule_info: {schedule: [{date, timeslots: [{type: 'open', start_time: '23:59', end_time: null}]}]}},
+    ]}) as any;
+
+    const live = await park.buildLiveDataForTest();
+
+    expect(live.map((l) => l.id)).toEqual(['700']);
+  });
 });
 
 describe('multi-language POI/entertainment merge', () => {

--- a/src/parks/plopsa/plopsa.ts
+++ b/src/parks/plopsa/plopsa.ts
@@ -526,7 +526,6 @@ class PlopsaBase extends Destination {
     ]);
 
     const waitTimes = (await waitResp.json()) as PlopsaWaitTimesResponse;
-    if (!waitTimes) return [];
 
     const hoursData = hoursResp ? (await hoursResp.json()) as PlopsaTodayHours : null;
 


### PR DESCRIPTION
## Summary
Follow-up to #252. That PR added:

\`\`\`ts
const waitTimes = (await waitResp.json()) as PlopsaWaitTimesResponse;
if (!waitTimes) return [];
\`\`\`

This was out of scope for a multi-language-merge PR and wasn't mentioned in its description. It also contradicts the function's own documented design — a comment a few lines below it explicitly states *"a failing entertainments feed drops only the shows"*, i.e. the intent is per-feed failure isolation. With this early return, a falsy wait-times body (e.g. a literal `null`) now wipes show live data too, not just ride data.

It also wasn't needed for crash-safety: `Object.entries(waitTimes ?? {})` further down already handles a null/undefined `waitTimes` safely.

## Fix
- Removed the early return.
- Added a regression test mirroring the existing "a failing entertainments feed drops only the shows" test, asserting the reverse: a null wait-times response drops only the ride data, not the shows.

Merged into `main` as a direct follow-up rather than onto #252's branch — no push access to the contributor's fork (`Pocket-Park/parksapi`) despite `maintainerCanModify` being set (403 on push). Discussed with @cube, agreed to merge #252 as submitted and land this as an immediate separate fix rather than block the whole PR on a fork permission issue.

## Test plan
- [x] `npx vitest run src/parks/plopsa` — 23/23 passed (was 22, +1 new regression test)
- [x] `npx vitest run` — full suite, 1474/1474 passed