### PR TITLE
chore: add containerised dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+node_modules
+web-ui/node_modules
+web-ui/dist
+dist
+coverage
+docs
+datacache
+snapshots
+.env
+cache.sqlite
+cache.sqlite-wal
+cache.sqlite-shm
+*.har
+http-dump.jsonl
+output.log
+testout_*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dev image for ParksAPI — Node 24 / npm 11 (see package.json "engines")
+FROM node:24-slim
+
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false \
+    NPM_CONFIG_FUND=false \
+    TZ=UTC
+
+WORKDIR /app
+
+# Install deps first so the layer is cached independently of the source.
+# --ignore-scripts skips the root "prepare": "tsc" hook, which cannot run yet
+# (no sources at this point) and is not needed: tsx executes TypeScript directly.
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# Baked-in sources, so the image is usable without a bind mount too.
+COPY . .
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,35 @@ FROM node:24-slim
 
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false \
     NPM_CONFIG_FUND=false \
-    TZ=UTC
+    TZ=UTC \
+    HOME=/home/node
 
 WORKDIR /app
+
+# node:24-slim ships an unprivileged `node` user (uid/gid 1000) but does not
+# select it. As root, everything the container writes into the bind mount is
+# root-owned on a Docker host — .env, dist/, cache.sqlite, docs/ — and the
+# developer then needs sudo to edit or delete their own files.
+#
+# Switching before `npm ci` rather than chowning afterwards keeps the image
+# ~200 MB smaller: a `RUN chown -R /app` would duplicate the whole
+# node_modules tree in a new layer. It also initialises the named node_modules
+# volume as uid 1000, so the entrypoint's `npm ci` fallback still works.
+#
+# Rootless Podman maps container uid 1000 to a subuid rather than to the
+# developer, so the Podman recipe in the Makefile header passes
+# --userns=keep-id; the entrypoint says so too if the mount is unwritable.
+RUN chown node:node /app
+USER node
 
 # Install deps first so the layer is cached independently of the source.
 # --ignore-scripts skips the root "prepare": "tsc" hook, which cannot run yet
 # (no sources at this point) and is not needed: tsx executes TypeScript directly.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
 RUN npm ci --ignore-scripts
 
 # Baked-in sources, so the image is usable without a bind mount too.
-COPY . .
+COPY --chown=node:node . .
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,15 @@
 #   make build      → build the image once
 #   make park PARK=efteling
 #
-# Fedora ships Podman, not Docker. Override if you are on a Docker host:
-#   make COMPOSE="docker compose" dev
+# On a Podman host (Fedora and friends), override COMPOSE:
+#   make COMPOSE="podman-compose --podman-run-args=--userns=keep-id" dev
+#
+# The image runs as the unprivileged `node` user (uid 1000). Rootless Podman
+# maps that to a subuid rather than to you, so without --userns=keep-id the
+# container cannot write to the bind-mounted source tree. Docker needs no
+# such flag. Export COMPOSE in your shell if you use Podman day to day.
 
-COMPOSE ?= podman-compose
+COMPOSE ?= docker compose
 SERVICE  = parksapi
 RUN      = $(COMPOSE) run --rm $(SERVICE)
 
@@ -72,8 +77,8 @@ compile: ## Type-check / compile TypeScript to dist/
 	$(RUN) npm run build
 
 .PHONY: web
-web: ## Serve the web admin on http://localhost:8888
-	$(COMPOSE) run --rm --service-ports $(SERVICE) npm run web
+web: ## Serve the web admin on http://localhost:8888 (WEB_PORT to change)
+	$(COMPOSE) --profile web run --rm --service-ports web
 
 .PHONY: shell
 shell: ## Open a shell inside the container
@@ -90,8 +95,8 @@ clean: ## Remove containers and the node_modules volume
 	-$(COMPOSE) down -v
 
 .PHONY: clean-all
-clean-all: clean ## Also delete the built image
-	-podman rmi localhost/parksapi-dev
+clean-all: ## Also delete the built image (engine-agnostic, unlike a bare rmi)
+	-$(COMPOSE) down -v --rmi all
 
 ##@ Help
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,103 @@
+# ParksAPI — everything runs in a container (Node 24 / npm 11 inside).
+# Nothing here needs Node installed on the host.
+#
+#   make            → this help
+#   make build      → build the image once
+#   make park PARK=efteling
+#
+# Fedora ships Podman, not Docker. Override if you are on a Docker host:
+#   make COMPOSE="docker compose" dev
+
+COMPOSE ?= podman-compose
+SERVICE  = parksapi
+RUN      = $(COMPOSE) run --rm $(SERVICE)
+
+# Optional: extra flags forwarded to the test harness, e.g.
+#   make dev ARGS="--skip-schedules --verbose"
+ARGS ?=
+PARK ?=
+
+.DEFAULT_GOAL := help
+
+##@ Setup
+
+.PHONY: build
+build: ## Build the dev image (npm install happens here)
+	$(COMPOSE) build
+
+.PHONY: rebuild
+rebuild: ## Rebuild the image from scratch, ignoring layer cache
+	$(COMPOSE) build --no-cache
+
+.PHONY: deps
+deps: ## Reinstall node_modules inside the container volume
+	$(RUN) npm ci --ignore-scripts
+
+##@ Running the harness
+
+.PHONY: dev
+dev: ## Test every park (long: 76 destinations, hits live APIs)
+	$(RUN) npm run dev -- $(ARGS)
+
+.PHONY: park
+park: ## Test one park — make park PARK=efteling
+	@test -n "$(PARK)" || { echo "usage: make park PARK=<parkId>   (see: make list)"; exit 1; }
+	$(RUN) npm run dev -- $(PARK) $(ARGS)
+
+.PHONY: category
+category: ## Test a whole category — make category CATEGORY=Universal
+	@test -n "$(CATEGORY)" || { echo "usage: make category CATEGORY=<name>"; exit 1; }
+	$(RUN) npm run dev -- --category $(CATEGORY) $(ARGS)
+
+.PHONY: list
+list: ## List available park IDs
+	$(RUN) npm run dev -- --list
+
+.PHONY: health
+health: ## Health-check all endpoints
+	$(RUN) npm run health
+
+##@ Build & tests
+
+.PHONY: test
+test: ## Run the Vitest suite
+	$(RUN) npm test
+
+.PHONY: coverage
+coverage: ## Run tests with coverage report
+	$(RUN) npm run test:coverage
+
+.PHONY: compile
+compile: ## Type-check / compile TypeScript to dist/
+	$(RUN) npm run build
+
+.PHONY: web
+web: ## Serve the web admin on http://localhost:8888
+	$(COMPOSE) run --rm --service-ports $(SERVICE) npm run web
+
+.PHONY: shell
+shell: ## Open a shell inside the container
+	$(RUN) bash
+
+##@ Housekeeping
+
+.PHONY: cache-clear
+cache-clear: ## Drop the SQLite cache and retest everything fresh
+	$(RUN) npm run dev -- --clear-cache $(ARGS)
+
+.PHONY: clean
+clean: ## Remove containers and the node_modules volume
+	-$(COMPOSE) down -v
+
+.PHONY: clean-all
+clean-all: clean ## Also delete the built image
+	-podman rmi localhost/parksapi-dev
+
+##@ Help
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nParksAPI — containerised commands\n"} \
+	  /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5); next } \
+	  /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@printf "\nFirst run:  make build && make park PARK=efteling\n\n"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ npm run test:coverage  # Coverage report
 npm run health         # Health check all endpoints
 ```
 
+### Without Node installed
+
+A container image pins Node 24 / npm 11, so nothing has to be installed on the
+host. Every command above has a `make` equivalent:
+
+```bash
+make build             # Build the dev image once
+make park PARK=efteling
+make test
+make web               # Web admin on http://localhost:8888
+make                   # Full list of targets
+```
+
+The default engine is Docker. On a Podman host, override `COMPOSE`:
+
+```bash
+make COMPOSE="podman-compose --podman-run-args=--userns=keep-id" park PARK=efteling
+```
+
+Credentials still come from `.env` in the repo root, which the entrypoint
+creates empty on first run.
+
 ## Supported Destinations
 
 75 destinations across Disney, Universal, Cedar Fair, Six Flags, Merlin, and many more.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,34 @@
+# Shared definition — the two services differ only by what they run and by
+# whether they publish a port.
+x-parksapi: &parksapi
+  build:
+    context: .
+  image: parksapi-dev
+  working_dir: /app
+  # :z = SELinux shared relabel (required on Fedora for bind mounts)
+  volumes:
+    - .:/app:z
+    # keep container-installed node_modules out of the host tree
+    - parksapi_node_modules:/app/node_modules
+  environment:
+    TZ: ${TZ:-UTC}
+  tty: true
+
 services:
+  # Default service: the harness, the tests, a shell. Publishes nothing.
   parksapi:
-    build:
-      context: .
-    image: localhost/parksapi-dev
-    working_dir: /app
-    # :z = SELinux shared relabel (required on Fedora for bind mounts)
-    volumes:
-      - .:/app:z
-      # keep container-installed node_modules out of the host tree
-      - parksapi_node_modules:/app/node_modules
-    environment:
-      TZ: ${TZ:-UTC}
-    # only published by `make web` (podman-compose run --service-ports)
-    ports:
-      - "8888:8888"
-    tty: true
+    <<: *parksapi
     command: ["npm", "run", "dev"]
+
+  # The web admin, and the only thing that binds a port. Behind a profile so
+  # it is inert unless asked for — `compose up` would otherwise take 8888 on
+  # every developer running the harness.
+  web:
+    <<: *parksapi
+    profiles: ["web"]
+    ports:
+      - "${WEB_PORT:-8888}:8888"
+    command: ["npm", "run", "web"]
 
 volumes:
   parksapi_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  parksapi:
+    build:
+      context: .
+    image: localhost/parksapi-dev
+    working_dir: /app
+    # :z = SELinux shared relabel (required on Fedora for bind mounts)
+    volumes:
+      - .:/app:z
+      # keep container-installed node_modules out of the host tree
+      - parksapi_node_modules:/app/node_modules
+    environment:
+      TZ: ${TZ:-UTC}
+    # only published by `make web` (podman-compose run --service-ports)
+    ports:
+      - "8888:8888"
+    tty: true
+    command: ["npm", "run", "dev"]
+
+volumes:
+  parksapi_node_modules:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,18 @@ set -e
 # Every npm script runs `tsx --env-file=.env`, which aborts if the file is
 # missing. An empty .env is a valid configuration (all @config props default
 # to empty strings), so create it when absent — this is the `touch .env` step.
-[ -f /app/.env ] || : > /app/.env
+#
+# Failing here means the bind-mounted tree is not writable by this container's
+# uid, which is what rootless Podman does without --userns=keep-id. Say so
+# rather than letting tsx report a missing file three commands later.
+# (touch, not `: > file`: a failed redirection on a special builtin kills the
+# whole script in dash, before this check can report anything.)
+if [ ! -f /app/.env ] && ! (touch /app/.env) 2>/dev/null; then
+  echo "✗ cannot write to /app as uid $(id -u): the source tree is mounted from" >&2
+  echo "  a host user this container is not mapped to." >&2
+  echo "  Podman: make COMPOSE=\"podman-compose --podman-run-args=--userns=keep-id\" …" >&2
+  exit 1
+fi
 
 # When the source tree is bind-mounted, node_modules comes from a named volume
 # that may still be empty on the very first run.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Every npm script runs `tsx --env-file=.env`, which aborts if the file is
+# missing. An empty .env is a valid configuration (all @config props default
+# to empty strings), so create it when absent — this is the `touch .env` step.
+[ -f /app/.env ] || : > /app/.env
+
+# When the source tree is bind-mounted, node_modules comes from a named volume
+# that may still be empty on the very first run.
+if [ ! -d /app/node_modules/tsx ]; then
+  echo "→ node_modules empty, running npm ci…"
+  npm ci --ignore-scripts
+fi
+
+exec "$@"


### PR DESCRIPTION
Run the harness, tests and build without installing Node 24 / npm 11 on the host. The image pins the versions from package.json "engines", so contributors get the same toolchain regardless of what their distro ships.

- Dockerfile: node:24-slim, deps installed in their own layer. `npm ci` uses --ignore-scripts because the root "prepare": "tsc" hook cannot run before the sources are copied, and is unnecessary: tsx executes TypeScript directly.
- docker-entrypoint.sh: creates an empty .env when absent (every npm script runs `tsx --env-file=.env`, which aborts on a missing file) and restores node_modules on the first run with a bind mount.
- docker-compose.yml: bind-mounts the tree with :z for SELinux, keeps node_modules in a named volume so it never lands in the host tree.
- Makefile: self-documenting targets (make park PARK=efteling, make test, make web...). Defaults to podman-compose; override with `make COMPOSE="docker compose" dev` on a Docker host.
- .dockerignore: excludes caches, secrets and build output from the context.

Verified in-container: `make compile` clean, `make test` 1536 tests passing.