### PR TITLE
fix(universal): a scheduled show is never CLOSED; fix USJ delayed shows

### DIFF
--- a/src/parks/universal/__tests__/places.test.ts
+++ b/src/parks/universal/__tests__/places.test.ts
@@ -375,7 +375,7 @@ describe('mapUniversalShowStatus', () => {
     expect(mapUniversalShowStatus('AT_CAPACITY')).toBe('DOWN');
   });
 
-  test('genuinely-closed states → CLOSED', () => {
+  test('genuinely-closed states → CLOSED (no showtimes)', () => {
     expect(mapUniversalShowStatus('CLOSED')).toBe('CLOSED');
     expect(mapUniversalShowStatus('EXTENDED_CLOSURE')).toBe('CLOSED');
     expect(mapUniversalShowStatus('COMING_SOON')).toBe('CLOSED');
@@ -385,6 +385,31 @@ describe('mapUniversalShowStatus', () => {
     expect(mapUniversalShowStatus('SOMETHING_NEW')).toBe('CLOSED');
     expect(mapUniversalShowStatus('')).toBe('CLOSED');
     expect(mapUniversalShowStatus(undefined)).toBe('CLOSED');
+  });
+
+  // Structural: a show still advertising future performances is running today,
+  // so CLOSED-with-showtimes is unreachable (the reported class of bug). This
+  // covers character meet-and-greets that report CLOSED between appearances.
+  test('CLOSED / CANCELED / unknown WITH future showtimes → OPERATING', () => {
+    expect(mapUniversalShowStatus('CLOSED', true)).toBe('OPERATING');
+    expect(mapUniversalShowStatus('CANCELED', true)).toBe('OPERATING');
+    expect(mapUniversalShowStatus('SOMETHING_NEW', true)).toBe('OPERATING');
+    expect(mapUniversalShowStatus(undefined, true)).toBe('OPERATING');
+  });
+
+  test('explicit long-closures stay CLOSED even with showtimes', () => {
+    expect(mapUniversalShowStatus('EXTENDED_CLOSURE', true)).toBe('CLOSED');
+    expect(mapUniversalShowStatus('COMING_SOON', true)).toBe('CLOSED');
+  });
+
+  test('delay states stay DOWN regardless of showtimes', () => {
+    expect(mapUniversalShowStatus('BRIEF_DELAY', true)).toBe('DOWN');
+    expect(mapUniversalShowStatus('WEATHER_DELAY', true)).toBe('DOWN');
+  });
+
+  test('OPEN stays OPERATING regardless of the flag', () => {
+    expect(mapUniversalShowStatus('OPEN', false)).toBe('OPERATING');
+    expect(mapUniversalShowStatus('OPEN', true)).toBe('OPERATING');
   });
 
   // Integration of the two halves the buildLiveData show loop combines: the
@@ -403,9 +428,30 @@ describe('mapUniversalShowStatus', () => {
         {show_time_id: 'b', status: 'ENABLED', start_time: '2026-08-05T16:00:00.000Z'},
       ],
     };
-    const status = mapUniversalShowStatus(show.status);
     const showtimes = parseShowTimes(show, 'America/New_York', now);
+    const status = mapUniversalShowStatus(show.status, showtimes.length > 0);
     expect(status).toBe('DOWN'); // was 'CLOSED' before the fix — the contradiction
     expect(showtimes).toHaveLength(2);
+  });
+
+  // A character meet-and-greet reports status CLOSED between appearances while
+  // still listing today's slots. buildLiveData now promotes it to OPERATING so
+  // the feed never shows CLOSED next to a live schedule.
+  test('CLOSED meet-and-greet with future showtimes → OPERATING with showtimes', () => {
+    const now = new Date('2026-08-05T14:00:00Z');
+    const show: UniversalShowListEntry = {
+      show_id: 'ush.meet.some_character',
+      resort_area_code: 'USH',
+      name: 'Character Meet',
+      status: 'CLOSED',
+      show_externally: true,
+      show_times: [
+        {show_time_id: 'a', status: 'ENABLED', start_time: '2026-08-05T18:30:00.000Z'},
+      ],
+    };
+    const showtimes = parseShowTimes(show, 'America/Los_Angeles', now);
+    const status = mapUniversalShowStatus(show.status, showtimes.length > 0);
+    expect(status).toBe('OPERATING'); // was 'CLOSED' — the reported contradiction
+    expect(showtimes).toHaveLength(1);
   });
 });

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -284,19 +284,24 @@ export function parseShowTimes(
 /**
  * Map a show-list entry's `status` to a wiki live status.
  *
- * Universal reuses its ride operating-state vocabulary for shows. The previous
+ * Universal reuses its ride operating-state vocabulary for shows. The original
  * mapping treated every value except 'OPEN' as CLOSED, which mislabelled a show
  * that is merely delayed (BRIEF_DELAY / WEATHER_DELAY) or at capacity as CLOSED
  * even while it still listed a full day of ENABLED performances — the reported
  * CLOSED-with-showtimes contradiction. Mirror the attraction status semantics
  * so a delayed show reads DOWN.
  *
- * This maps the raw status only. A show whose status is literally CLOSED can
- * still carry future showtimes (e.g. character meet-and-greets between
- * appearances); that separate case is not resolved here.
+ * `hasFutureShowtimes` closes the contradiction structurally rather than by
+ * enumerating today's known statuses: a show still advertising future ENABLED
+ * performances is operating today (e.g. character meet-and-greets that report
+ * `CLOSED` between appearances), so it is never emitted as CLOSED alongside a
+ * live schedule. Explicit long closures (EXTENDED_CLOSURE / COMING_SOON) still
+ * win over stray showtimes. Delay states stay DOWN — DOWN + showtimes is
+ * coherent (interrupted but scheduled).
  */
 export function mapUniversalShowStatus(
   status: string | undefined,
+  hasFutureShowtimes = false,
 ): 'OPERATING' | 'DOWN' | 'CLOSED' {
   switch (status) {
     case 'OPEN':
@@ -306,9 +311,14 @@ export function mapUniversalShowStatus(
     case 'WEATHER_DELAY':
     case 'AT_CAPACITY':
       return 'DOWN';
-    default:
-      // CLOSED, CANCELED, EXTENDED_CLOSURE, COMING_SOON, unknown → CLOSED
+    case 'EXTENDED_CLOSURE':
+    case 'COMING_SOON':
+      // Strong "not running for a while" signals win over any stray showtimes.
       return 'CLOSED';
+    default:
+      // CLOSED / CANCELED / unknown: operating today iff it still lists future
+      // ENABLED performances, otherwise CLOSED.
+      return hasFutureShowtimes ? 'OPERATING' : 'CLOSED';
   }
 }
 
@@ -1136,9 +1146,9 @@ class Universal extends Destination {
       if (!show.show_externally) continue;
       const showId = sanitizeId(show.show_id);
       const showEntry = getOrCreateLiveData(showId);
-      showEntry.status = mapUniversalShowStatus(show.status);
 
       const times = parseShowTimes(show, this.timezone, now);
+      showEntry.status = mapUniversalShowStatus(show.status, times.length > 0);
       if (times.length > 0) {
         showEntry.showtimes = times;
       }

--- a/src/parks/usj/__tests__/showStatus.test.ts
+++ b/src/parks/usj/__tests__/showStatus.test.ts
@@ -1,0 +1,27 @@
+import {describe, test, expect} from 'vitest';
+import {mapQueueStatus} from '../universalstudiosjapan.js';
+
+// USJ shows and attractions share one status vocabulary. The show path used to
+// map with a naive `status === 'OPEN' ? 'OPERATING' : 'CLOSED'`, which reported
+// a merely-delayed show as CLOSED while it still listed a full day of ENABLED
+// performances. It now reuses mapQueueStatus, so a delayed show reads DOWN.
+describe('USJ mapQueueStatus (shared by attractions and shows)', () => {
+  test('OPEN → OPERATING', () => {
+    expect(mapQueueStatus('OPEN')).toBe('OPERATING');
+  });
+
+  // Regression: the reported Universal bug class — delayed ≠ closed.
+  test('BRIEF_DELAY / WEATHER_DELAY → DOWN (delayed, not closed)', () => {
+    expect(mapQueueStatus('BRIEF_DELAY')).toBe('DOWN');
+    expect(mapQueueStatus('WEATHER_DELAY')).toBe('DOWN');
+  });
+
+  test('CLOSED / N/A → CLOSED', () => {
+    expect(mapQueueStatus('CLOSED')).toBe('CLOSED');
+    expect(mapQueueStatus('N/A')).toBe('CLOSED');
+  });
+
+  test('unknown status → CLOSED (safe default)', () => {
+    expect(mapQueueStatus('SOMETHING_NEW')).toBe('CLOSED');
+  });
+});

--- a/src/parks/usj/universalstudiosjapan.ts
+++ b/src/parks/usj/universalstudiosjapan.ts
@@ -21,7 +21,7 @@ function sanitizeId(id: string): string {
 
 // ─── Status mapping ───────────────────────────────────────────────────────────
 
-const mapQueueStatus = createStatusMap(
+export const mapQueueStatus = createStatusMap(
   {
     OPERATING: ['OPEN'],
     DOWN: ['WEATHER_DELAY', 'BRIEF_DELAY'],
@@ -426,7 +426,11 @@ export class UniversalStudiosJapan extends Destination {
 
     // Show times
     for (const show of showListData) {
-      const showStatus = show.status === 'OPEN' ? 'OPERATING' : 'CLOSED';
+      // Use the same status vocabulary as attractions: a delayed show
+      // (BRIEF_DELAY / WEATHER_DELAY) is DOWN, not CLOSED. The old binary
+      // `=== 'OPEN' ? OPERATING : CLOSED` mislabelled delayed shows as closed
+      // even while they still listed a full day of ENABLED performances.
+      const showStatus = mapQueueStatus(show.status);
 
       const showTimes = (show.show_times || [])
         .filter((st) => st.status === 'ENABLED')


### PR DESCRIPTION
Follow-up to #282. Closes the **CLOSED-with-showtimes** contradiction across the Universal family.

## Orlando / Hollywood (`universal.ts`)

#282 fixed delayed shows (`BRIEF_DELAY` → DOWN), but the reviewers found the reported symptom class was still live for a *different* status: character meet-and-greets report `status: CLOSED` between appearances while listing today's slots. This makes the contradiction unreachable by construction rather than by enumerating known statuses:

`mapUniversalShowStatus(status, hasFutureShowtimes)` — a show still advertising **future ENABLED performances** is OPERATING today, so it's never emitted CLOSED next to a live schedule. Explicit long closures (`EXTENDED_CLOSURE`/`COMING_SOON`) still win over stray showtimes; delay states stay DOWN.

Verified on the live Hollywood feed today:
| Show | source status | showtimes | emitted |
|---|---|---|---|
| Meet Gabby / DreamWorks Trolls / Snowball | CLOSED | ≥1 | **OPERATING** (was CLOSED) |
| 5 Towers Stage / Street Performers / Colorful Yoshi | CLOSED | 0 | CLOSED (unchanged) |
| all others | OPEN | — | OPERATING (unchanged) |

## USJ (`universalstudiosjapan.ts`)

The USJ show path had the same naive `=== 'OPEN' ? OPERATING : CLOSED` binary that #282 fixed for Orlando — so a delayed USJ show would be mislabelled CLOSED (latent: USJ's feed is all-OPEN right now). USJ already defines `mapQueueStatus` (OPEN→OPERATING, BRIEF_DELAY/WEATHER_DELAY→DOWN, else→CLOSED, with unknown-status logging) for its attractions; the show path now reuses it.

## Spot-check: Beijing / Singapore (out of scope, documented)

- **Beijing** uses a different backend (`gems_status` + `is_closed`), not the Universal CDN show-list. It can also emit CLOSED + showtimes, but via different vocabulary — a separate investigation, not folded in here.
- **Singapore** *deliberately* keeps showtimes on closed shows ("the wiki shows the day's schedule either way"). Left as the maintainer intended.

## Tests

Extended the Universal show-status table (promotion, long-closure-stays-CLOSED, delay-stays-DOWN, and a meet-and-greet integration case) and added a USJ status-mapping test with the `BRIEF_DELAY → DOWN` regression. Full suite **1554/1554**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)