### PR TITLE
fix(qiddiyacity): fix overnight-close rollover for non-midnight close times

### DIFF
--- a/src/parks/qiddiyacity/__tests__/qiddiyacity.test.ts
+++ b/src/parks/qiddiyacity/__tests__/qiddiyacity.test.ts
@@ -8,9 +8,25 @@
  * (separately-sourced, unaffected) dashboard endpoint when that happens.
  */
 import {describe, test, expect} from 'vitest';
-import {parseDashboardHours, buildTodayScheduleFromDashboard} from '../qiddiyacity.js';
+import {parseDashboardHours, buildTodayScheduleFromDashboard, closesNextDay} from '../qiddiyacity.js';
 
 const TZ = 'Asia/Riyadh';
+
+describe('closesNextDay', () => {
+  test('rolls over for an exact midnight close', () => {
+    expect(closesNextDay('16:00', '00:00')).toBe(true);
+  });
+
+  test('rolls over for a post-midnight close that is not exactly 00:00', () => {
+    // e.g. a Fright Fest night running 4pm-1am — this used to be missed by
+    // a check that only fired on an exact "00:00" close.
+    expect(closesNextDay('16:00', '01:00')).toBe(true);
+  });
+
+  test('does not roll over for a same-day close', () => {
+    expect(closesNextDay('10:00', '18:00')).toBe(false);
+  });
+});
 
 describe('parseDashboardHours', () => {
   test('parses a standard AM/PM range with a trailing timezone abbreviation', () => {
@@ -44,6 +60,12 @@ describe('buildTodayScheduleFromDashboard', () => {
 
   test('rolls a midnight closing time over to the next calendar day', () => {
     const dashboard = {parkInfo: {isOpen: true, openingHours: '4:00 PM - 12:00 AM KSA'}};
+    const schedule = buildTodayScheduleFromDashboard(dashboard, today, TZ);
+    expect(schedule[0].closingTime).toContain('2026-07-20');
+  });
+
+  test('rolls a past-midnight closing time (not exactly 00:00) over to the next calendar day', () => {
+    const dashboard = {parkInfo: {isOpen: true, openingHours: '4:00 PM - 1:00 AM KSA'}};
     const schedule = buildTodayScheduleFromDashboard(dashboard, today, TZ);
     expect(schedule[0].closingTime).toContain('2026-07-20');
   });

--- a/src/parks/qiddiyacity/qiddiyacity.ts
+++ b/src/parks/qiddiyacity/qiddiyacity.ts
@@ -105,6 +105,18 @@ function to24Hour(hour: number, period: string): number {
 }
 
 /**
+ * True when a close time (24h HH:mm) falls on the calendar day after an
+ * open time (24h HH:mm) — i.e. the venue closes past midnight relative to
+ * opening. Compares as zero-padded 24h strings, so lexical order matches
+ * chronological order within a day; a close time that is not later than
+ * open (e.g. open 16:00 / close 01:00) means it rolled into the next day,
+ * not just an exact "00:00" close.
+ */
+export function closesNextDay(open: string, close: string): boolean {
+  return close <= open;
+}
+
+/**
  * Parse a dashboard `openingHours` string like "4:00 PM - 12:00 AM KSA"
  * into 24h HH:mm open/close times. Returns null for non-matching strings
  * (e.g. "Closed").
@@ -140,7 +152,7 @@ export function buildTodayScheduleFromDashboard(
   if (!hours) return [];
 
   const dateStr = formatDate(today, timezone);
-  const closingDate = hours.close === '00:00' ? formatDate(addDays(today, 1), timezone) : dateStr;
+  const closingDate = closesNextDay(hours.open, hours.close) ? formatDate(addDays(today, 1), timezone) : dateStr;
 
   return [{
     date: dateStr,
@@ -547,8 +559,8 @@ export class QiddiyaCity extends Destination {
       const hours = weeklyHours[dayIdx];
       if (!hours) continue; // Closed day
 
-      // Handle midnight closing (e.g. "12 AM" = next day)
-      const closingDate = hours.close === '00:00' ? formatDate(addDays(date, 1), this.timezone) : dateStr;
+      // Handle overnight closing (e.g. "12 AM" or "1 AM" = next day)
+      const closingDate = closesNextDay(hours.open, hours.close) ? formatDate(addDays(date, 1), this.timezone) : dateStr;
 
       schedule.push({
         date: dateStr,


### PR DESCRIPTION
## Summary
- Follow-up to #260. Both the weekly-pattern schedule and the new dashboard fallback only rolled the closing date to the next calendar day when `close === '00:00'` exactly, missing any other past-midnight close (e.g. a 4pm-1am Fright Fest night) — that produced a `closingTime` before `openingTime` on the same day instead of the next.
- Extracted `closesNextDay(open, close)` and used it in both places: a close time that's not later than open means it rolled over.

## Test plan
- [x] New unit tests for `closesNextDay`, plus a regression case on `buildTodayScheduleFromDashboard` with a `1:00 AM` close (TDD — written first, watched fail with `2026-07-19T01:00:00+03:00` instead of rolling to `07-20`, then fixed)
- [x] `npx tsc --noEmit` clean
- [x] `npm run dev -- qiddiyacity` against live data
- [x] Full `vitest` suite green (1491/1491)

🤖 Generated with [Claude Code](https://claude.com/claude-code)