### PR TITLE
fix(build): state decorator options in vitest config

### DIFF
--- a/src/__tests__/decoratorTransform.test.ts
+++ b/src/__tests__/decoratorTransform.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Guard for the build pipeline, not for any one library.
+ *
+ * Test files are excluded from tsconfig.json (they must not reach `dist/`),
+ * and Vite's transformer resolves each file against that config to decide
+ * whether to apply `experimentalDecorators`. An excluded file gets no
+ * decorator support, so the syntax is emitted verbatim and every test that
+ * declares a decorated class dies at import with
+ * `SyntaxError: Invalid or unexpected token`.
+ *
+ * Older Vite applied the options regardless of the exclusion, which hid the
+ * problem until a Vite bump surfaced it across 19 files at once. vitest.config
+ * now states `oxc.decorator` explicitly; this file is the assertion that it
+ * still holds, and it fails as one named test rather than as a wall of syntax
+ * errors.
+ *
+ * Nearly every core test declares decorated classes inline (@config, @cache,
+ * @http, @inject), so a regression here takes most of the suite with it.
+ */
+
+import {describe, expect, test} from 'vitest';
+
+describe('decorator transform in test files', () => {
+  test('class decorators run', () => {
+    const seen: string[] = [];
+
+    function tagClass(target: any) {
+      seen.push(target.name);
+    }
+
+    @tagClass
+    class Decorated {}
+
+    // Reference the class so it cannot be elided.
+    expect(Decorated.name).toBe('Decorated');
+    expect(seen).toEqual(['Decorated']);
+  });
+
+  test('property decorators run and receive the property key', () => {
+    const seen: string[] = [];
+
+    function tagProperty(_target: any, key: string) {
+      seen.push(key);
+    }
+
+    class Decorated {
+      @tagProperty apiKey: string = '';
+      @tagProperty timeout: number = 0;
+    }
+
+    expect(new Decorated().apiKey).toBe('');
+    expect(seen).toEqual(['apiKey', 'timeout']);
+  });
+
+  test('method decorators can wrap the descriptor', () => {
+    function double(_target: any, _key: string, descriptor: PropertyDescriptor) {
+      const original = descriptor.value;
+      descriptor.value = function (this: unknown, ...args: number[]) {
+        return original.apply(this, args) * 2;
+      };
+      return descriptor;
+    }
+
+    class Decorated {
+      @double
+      value(n: number): number {
+        return n + 1;
+      }
+    }
+
+    // Undecorated this would be 4, so the wrapper demonstrably applied.
+    expect(new Decorated().value(3)).toBe(8);
+  });
+
+  test('decorator factories receive their arguments', () => {
+    const seen: Array<{key: string; opts: {ttl: number}}> = [];
+
+    function withOptions(opts: {ttl: number}) {
+      return function (_target: any, key: string) {
+        seen.push({key, opts});
+      };
+    }
+
+    class Decorated {
+      @withOptions({ttl: 60}) cached: string = '';
+    }
+
+    expect(new Decorated().cached).toBe('');
+    expect(seen).toEqual([{key: 'cached', opts: {ttl: 60}}]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,25 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  // Decorator support has to be stated here, not inherited from tsconfig.json.
+  //
+  // Vite's transformer resolves each file against tsconfig.json to decide
+  // whether to apply `experimentalDecorators` / `emitDecoratorMetadata`, and
+  // that config excludes `**/__tests__` and `**/*.test.ts` (they must not
+  // reach `dist/`). An excluded file gets neither option, so decorator syntax
+  // is emitted verbatim and every test that declares a decorated class dies at
+  // import with `SyntaxError: Invalid or unexpected token`.
+  //
+  // Older Vite ignored the exclusion and applied the options anyway, which is
+  // why this was invisible until a Vite bump. Setting them explicitly makes
+  // the suite independent of that behaviour in either direction. Keep these
+  // two in step with the matching tsconfig.json compilerOptions.
+  oxc: {
+    decorator: {
+      legacy: true,                 // = experimentalDecorators
+      emitDecoratorMetadata: true,  // = emitDecoratorMetadata (needs legacy)
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Unblocks the Vitest bump in #273, which currently drops 19 test files and 450 tests.

## What breaks

Vite's transformer resolves each file against `tsconfig.json` to decide whether to apply `experimentalDecorators` / `emitDecoratorMetadata`. That config excludes `**/__tests__` and `**/*.test.ts`, since they must not reach `dist/`. An excluded file gets neither option, so decorator syntax is emitted verbatim:

```
src/__tests__/cache.test.ts:343
    @(0,__vite_ssr_import_1__.default)({ ttlSeconds: 60 }) async getData(param) {
    ^
SyntaxError: Invalid or unexpected token
```

Older Vite applied the options regardless of the exclusion, which is why this stayed invisible. A newer Vite honours it, and the suite goes from 1536 passing to 1086 with 19 failed files. Every failure is in `src/__tests__`; the park suites survive because `src/parks` is not excluded.

## The fix

State the two options in `vitest.config.ts` via `oxc.decorator`, so the suite no longer depends on that behaviour in either direction:

```ts
oxc: {
  decorator: {
    legacy: true,                 // = experimentalDecorators
    emitDecoratorMetadata: true,
  },
},
```

`esbuild.tsconfigRaw` and `oxc.tsconfigRaw` do not work here: `OxcOptions` omits `tsconfig` outright.

Also adds `src/__tests__/decoratorTransform.test.ts`, which declares decorated classes inline and asserts class, property, method and factory decorators all run. Nearly every core test declares decorated classes, so a regression here takes most of the suite with it; this turns that into one named failure instead of a wall of syntax errors.

## Alternative considered

Moving the test excludes into a `tsconfig.build.json` and letting the base config cover test files also fixes it, and keeps a single source of truth. It pulls 123 pre-existing type errors across 21 test files into the type-check surface though (missing `.js` import extensions, implicit `any`, tests reaching protected members). Worth doing on its own, not inside this fix.

## Verification

| | current toolchain | toolchain from #273 |
|---|---|---|
| before this change | 1536 pass | 19 files fail, 450 tests lost |
| after this change | 1540 pass | 1540 pass |

The new guard test fails on the newer toolchain without this change and passes with it. `npm run build` is unaffected.

Merge order: this first, then rebase #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
