### PR TITLE
fix(attractionsio): trust an explicit IsOpen for attraction live status (Djurs Sommerland mass-CLOSED)

### DIFF
--- a/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
+++ b/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
@@ -152,6 +152,29 @@ describe('buildLiveData', () => {
     expect(entry.queue.STANDBY.waitTime).toBe(30);
   });
 
+  test('an attraction with IsOpen:true but IsOperational:false is OPERATING (unmetered rides, e.g. Djurs)', async () => {
+    const live = mkLive();
+    live.entities.Item.records.push(
+      {_id: 101, IsOperational: false, IsOpen: true, OpeningTimes: range('10:00:00', '20:00:00')},
+    );
+    const result = await new Probe(mkRecords(), live).live();
+    expect(result.find(l => l.id === '101').status).toBe('OPERATING');
+  });
+
+  test('an attraction with an explicit IsOpen:false is CLOSED even when IsOperational is true', async () => {
+    const live = mkLive();
+    live.entities.Item.records[0] = {_id: 100, IsOperational: true, IsOpen: false, QueueTime: 1800};
+    const result = await new Probe(mkRecords(), live).live();
+    expect(result.find(l => l.id === '100').status).toBe('CLOSED');
+  });
+
+  test('an attraction with no IsOpen falls back to IsOperational: false → CLOSED', async () => {
+    const live = mkLive();
+    live.entities.Item.records.push({_id: 101, IsOperational: false});
+    const result = await new Probe(mkRecords(), live).live();
+    expect(result.find(l => l.id === '101').status).toBe('CLOSED');
+  });
+
   test('a restaurant with a live IsOpen:true is OPERATING regardless of the window', async () => {
     const live = await new Probe().live();
     expect(live.find(l => l.id === '300').status).toBe('OPERATING');

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -141,10 +141,13 @@ type LiveDataRecord = {
   IsOpen?: boolean;
   QueueTime?: number | null;
   /**
-   * Present on venue records (restaurants/shops); rides leave it null. A
-   * stringified {"type":"range",start,end} blob of today's opening window.
-   * `IsOperational` flags *running rides*, so it is always false for dining/
-   * retail venues — `IsOpen` is the correct open/closed signal there.
+   * A stringified {"type":"range",start,end} blob of today's opening window.
+   * Present on venue records (restaurants/shops); most feeds leave it null on
+   * rides, but Djurs Sommerland populates it on attractions too.
+   * `IsOperational` flags *queue-metered running rides*, so it is always
+   * false for dining/retail venues — and, on feeds like Djurs Sommerland,
+   * for open-but-unmetered attractions as well. An explicit `IsOpen` boolean
+   * is the authoritative open/closed signal wherever it is present.
    */
   OpeningTimes?: string | null;
 };
@@ -1172,11 +1175,16 @@ class AttractionsIOV1 extends Destination {
 
       // Attractions: operating status + standby wait time
       if (attractionIds.has(id)) {
-        // Determine status
-        let status: 'OPERATING' | 'CLOSED' | 'DOWN' = record.IsOperational ? 'OPERATING' : 'CLOSED';
-        if (record.IsOpen === false) {
-          status = 'CLOSED';
-        }
+        // An explicit boolean IsOpen is the authoritative live signal, as in
+        // the dining branch below: some feeds (e.g. Djurs Sommerland) set
+        // IsOperational only on their queue-metered rides, leaving every
+        // unmetered-but-open attraction at IsOperational:false. Fall back to
+        // IsOperational when IsOpen is absent (Merlin feeds omit it on
+        // non-operating rides).
+        const isOpen = typeof record.IsOpen === 'boolean'
+          ? record.IsOpen
+          : !!record.IsOperational;
+        const status: 'OPERATING' | 'CLOSED' = isOpen ? 'OPERATING' : 'CLOSED';
 
         const entry: LiveData = {
           id,


### PR DESCRIPTION
## Problem

Djurs Sommerland publishes most of its attractions as `CLOSED` even while the park is open. Snapshot from production on 2026-07-17 (park open 10:00–20:00, Aqua Park 12:00–18:00 per djurssommerland.dk): **47 of 100 live entities CLOSED**, including the Vandland water park, Water Slides, Junior Aqua Park, and dozens of family rides and playgrounds. Every CLOSED attraction had no wait time; every attraction with a wait time was OPERATING — which pointed at queue metering, not actual closures.

## Root cause

The Djurs live feed (`live-data.attractions.io/<key>.json`) only sets `IsOperational: true` on its **~21 queue-metered headline rides**. Every other open attraction reports:

```json
{"IsOperational": false, "IsOpen": true, "OpeningTimes": "{\"type\":\"range\",\"start\":\"2026-07-17 10:00:00\",\"end\":\"2026-07-17 20:00:00\"}"}
```

At scan time the feed contained **44 tracked attractions** in this state (open with today's hours) and exactly **1** genuinely closed attraction (`IsOpen: false` — a meet & greet). The attraction branch of `buildLiveData()` derived status purely from `IsOperational` (`IsOperational ? OPERATING : CLOSED`), so all 44 were published as CLOSED. The dining branch already treated an explicit boolean `IsOpen` as authoritative — attractions just never got the same rule.

## Fix

For attractions, an explicit **boolean `IsOpen` now wins**; `IsOperational` remains the fallback when `IsOpen` is absent (Merlin feeds omit it on non-operating rides). Status truth table:

| `IsOperational` | `IsOpen` | Before | After |
|---|---|---|---|
| true | true | OPERATING | OPERATING |
| true | absent | OPERATING | OPERATING |
| true | false | CLOSED | CLOSED |
| false | **true** | **CLOSED** | **OPERATING** ← the fix |
| false | absent | CLOSED | CLOSED |
| false | false | CLOSED | CLOSED |

Only one combination changes, so a park can only be affected if its feed explicitly asserts `IsOpen: true` on a non-operational attraction.

## Cross-park impact analysis

Scanned the live feeds of every park on this base class with a publicly recoverable feed key (10 of 16), joined against tracked entities via the production API:

| Park | Tracked attractions in `(IsOperational:false, IsOpen:true)` | Output change |
|---|---|---|
| Djurs Sommerland | **44** | 47 CLOSED → 3 CLOSED (the fix) |
| **Legoland Windsor** | **5** | see below |
| Alton Towers | 0 | none |
| Thorpe Park | 0 | none |
| Chessington | 0 | none |
| Gardaland | 0 | none |
| Heide Park | 0 | none |
| Legoland Billund | 0 | none |
| Legoland California | 0 (scanned while park closed — night state is clean) | none |
| Legoland Deutschland | 0 | none |

### Legoland Windsor also gets fixed

Windsor has 5 attractions that flip CLOSED → OPERATING: **Pirate Goldwash, LEGO® Studios 4D, The Brick, LEGO Ferrari Build & Race, LEGOLAND® Adventure Golf**. These are exactly the Djurs-style unmetered walk-through/experience attractions; their records carried `IsOpen: true` with today's opening hours while the park was open. They appear to have been wrongly CLOSED all day until now — same bug, second park.

### Breakdown semantics verified live

The main regression worry was Merlin breakdowns being masked as OPERATING. Directly disproven during the scan:

- Legoland Windsor's **Jolly Rocker** was broken down at scan time (`QueueStatusMessage: "BACK SOON"`) and reported `IsOperational: false, IsOpen: false` → stays CLOSED under the new logic.
- Chessington had a ride in `TEMPORARY DELAY` — it kept `IsOperational: true`.
- Heide's running rides all report `"Geöffnet"` with both flags true.

So no observed attractions.io feed leaves `IsOpen: true` on anything that isn't actually open — including closed-park (California at night) and broken-down states.

## Verification

- New test `an attraction with IsOpen:true but IsOperational:false is OPERATING` failed before the fix, passes after; two guard tests pin the unchanged combos (`IsOpen:false` still closes, absent `IsOpen` still falls back to `IsOperational`).
- Full suite: 1482/1482 passing, `tsc` clean.
- End-to-end (`npm run dev -- djurssommerland` with the park's public app config): **96 OPERATING / 3 CLOSED**, all 21 wait times intact — vs 53/47 in production at the same time.
- End-to-end Alton Towers as Merlin control: 38 OPERATING / 48 CLOSED / 34 wait times vs production's 39 / 46 / 34 at the same moment — identical semantics, drift explained by rides changing state between snapshots.

## Not covered / follow-ups

- Six parks have no publicly recoverable feed key (Legoland Orlando / Japan / New York / Korea, Peppa Pig Florida, Knoebels) and couldn't be scanned. For them to regress, their feed would have to assert `IsOpen: true` on a closed attraction — behavior no examined feed exhibits in any state. Comparing OPERATING counts before/after deploy for those six would settle it conclusively.
- Separate pre-existing issue, deliberately not touched here: Merlin walk-through attractions with **no** `IsOpen` field at all (e.g. Alton's Haunted Hollow, CBeebies photo studio) still show CLOSED all day. Fixing that would need the `OpeningTimes` window fallback (like the dining branch) and its own verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
