### PR TITLE
fix(universal): map delayed shows to DOWN, not CLOSED

### DIFF
--- a/src/parks/universal/__tests__/places.test.ts
+++ b/src/parks/universal/__tests__/places.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the pure helpers backing the /places migration.
  */
 import {describe, test, expect} from 'vitest';
-import {placeToEntity, isEventVariantAlias, parseShowTimes, type UniversalPlace, type UniversalShowListEntry} from '../universal.js';
+import {placeToEntity, isEventVariantAlias, parseShowTimes, mapUniversalShowStatus, type UniversalPlace, type UniversalShowListEntry} from '../universal.js';
 
 const DESTINATION = 'universalresort_orlando';
 const TZ = 'America/New_York';
@@ -357,5 +357,33 @@ describe('parseShowTimes', () => {
   test('empty / missing show_times → []', () => {
     expect(parseShowTimes({...baseShow, show_times: []}, UOR_TZ, new Date())).toEqual([]);
     expect(parseShowTimes({...baseShow, show_times: undefined}, UOR_TZ, new Date())).toEqual([]);
+  });
+});
+
+describe('mapUniversalShowStatus', () => {
+  test('OPEN / RIDE_NOW → OPERATING', () => {
+    expect(mapUniversalShowStatus('OPEN')).toBe('OPERATING');
+    expect(mapUniversalShowStatus('RIDE_NOW')).toBe('OPERATING');
+  });
+
+  // Regression: a show that is merely delayed still runs a full day of
+  // performances. The old `=== 'OPEN' ? OPERATING : CLOSED` mapping reported it
+  // CLOSED while emitting showtimes — contradictory. BRIEF_DELAY means DOWN.
+  test('BRIEF_DELAY / WEATHER_DELAY / AT_CAPACITY → DOWN (delayed, not closed)', () => {
+    expect(mapUniversalShowStatus('BRIEF_DELAY')).toBe('DOWN');
+    expect(mapUniversalShowStatus('WEATHER_DELAY')).toBe('DOWN');
+    expect(mapUniversalShowStatus('AT_CAPACITY')).toBe('DOWN');
+  });
+
+  test('genuinely-closed states → CLOSED', () => {
+    expect(mapUniversalShowStatus('CLOSED')).toBe('CLOSED');
+    expect(mapUniversalShowStatus('EXTENDED_CLOSURE')).toBe('CLOSED');
+    expect(mapUniversalShowStatus('COMING_SOON')).toBe('CLOSED');
+  });
+
+  test('unknown / empty / undefined → CLOSED (safe default)', () => {
+    expect(mapUniversalShowStatus('SOMETHING_NEW')).toBe('CLOSED');
+    expect(mapUniversalShowStatus('')).toBe('CLOSED');
+    expect(mapUniversalShowStatus(undefined)).toBe('CLOSED');
   });
 });

--- a/src/parks/universal/__tests__/places.test.ts
+++ b/src/parks/universal/__tests__/places.test.ts
@@ -386,4 +386,26 @@ describe('mapUniversalShowStatus', () => {
     expect(mapUniversalShowStatus('')).toBe('CLOSED');
     expect(mapUniversalShowStatus(undefined)).toBe('CLOSED');
   });
+
+  // Integration of the two halves the buildLiveData show loop combines: the
+  // reported bug was a delayed show emitting status + showtimes that
+  // contradicted each other. Assert they now coexist coherently on one entry.
+  test('delayed show yields DOWN together with its showtimes (contradiction resolved)', () => {
+    const now = new Date('2026-08-05T14:00:00Z');
+    const show: UniversalShowListEntry = {
+      show_id: 'uor.usf.shows.the_bourne_stuntacular',
+      resort_area_code: 'UOR',
+      name: 'The Bourne Stuntacular',
+      status: 'BRIEF_DELAY',
+      show_externally: true,
+      show_times: [
+        {show_time_id: 'a', status: 'ENABLED', start_time: '2026-08-05T15:15:00.000Z'},
+        {show_time_id: 'b', status: 'ENABLED', start_time: '2026-08-05T16:00:00.000Z'},
+      ],
+    };
+    const status = mapUniversalShowStatus(show.status);
+    const showtimes = parseShowTimes(show, 'America/New_York', now);
+    expect(status).toBe('DOWN'); // was 'CLOSED' before the fix — the contradiction
+    expect(showtimes).toHaveLength(2);
+  });
 });

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -287,10 +287,13 @@ export function parseShowTimes(
  * Universal reuses its ride operating-state vocabulary for shows. The previous
  * mapping treated every value except 'OPEN' as CLOSED, which mislabelled a show
  * that is merely delayed (BRIEF_DELAY / WEATHER_DELAY) or at capacity as CLOSED
- * even while it still lists a full day of ENABLED performances — a
+ * even while it still listed a full day of ENABLED performances — the reported
  * CLOSED-with-showtimes contradiction. Mirror the attraction status semantics
- * so a delayed-but-scheduled show reads DOWN, and only genuinely-closed states
- * read CLOSED.
+ * so a delayed show reads DOWN.
+ *
+ * This maps the raw status only. A show whose status is literally CLOSED can
+ * still carry future showtimes (e.g. character meet-and-greets between
+ * appearances); that separate case is not resolved here.
  */
 export function mapUniversalShowStatus(
   status: string | undefined,
@@ -304,7 +307,7 @@ export function mapUniversalShowStatus(
     case 'AT_CAPACITY':
       return 'DOWN';
     default:
-      // CLOSED, EXTENDED_CLOSURE, COMING_SOON, unknown → CLOSED
+      // CLOSED, CANCELED, EXTENDED_CLOSURE, COMING_SOON, unknown → CLOSED
       return 'CLOSED';
   }
 }

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -281,6 +281,34 @@ export function parseShowTimes(
   return out;
 }
 
+/**
+ * Map a show-list entry's `status` to a wiki live status.
+ *
+ * Universal reuses its ride operating-state vocabulary for shows. The previous
+ * mapping treated every value except 'OPEN' as CLOSED, which mislabelled a show
+ * that is merely delayed (BRIEF_DELAY / WEATHER_DELAY) or at capacity as CLOSED
+ * even while it still lists a full day of ENABLED performances — a
+ * CLOSED-with-showtimes contradiction. Mirror the attraction status semantics
+ * so a delayed-but-scheduled show reads DOWN, and only genuinely-closed states
+ * read CLOSED.
+ */
+export function mapUniversalShowStatus(
+  status: string | undefined,
+): 'OPERATING' | 'DOWN' | 'CLOSED' {
+  switch (status) {
+    case 'OPEN':
+    case 'RIDE_NOW':
+      return 'OPERATING';
+    case 'BRIEF_DELAY':
+    case 'WEATHER_DELAY':
+    case 'AT_CAPACITY':
+      return 'DOWN';
+    default:
+      // CLOSED, EXTENDED_CLOSURE, COMING_SOON, unknown → CLOSED
+      return 'CLOSED';
+  }
+}
+
 // ─── shows/show-list.json (CDN) types ────────────────────────────────────────
 
 export type UniversalShowTime = {
@@ -1105,7 +1133,7 @@ class Universal extends Destination {
       if (!show.show_externally) continue;
       const showId = sanitizeId(show.show_id);
       const showEntry = getOrCreateLiveData(showId);
-      showEntry.status = show.status === 'OPEN' ? 'OPERATING' : 'CLOSED';
+      showEntry.status = mapUniversalShowStatus(show.status);
 
       const times = parseShowTimes(show, this.timezone, now);
       if (times.length > 0) {


### PR DESCRIPTION
## Report

A community member spotted The Bourne Stuntacular in the `/live` feed with `status: CLOSED` but a full list of showtimes for the day — contradictory.

## Root cause

The show-list source record is:
```
status: "BRIEF_DELAY"   (not "OPEN")
show_times: 8 × ENABLED performances today
```
The show path mapped status with `show.status === 'OPEN' ? 'OPERATING' : 'CLOSED'`, so every non-OPEN state — including `BRIEF_DELAY` (a temporary delay) — collapsed to CLOSED, while `parseShowTimes` independently still emitted the ENABLED showtimes. Universal reuses its **ride** operating-state vocabulary for shows, and the attraction path already maps `BRIEF_DELAY`/`WEATHER_DELAY` → DOWN — the show path just never did.

## Fix

`mapUniversalShowStatus()` mirrors the attraction semantics:
- `OPEN` / `RIDE_NOW` → OPERATING
- `BRIEF_DELAY` / `WEATHER_DELAY` / `AT_CAPACITY` → DOWN
- `CLOSED` / `EXTENDED_CLOSURE` / `COMING_SOON` / unknown → CLOSED

Bourne now emits **DOWN** with its 8 showtimes (a delayed-but-scheduled show), instead of CLOSED-with-showtimes.

## Tests

New unit tests cover the full status table, including the `BRIEF_DELAY → DOWN` regression that would have caught this. Full suite 1544/1544.

Verified against the live CDN feed (`assets.universalparks.com/uor/shows/show-list.json`): the one currently-non-OPEN show (Bourne, `BRIEF_DELAY`) now maps to DOWN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)