### PR TITLE
fix(qiddiyacity): fall back to dashboard hours when website schedule scrape is WAF-blocked

### DIFF
--- a/src/parks/qiddiyacity/__tests__/qiddiyacity.test.ts
+++ b/src/parks/qiddiyacity/__tests__/qiddiyacity.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for Qiddiya City's dashboard-derived schedule fallback.
+ *
+ * The website scrape that normally supplies the weekly hours pattern
+ * (getWebsiteSchedule) can be WAF-blocked independently of the API
+ * subdomain that supplies activities/live data. These tests cover the
+ * pure fallback logic that derives a single-day schedule from the
+ * (separately-sourced, unaffected) dashboard endpoint when that happens.
+ */
+import {describe, test, expect} from 'vitest';
+import {parseDashboardHours, buildTodayScheduleFromDashboard} from '../qiddiyacity.js';
+
+const TZ = 'Asia/Riyadh';
+
+describe('parseDashboardHours', () => {
+  test('parses a standard AM/PM range with a trailing timezone abbreviation', () => {
+    expect(parseDashboardHours('4:00 PM - 12:00 AM KSA')).toEqual({open: '16:00', close: '00:00'});
+  });
+
+  test('parses a range entirely within one half of the day', () => {
+    expect(parseDashboardHours('10:30 AM - 6:00 PM')).toEqual({open: '10:30', close: '18:00'});
+  });
+
+  test('returns null for non-matching strings like "Closed"', () => {
+    expect(parseDashboardHours('Closed')).toBeNull();
+  });
+
+  test('returns null for empty or missing input', () => {
+    expect(parseDashboardHours('')).toBeNull();
+    expect(parseDashboardHours(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe('buildTodayScheduleFromDashboard', () => {
+  const today = new Date('2026-07-19T12:00:00Z');
+
+  test('builds a single OPERATING entry for today from openingHours', () => {
+    const dashboard = {parkInfo: {isOpen: true, openingHours: '4:00 PM - 12:00 AM KSA'}};
+    const schedule = buildTodayScheduleFromDashboard(dashboard, today, TZ);
+    expect(schedule).toHaveLength(1);
+    expect(schedule[0].date).toBe('2026-07-19');
+    expect(schedule[0].type).toBe('OPERATING');
+  });
+
+  test('rolls a midnight closing time over to the next calendar day', () => {
+    const dashboard = {parkInfo: {isOpen: true, openingHours: '4:00 PM - 12:00 AM KSA'}};
+    const schedule = buildTodayScheduleFromDashboard(dashboard, today, TZ);
+    expect(schedule[0].closingTime).toContain('2026-07-20');
+  });
+
+  test('returns no schedule when the dashboard reports the park closed', () => {
+    const dashboard = {parkInfo: {isOpen: false, openingHours: '4:00 PM - 12:00 AM KSA'}};
+    expect(buildTodayScheduleFromDashboard(dashboard, today, TZ)).toEqual([]);
+  });
+
+  test('returns no schedule when openingHours is missing or unparseable', () => {
+    expect(buildTodayScheduleFromDashboard({parkInfo: {}}, today, TZ)).toEqual([]);
+    expect(buildTodayScheduleFromDashboard(undefined, today, TZ)).toEqual([]);
+  });
+});

--- a/src/parks/qiddiyacity/qiddiyacity.ts
+++ b/src/parks/qiddiyacity/qiddiyacity.ts
@@ -98,6 +98,58 @@ const DAY_NAME_TO_INDEX: Record<string, number> = {
 // Number of days of schedule data to project from the weekly pattern.
 const SCHEDULE_DAYS = 30;
 
+/** Convert a 12h hour + AM/PM period to a 24h hour. */
+function to24Hour(hour: number, period: string): number {
+  if (period === 'AM') return hour === 12 ? 0 : hour;
+  return hour === 12 ? 12 : hour + 12;
+}
+
+/**
+ * Parse a dashboard `openingHours` string like "4:00 PM - 12:00 AM KSA"
+ * into 24h HH:mm open/close times. Returns null for non-matching strings
+ * (e.g. "Closed").
+ */
+export function parseDashboardHours(str: string): {open: string; close: string} | null {
+  const match = (str || '').match(/(\d{1,2}):(\d{2})\s*(AM|PM)\s*-\s*(\d{1,2}):(\d{2})\s*(AM|PM)/i);
+  if (!match) return null;
+
+  const openHour = to24Hour(parseInt(match[1], 10), match[3].toUpperCase());
+  const closeHour = to24Hour(parseInt(match[4], 10), match[6].toUpperCase());
+
+  return {
+    open: `${String(openHour).padStart(2, '0')}:${match[2]}`,
+    close: `${String(closeHour).padStart(2, '0')}:${match[5]}`,
+  };
+}
+
+/**
+ * Fallback schedule source for when the website scrape that normally
+ * supplies the weekly hours pattern is unavailable (e.g. WAF-blocked —
+ * see getWebsiteSchedule). The dashboard endpoint lives on a different
+ * subdomain and only ever reports *today's* hours, not a weekly pattern,
+ * so this covers a single day rather than a full projection.
+ */
+export function buildTodayScheduleFromDashboard(
+  dashboard: QiddiyaDashboardResponse['data'] | undefined,
+  today: Date,
+  timezone: string,
+): Array<{date: string; type: string; openingTime: string; closingTime: string}> {
+  if (dashboard?.parkInfo?.isOpen === false) return [];
+
+  const hours = parseDashboardHours(dashboard?.parkInfo?.openingHours || '');
+  if (!hours) return [];
+
+  const dateStr = formatDate(today, timezone);
+  const closingDate = hours.close === '00:00' ? formatDate(addDays(today, 1), timezone) : dateStr;
+
+  return [{
+    date: dateStr,
+    type: 'OPERATING',
+    openingTime: constructDateTime(dateStr, hours.open, timezone),
+    closingTime: constructDateTime(closingDate, hours.close, timezone),
+  }];
+}
+
 // Classify an activity as belonging to Six Flags or Aqua Rabia based on the
 // asset path in its image URL. The shared API endpoint returns activities for
 // both parks mixed together.
@@ -206,6 +258,13 @@ export class QiddiyaCity extends Destination {
    * Scrape weekly schedule from the website's megaMenu svelte component.
    * Returns a map of day index (0=Sun..6=Sat) → {open, close} in HH:mm,
    * or absent for closed days.
+   *
+   * sixflagsqiddiyacity.com sits behind Cloudflare Bot Management, which
+   * can 403 this fetch independently of the api.* subdomain used for
+   * activities/live data (confirmed 2026-07-19: browser UA didn't help,
+   * bot-management blocks are fingerprint/reputation-based, not header-
+   * based). When that happens this returns {} and buildSchedules() falls
+   * back to buildTodayScheduleFromDashboard() for a same-day-only schedule.
    */
   @cache({ttlSeconds: 43200}) // 12h
   async getWebsiteSchedule(): Promise<Record<number, {open: string; close: string}>> {
@@ -328,8 +387,7 @@ export class QiddiyaCity extends Destination {
   }
 
   private to24h(hour: number, period: string): number {
-    if (period === 'AM') return hour === 12 ? 0 : hour;
-    return hour === 12 ? 12 : hour + 12;
+    return to24Hour(hour, period);
   }
 
   // ─── Destination + entities ─────────────────────────────────────────────
@@ -472,7 +530,9 @@ export class QiddiyaCity extends Destination {
     const aquaRabia: EntitySchedule = {id: AQUA_RABIA_PARK_ID, schedule: []} as EntitySchedule;
 
     if (Object.keys(weeklyHours).length === 0) {
-      return [{id: SIX_FLAGS_PARK_ID, schedule: []} as EntitySchedule, aquaRabia];
+      const dashboard = await this.getDashboard();
+      const todaySchedule = buildTodayScheduleFromDashboard(dashboard, new Date(), this.timezone);
+      return [{id: SIX_FLAGS_PARK_ID, schedule: todaySchedule} as EntitySchedule, aquaRabia];
     }
 
     // Project the weekly pattern onto the next N days.


### PR DESCRIPTION
## Summary
- `sixflagsqiddiyacity.com` sits behind Cloudflare Bot Management and now 403s the homepage scrape `getWebsiteSchedule()` uses for the weekly hours pattern, independently of `api.sixflagsqiddiyacity.com` (activities/live data) which is unaffected — so `getSchedules()` was returning 0 days while attractions/wait times kept working.
- Adds `buildTodayScheduleFromDashboard()`, deriving a same-day-only schedule from the dashboard endpoint's `openingHours` field (already fetched for the `isOpen` flag, on the healthy api subdomain) when the website scrape comes back empty.
- Doesn't restore the full 30-day projection — that needs the WAF to lift or a proxy route for `sixflagsqiddiyacity.com` specifically, which is a routing decision outside this fix's scope.

## Test plan
- [x] New unit tests for `parseDashboardHours` and `buildTodayScheduleFromDashboard` (TDD — written first, watched fail, then implemented)
- [x] `npx tsc --noEmit` clean
- [x] `npm run dev -- qiddiyacity` against live data: schedule went from 0 days to 1 day, attractions/live data unaffected (32 entities, live wait times)
- [x] Full `vitest` suite green (1487/1487; one unrelated flaky timeout in `traceContextPropagation.test.ts` reproduced on `main` too under full-suite load, passes in isolation on both branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)