### PR TITLE
fix(sixflags): coerce waterpark fimsId to a number

### DIFF
--- a/src/parks/sixflags/__tests__/sixflags.test.ts
+++ b/src/parks/sixflags/__tests__/sixflags.test.ts
@@ -1,0 +1,103 @@
+import {describe, test, expect, beforeEach} from 'vitest';
+import {SixFlags} from '../sixflags.js';
+import {CacheLib} from '../../../cache.js';
+
+function jsonResponse(payload: unknown) {
+  return {json: async () => payload};
+}
+
+/**
+ * Firebase serves `otherParks[].fimsId` as a numeric-looking *string* for
+ * some parks even though it's typed as `number`. Regression coverage for
+ * the bug this caused: `getParkData()` must coerce it, or the strict
+ * `poi.parkId === wp.parkId` comparison in buildEntityList() never matches
+ * (poi.parkId is always a real number from the POI API), the bundled
+ * waterpark lookup silently returns zero POIs, and the /poi/park/{id}
+ * standalone fallback 404s for BUNDLED-pattern waterparks — net effect,
+ * the waterpark's entities vanish from every sync and the collector
+ * proposes deleting them. Confirmed live for 5 of 7 Six Flags waterparks
+ * (Cedar Point Shores, Knott's Soak City, and the NJ/LA/Chicago Hurricane
+ * Harbors) before the fix.
+ */
+class Probe extends SixFlags {
+  public firebaseConfig: unknown = {};
+
+  override async fetchFirebaseConfig(): Promise<any> {
+    return jsonResponse(this.firebaseConfig);
+  }
+}
+
+function configWith(otherParks: Array<Record<string, unknown>>) {
+  return {
+    entries: {
+      parkTypeHourAvailability: JSON.stringify({
+        parkHourSettings: {
+          905: {
+            code: 'GADV',
+            showThemePark: true,
+            otherParks,
+          },
+        },
+      }),
+      oneShot: JSON.stringify({
+        parks_configuration: [{parkId: 905, parkName: 'Six Flags Great Adventure'}],
+      }),
+    },
+  };
+}
+
+describe('getParkData waterpark parkId coercion', () => {
+  // getParkData() is @cache-decorated and takes no arguments, so every
+  // Probe instance shares the same cache key — clear it between tests or
+  // later tests see the first test's cached result instead of their own.
+  beforeEach(() => {
+    CacheLib.clearByClassName('Probe');
+  });
+
+  test('coerces a string fimsId to a number', async () => {
+    const park = new Probe();
+    park.firebaseConfig = configWith([
+      {label: 'Water Park', fimsId: '925', fimsSiteCode: 'HHNJ', subProperty: 'Hurricane Harbor New Jersey'},
+    ]);
+
+    const parks = await park.getParkData();
+    const ga = parks.find(p => p.parkId === 905);
+
+    expect(ga?.waterParks).toHaveLength(1);
+    expect(ga?.waterParks[0].parkId).toBe(925);
+    expect(typeof ga?.waterParks[0].parkId).toBe('number');
+  });
+
+  test('leaves an already-numeric fimsId untouched', async () => {
+    const park = new Probe();
+    park.firebaseConfig = configWith([
+      {label: 'Water Park', fimsId: 913, fimsSiteCode: 'HHAR', subProperty: 'Hurricane Harbor Arlington'},
+    ]);
+
+    const parks = await park.getParkData();
+    const ga = parks.find(p => p.parkId === 905);
+
+    expect(ga?.waterParks[0].parkId).toBe(913);
+    expect(typeof ga?.waterParks[0].parkId).toBe('number');
+  });
+
+  test('a coerced waterpark parkId matches bundled POI records by strict equality', async () => {
+    // This is the actual failure mode: buildEntityList() filters the
+    // parent's already-fetched POI list with `poi.parkId === wp.parkId`.
+    // poi.parkId comes from the POI API and is always a number, so a
+    // string wp.parkId would never match even when the numeric values
+    // are identical.
+    const park = new Probe();
+    park.firebaseConfig = configWith([
+      {label: 'Water Park', fimsId: '925', fimsSiteCode: 'HHNJ', subProperty: 'Hurricane Harbor New Jersey'},
+    ]);
+
+    const parks = await park.getParkData();
+    const wp = parks.find(p => p.parkId === 905)?.waterParks[0];
+
+    const poiFromApi = [{parkId: 925, venueId: 1, fimsId: 'x', name: 'The Winds'}];
+    const matches = poiFromApi.filter(poi => poi.parkId === wp?.parkId);
+
+    expect(matches).toHaveLength(1);
+  });
+});

--- a/src/parks/sixflags/sixflags.ts
+++ b/src/parks/sixflags/sixflags.ts
@@ -459,7 +459,7 @@ export class SixFlags extends Destination {
    * (new fields, new grouping rules like WATERPARK_PARENT_OVERRIDES, …).
    * Old entries become unreachable and expire on their TTL — no manual flush.
    */
-  @cache({ttlSeconds: 86400, cacheVersion: 4})
+  @cache({ttlSeconds: 86400, cacheVersion: 5})
   async getParkData(): Promise<SixFlagsParkData[]> {
     const entries = await this.getFirebaseConfig();
 
@@ -538,11 +538,20 @@ export class SixFlags extends Destination {
         }
       }
 
-      // Extract water parks from otherParks array
+      // Extract water parks from otherParks array. `fimsId` is typed as
+      // number but Firebase actually serves it as a numeric-looking string
+      // for some parks — coerce it, or the strict `poi.parkId === wp.parkId`
+      // comparison in buildEntityList() never matches (poi.parkId is always
+      // a real number), the bundled lookup silently returns zero POIs, and
+      // the /poi/park/{id} standalone fallback 404s for BUNDLED-pattern
+      // waterparks. Net effect: the waterpark's entities vanish from every
+      // sync and the collector proposes deleting them. Confirmed live for
+      // Cedar Point Shores, Knott's Soak City, and 3 Hurricane Harbors
+      // (NJ/LA/Chicago) — all had string fimsId and an empty entity list.
       const waterParks = (park.otherParks || [])
         .filter(op => op.label === 'Water Park' && op.fimsId && op.fimsSiteCode)
         .map(op => ({
-          parkId: op.fimsId,
+          parkId: Number(op.fimsId),
           code: op.fimsSiteCode,
           name: op.subProperty || `Water Park ${op.fimsSiteCode}`,
           label: op.label,


### PR DESCRIPTION
## Summary
Root cause for the messy Six Flags moderation queues (Six Flags Great Adventure 77 pending items, Great America 38, etc.): `otherParks[].fimsId` is typed as `number` but Firebase actually serves it as a numeric-looking **string** for some parks.

`buildEntityList()` bundles a waterpark's POIs out of its parent's already-fetched response with a strict `poi.parkId === wp.parkId` comparison. `poi.parkId` always comes back as a real number from the POI API, so a string `wp.parkId` never matches — the bundled lookup silently returns 0 POIs. The `/poi/park/{id}` standalone fallback then 404s too (by design, for BUNDLED-pattern waterparks their POIs only ever exist in the parent's response), and `getPOI()`'s catch-all swallows that 404 and returns `[]`.

Net effect: the waterpark's entities vanish from every sync, and the collector proposes deleting all of them.

## Verified live, before the fix
5 of 7 Six Flags waterparks had a string `fimsId` and an empty entity list:
- Cedar Point Shores
- Knott's Soak City
- Hurricane Harbor New Jersey (under Six Flags Great Adventure)
- Hurricane Harbor Los Angeles (under Six Flags Magic Mountain)
- Hurricane Harbor Chicago (under Six Flags Great America)

The other 2 (Hurricane Harbor Arlington, Hurricane Harbor Oklahoma City) come through a different code path (`WATERPARK_PARENT_OVERRIDES`, already numeric) and were unaffected.

## Fix
- `Number(op.fimsId)` when building the `waterParks` array in `getParkData()`.
- Bumped `getParkData()`'s `cacheVersion` since this changes the cached `waterParks[].parkId` shape.

## Verified live, after the fix
All 5 affected resorts now emit both their main park and waterpark as separate `PARK` entities with populated attractions/shows/restaurants:
- Cedar Point: 182 total entities across both parks
- Knott's Berry Farm: 143
- Six Flags Magic Mountain: 100
- Six Flags Great America: 125
- Six Flags Great Adventure: Hurricane Harbor NJ's 37 entities came back with IDs matching the ones the moderation queue was about to delete (`RIDE-925-*`)

## Test plan
- [x] `npx vitest run src/parks/sixflags` — new test file, 3/3 passed (no prior test coverage existed for this class)
- [x] `npx vitest run` — full suite, 1477/1477 passed
- [x] Live verification across all 5 affected resorts (see above)