### PR TITLE
fix(cache): synchronous=NORMAL on the persistent HTTP cache (fsync tolerance)

### DIFF
--- a/src/__tests__/cachePragmas.test.ts
+++ b/src/__tests__/cachePragmas.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// The shared test setup forces CACHE_DB_PATH=:memory: (vitest.setup.ts), where
+// journal_mode is 'memory' and synchronous is moot. To prove the PERSISTENT
+// cache gets the fsync-tolerant pragmas, re-import the module against a real
+// on-disk path.
+describe('cache DB fsync pragmas (on-disk)', () => {
+  it('opens the persistent cache in WAL with synchronous=NORMAL', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cache-pragma-'));
+    process.env.CACHE_DB_PATH = join(dir, 'cache.sqlite');
+    vi.resetModules();
+    const { database } = await import('../cache.js');
+    expect(
+      (database.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode,
+    ).toBe('wal');
+    // 0=OFF 1=NORMAL 2=FULL — NORMAL fsyncs at checkpoints, not per commit.
+    expect(
+      (database.prepare('PRAGMA synchronous').get() as { synchronous: number }).synchronous,
+    ).toBe(1);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -98,6 +98,12 @@ initializeDatabase(database);
 try {
   database.exec('PRAGMA journal_mode=WAL');
   database.exec('PRAGMA busy_timeout=5000');
+  // synchronous=NORMAL: with WAL, fsync only at checkpoints, not per commit.
+  // This is the hot HTTP-response cache — hammered during a park's entity/sync
+  // sweep — and DatabaseSync is synchronous, so per-commit fsync on a slow or
+  // saturated disk stalls the caller's event loop. NORMAL only risks losing the
+  // last uncheckpointed cache rows on a hard crash, which are just re-fetched.
+  database.exec('PRAGMA synchronous=NORMAL');
 } catch {
   // Ignore if PRAGMAs fail (e.g. in-memory databases)
 }


### PR DESCRIPTION
## Why
Companion to the collector-side SQLite fsync change. The on-disk HTTP cache (`cache.sqlite`) runs **WAL but `synchronous=FULL`**, so `DatabaseSync` fsyncs on **every commit**. During a park's entity/sync sweep the cache is written hard, and because the call is synchronous, on a slow/saturated disk each write stalls the caller's event loop on a full fsync. `synchronous=NORMAL` fsyncs only at checkpoints — the single biggest burst-writer of the SQLite DBs involved.

## Safety
Only durability change: losing the last uncheckpointed cache rows on a hard crash — a cache miss that re-fetches. No correctness impact.

## Test
`cachePragmas.test.ts` re-imports the module against a real on-disk path (the shared `vitest.setup.ts` forces `:memory:`, where journal_mode is 'memory') and asserts `journal_mode=wal` + `synchronous=1` (NORMAL). Existing `cache.test.ts` unaffected (81/81).