### PR TITLE
feat(seaworld): cover all 12 parks in the operator's estate

### DIFF
--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -15,6 +15,8 @@ import {
   SeaworldSanDiego,
   BuschGardensTampa,
   BuschGardensWilliamsburg,
+  SesamePlacePhiladelphia,
+  SesamePlaceSanDiego,
 } from '../seaworld.js';
 
 // ---------------------------------------------------------------------------
@@ -43,6 +45,14 @@ const MOCK_PARK_DETAIL_SWO = {
         Coordinate: {Latitude: 28.412, Longitude: -81.462},
       },
     ],
+    Pools: [
+      {
+        Id: 'pool-001',
+        Name: 'Roa’s Rapids',
+        Type: 'Pools',
+        Coordinate: {Latitude: 28.415, Longitude: -81.465},
+      },
+    ],
     Shows: [
       {
         Id: 'show-001',
@@ -65,6 +75,17 @@ const MOCK_PARK_DETAIL_SWO = {
     ],
     AnimalExperiences: [
       {Id: 'ae-001', Name: 'Dolphin Encounter', Type: 'Animal Experiences'},
+    ],
+    // Water-park amenities that sit alongside Pools/Slides and must NOT be
+    // promoted to attractions when Pools is.
+    Cabanas: [
+      {Id: 'cab-001', Name: 'Private Cabana 12', Type: 'Cabanas'},
+    ],
+    Restrooms: [
+      {Id: 'wc-001', Name: 'Restroom', Type: 'Restrooms'},
+    ],
+    Shops: [
+      {Id: 'shop-001', Name: 'Gift Shop', Type: 'Shops'},
     ],
   },
   open_hours: [
@@ -116,17 +137,23 @@ function createMockedOrlando() {
 
   // Mock getParkDetail to return our fixture only for the SWO park
   // and a minimal fixture for Aquatica
+  // Each sibling park returns its OWN Id. Returning a shared fixture for every
+  // non-SWO UUID would collapse Aquatica and Discovery Cove onto one entity id
+  // and hide a duplicate-park bug rather than expose it.
+  const SIBLINGS: Record<string, string> = {
+    '4B040706-968A-41B4-9967-D93C7814E665': 'Aquatica Orlando',
+    '1FB04DFC-B6C0-4918-BE36-EE6DD14FE741': 'Discovery Cove Orlando',
+  };
   park.getParkDetail = async (parkId: string) => {
     if (parkId === MOCK_PARK_ID_SWO) {
       return MOCK_PARK_DETAIL_SWO as any;
     }
-    // Aquatica minimal
     return {
-      Id: '4B040706-968A-41B4-9967-D93C7814E665',
-      park_Name: 'Aquatica Orlando',
+      Id: parkId,
+      park_Name: SIBLINGS[parkId] ?? 'Unknown Park',
       TimeZone: 'America/New_York',
       map_center: {Latitude: 28.42, Longitude: -81.47},
-      POIs: {Rides: [], Shows: [], Dining: [], Slides: []},
+      POIs: {Rides: [], Shows: [], Dining: [], Slides: [], Pools: []},
       open_hours: [],
     } as any;
   };
@@ -155,11 +182,19 @@ describe('SeaworldOrlando', () => {
       expect(park.timezone).toBe('America/New_York');
     });
 
-    it('has two resort IDs', () => {
+    it('has three resort IDs', () => {
       const park = new SeaworldOrlando();
-      expect(park.resortIds).toHaveLength(2);
+      expect(park.resortIds).toHaveLength(3);
       expect(park.resortIds[0]).toBe('AC3AF402-3C62-4893-8B05-822F19B9D2BC');
       expect(park.resortIds[1]).toBe('4B040706-968A-41B4-9967-D93C7814E665');
+      expect(park.resortIds[2]).toBe('1FB04DFC-B6C0-4918-BE36-EE6DD14FE741');
+    });
+
+    it('keeps SeaWorld Orlando first so the destination pin does not move', () => {
+      // getDestinations() reads map_center off resortIds[0]. A reorder here
+      // would relocate the destination without failing anything else.
+      const park = new SeaworldOrlando();
+      expect(park.resortIds[0]).toBe('AC3AF402-3C62-4893-8B05-822F19B9D2BC');
     });
 
     it('getCacheKeyPrefix returns destination-specific prefix', () => {
@@ -189,17 +224,35 @@ describe('SeaworldOrlando', () => {
   });
 
   describe('buildEntityList', () => {
-    it('includes destination, parks, attractions (rides+slides), shows, restaurants', async () => {
+    it('includes destination, parks, attractions (rides+slides+pools), shows, restaurants', async () => {
       const park = createMockedOrlando();
       const entities = await (park as any).buildEntityList();
 
       const byType = (type: string) => entities.filter((e: any) => e.entityType === type);
 
       expect(byType('DESTINATION')).toHaveLength(1);
-      expect(byType('PARK')).toHaveLength(2); // SWO + Aquatica
-      expect(byType('ATTRACTION')).toHaveLength(2); // 1 ride + 1 slide (SWO only)
+      expect(byType('PARK')).toHaveLength(3); // SWO + Aquatica + Discovery Cove
+      expect(byType('ATTRACTION')).toHaveLength(3); // 1 ride + 1 slide + 1 pool (SWO only)
       expect(byType('SHOW')).toHaveLength(1);
       expect(byType('RESTAURANT')).toHaveLength(1);
+    });
+
+    it('emits one PARK per resort ID with distinct ids', async () => {
+      const park = createMockedOrlando();
+      const entities = await (park as any).buildEntityList();
+      const parkIds = entities.filter((e: any) => e.entityType === 'PARK').map((e: any) => e.id);
+      expect(new Set(parkIds).size).toBe(parkIds.length);
+      expect(parkIds).toEqual(park.resortIds);
+    });
+
+    it('maps Pools as a RIDE attraction (water-park headline items)', async () => {
+      const park = createMockedOrlando();
+      const entities = await (park as any).buildEntityList();
+      const pool = entities.find((e: any) => e.id === 'pool-001');
+      expect(pool).toBeDefined();
+      expect(pool.entityType).toBe('ATTRACTION');
+      expect(pool.attractionType).toBe('RIDE');
+      expect(pool.parentId).toBe(MOCK_PARK_ID_SWO);
     });
 
     it('does not include Services or AnimalExperiences', async () => {
@@ -208,6 +261,17 @@ describe('SeaworldOrlando', () => {
       const ids = entities.map((e: any) => e.id);
       expect(ids).not.toContain('svc-001');
       expect(ids).not.toContain('ae-001');
+    });
+
+    it('does not promote water-park amenities alongside Pools', async () => {
+      // Cabanas outnumber every real attraction at these parks (45 at Adventure
+      // Island). Letting them through would swamp the park with rentals.
+      const park = createMockedOrlando();
+      const entities = await (park as any).buildEntityList();
+      const ids = entities.map((e: any) => e.id);
+      expect(ids).not.toContain('cab-001');
+      expect(ids).not.toContain('wc-001');
+      expect(ids).not.toContain('shop-001');
     });
 
     it('entity IDs are strings (UUIDs preserved)', async () => {
@@ -341,6 +405,8 @@ describe('Cache key prefix isolation', () => {
       new SeaworldSanDiego(),
       new BuschGardensTampa(),
       new BuschGardensWilliamsburg(),
+      new SesamePlacePhiladelphia(),
+      new SesamePlaceSanDiego(),
     ];
     const prefixes = parks.map(p => p.getCacheKeyPrefix());
     const uniquePrefixes = new Set(prefixes);
@@ -357,8 +423,9 @@ describe('Destination subclasses', () => {
     const park = new SeaworldSanAntonio();
     expect(park.destinationId).toBe('seaworldsanantonio');
     expect(park.timezone).toBe('America/Chicago');
-    expect(park.resortIds).toHaveLength(1);
+    expect(park.resortIds).toHaveLength(2);
     expect(park.resortIds[0]).toBe('F4040D22-8B8D-4394-AEC7-D05FA5DEA945');
+    expect(park.resortIds[1]).toBe('04668F50-A57E-4DE6-8E70-D4567D9B46B5'); // Aquatica SA
   });
 
   it('SeaworldSanDiego has correct config', () => {
@@ -372,14 +439,64 @@ describe('Destination subclasses', () => {
     const park = new BuschGardensTampa();
     expect(park.destinationId).toBe('buschgardenstampa');
     expect(park.timezone).toBe('America/New_York');
+    expect(park.resortIds).toHaveLength(2);
     expect(park.resortIds[0]).toBe('C001866B-555D-4E92-B48E-CC67E195DE96');
+    expect(park.resortIds[1]).toBe('770E691C-E6DA-4264-AF27-863189380D0B'); // Adventure Island
   });
 
   it('BuschGardensWilliamsburg preserves legacy destinationId typo', () => {
     const park = new BuschGardensWilliamsburg();
     // "willamsburg" — one 'l' — matches JS implementation
     expect(park.destinationId).toBe('buschgardenswillamsburg');
+    expect(park.resortIds).toHaveLength(2);
     expect(park.resortIds[0]).toBe('45FE1F31-D4E4-4B1E-90E0-5255111070F2');
+    expect(park.resortIds[1]).toBe('66480532-A73C-4617-9B2D-EDC4430CAB86'); // Water Country USA
+  });
+
+  it('SesamePlacePhiladelphia has correct config', () => {
+    const park = new SesamePlacePhiladelphia();
+    expect(park.destinationId).toBe('sesameplacephiladelphia');
+    expect(park.destinationName).toBe('Sesame Place Philadelphia');
+    expect(park.timezone).toBe('America/New_York');
+    expect(park.resortIds).toEqual(['F7408854-28CB-4B1E-98E5-4449FE600E85']);
+  });
+
+  it('SesamePlaceSanDiego has correct config', () => {
+    const park = new SesamePlaceSanDiego();
+    expect(park.destinationId).toBe('sesameplacesandiego');
+    expect(park.destinationName).toBe('Sesame Place San Diego');
+    expect(park.timezone).toBe('America/Los_Angeles');
+    expect(park.resortIds).toEqual(['A988F4CE-6A81-4527-9535-DDB378689E52']);
+  });
+});
+
+describe('Park UUID assignment across destinations', () => {
+  const ALL = () => [
+    new SeaworldOrlando(),
+    new SeaworldSanAntonio(),
+    new SeaworldSanDiego(),
+    new BuschGardensTampa(),
+    new BuschGardensWilliamsburg(),
+    new SesamePlacePhiladelphia(),
+    new SesamePlaceSanDiego(),
+  ];
+
+  it('assigns every park UUID to exactly one destination', () => {
+    // A UUID pasted into two destinations would publish the same PARK twice
+    // under different parents, and the collector would see it flap between them.
+    const all = ALL().flatMap((p) => p.resortIds);
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('covers all 12 parks the operator publishes', () => {
+    expect(ALL().flatMap((p) => p.resortIds)).toHaveLength(12);
+  });
+
+  it('gives every destination a unique id and at least one park', () => {
+    const parks = ALL();
+    const ids = parks.map((p) => p.destinationId);
+    expect(new Set(ids).size).toBe(parks.length);
+    for (const p of parks) expect(p.resortIds.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -1,14 +1,28 @@
 /**
  * SeaWorld / Busch Gardens Parks TypeScript Implementation
  *
- * Supports 5 destinations:
- *  - SeaWorld Orlando (SeaWorld + Aquatica)
- *  - SeaWorld San Antonio
+ * Supports 7 destinations covering all 12 parks the operator publishes:
+ *  - SeaWorld Orlando (SeaWorld + Aquatica + Discovery Cove)
+ *  - SeaWorld San Antonio (SeaWorld + Aquatica)
  *  - SeaWorld San Diego
- *  - Busch Gardens Tampa
- *  - Busch Gardens Williamsburg
+ *  - Busch Gardens Tampa (Busch Gardens + Adventure Island)
+ *  - Busch Gardens Williamsburg (Busch Gardens + Water Country USA)
+ *  - Sesame Place Philadelphia
+ *  - Sesame Place San Diego
  *
- * API: https://public.api.seaworld.com/ (no auth required)
+ * The full park list is enumerable at `v1/park/` (no path parameter), which
+ * returns every park's UUID, brand and name. That is where the UUIDs below come
+ * from, so a park added by the operator is discoverable rather than guessed —
+ * check it before assuming a park has no feed.
+ *
+ * Not every park reports queues. The water parks (Adventure Island, both
+ * Aquaticas, Water Country USA) and Discovery Cove return an empty `WaitTimes`
+ * array while still publishing a full POI list and operating calendar, so they
+ * are entity-and-schedule parks by design, not a broken join. Third-party
+ * aggregators list wait times for some of them; the operator's own feed does
+ * not carry any.
+ *
+ * API: base URL is config-only (`SEAWORLD_BASEURL`), no auth required.
  */
 
 import {Destination, type DestinationConstructor} from '../../destination.js';
@@ -280,8 +294,14 @@ export class SeaworldDestination extends Destination {
       }
       entities.push(parkEntity);
 
-      // --- ATTRACTIONs (Rides + Slides) ---
-      const rides = this.getAllPoisOfTypes(parkDetail, ['Rides', 'Slides']);
+      // --- ATTRACTIONs (Rides + Slides + Pools) ---
+      // `Pools` is the water parks' own type for wave pools, lazy rivers and
+      // activity lagoons — the headline attractions at a park whose only other
+      // rideable type is `Slides`. Leaving it out cost Discovery Cove every
+      // attraction it has (it lists no Rides or Slides at all) and stripped the
+      // signature item from each water park. Cabanas, Services, Restrooms and
+      // Shops stay out: those are amenities, not attractions.
+      const rides = this.getAllPoisOfTypes(parkDetail, ['Rides', 'Slides', 'Pools']);
       for (const poi of rides) {
         const entity: Entity = {
           id: poi.Id,
@@ -519,7 +539,11 @@ export class SeaworldDestination extends Destination {
 
 /**
  * SeaWorld Parks and Resorts Orlando
- * Includes: SeaWorld Orlando + Aquatica Orlando
+ * Includes: SeaWorld Orlando + Aquatica Orlando + Discovery Cove Orlando
+ *
+ * Discovery Cove is appended rather than inserted: `getDestinations()` takes the
+ * destination's coordinates from `resortIds[0]`, so reordering this array would
+ * silently move the destination pin to a different park.
  */
 @destinationController({category: 'SeaWorld'})
 export class SeaworldOrlando extends SeaworldDestination {
@@ -528,6 +552,7 @@ export class SeaworldOrlando extends SeaworldDestination {
     this.resortIds = [
       'AC3AF402-3C62-4893-8B05-822F19B9D2BC', // SeaWorld Orlando
       '4B040706-968A-41B4-9967-D93C7814E665', // Aquatica Orlando
+      '1FB04DFC-B6C0-4918-BE36-EE6DD14FE741', // Discovery Cove Orlando
     ];
     this.timezone = 'America/New_York';
     this.destinationName = 'SeaWorld Parks and Resorts Orlando';
@@ -537,13 +562,15 @@ export class SeaworldOrlando extends SeaworldDestination {
 
 /**
  * SeaWorld San Antonio
+ * Includes: SeaWorld San Antonio + Aquatica San Antonio
  */
 @destinationController({category: 'SeaWorld'})
 export class SeaworldSanAntonio extends SeaworldDestination {
   constructor(options?: DestinationConstructor) {
     super(options);
     this.resortIds = [
-      'F4040D22-8B8D-4394-AEC7-D05FA5DEA945',
+      'F4040D22-8B8D-4394-AEC7-D05FA5DEA945', // SeaWorld San Antonio
+      '04668F50-A57E-4DE6-8E70-D4567D9B46B5', // Aquatica San Antonio
     ];
     this.timezone = 'America/Chicago';
     this.destinationName = 'SeaWorld San Antonio';
@@ -569,13 +596,15 @@ export class SeaworldSanDiego extends SeaworldDestination {
 
 /**
  * Busch Gardens Tampa
+ * Includes: Busch Gardens Tampa + Adventure Island Tampa
  */
 @destinationController({category: 'Busch Gardens'})
 export class BuschGardensTampa extends SeaworldDestination {
   constructor(options?: DestinationConstructor) {
     super(options);
     this.resortIds = [
-      'C001866B-555D-4E92-B48E-CC67E195DE96',
+      'C001866B-555D-4E92-B48E-CC67E195DE96', // Busch Gardens Tampa
+      '770E691C-E6DA-4264-AF27-863189380D0B', // Adventure Island Tampa
     ];
     this.timezone = 'America/New_York';
     this.destinationName = 'Busch Gardens Tampa';
@@ -585,6 +614,8 @@ export class BuschGardensTampa extends SeaworldDestination {
 
 /**
  * Busch Gardens Williamsburg
+ * Includes: Busch Gardens Williamsburg + Water Country USA
+ *
  * Note: destinationId preserves legacy typo "willamsburg" (one 'l') for
  * backwards compatibility with the JS implementation.
  */
@@ -593,10 +624,59 @@ export class BuschGardensWilliamsburg extends SeaworldDestination {
   constructor(options?: DestinationConstructor) {
     super(options);
     this.resortIds = [
-      '45FE1F31-D4E4-4B1E-90E0-5255111070F2',
+      '45FE1F31-D4E4-4B1E-90E0-5255111070F2', // Busch Gardens Williamsburg
+      '66480532-A73C-4617-9B2D-EDC4430CAB86', // Water Country USA
     ];
     this.timezone = 'America/New_York';
     this.destinationName = 'Busch Gardens Williamsburg';
     this.destinationId = 'buschgardenswillamsburg';
+  }
+}
+
+/**
+ * Sesame Place Philadelphia
+ *
+ * The API still calls this park "Sesame Place Langhorne" (its town), which is
+ * what the PARK entity is named, while the park has traded publicly as Sesame
+ * Place Philadelphia since 2021. The destination carries the public brand so it
+ * is findable under the name guests use.
+ *
+ * Reports real queues: 17 ride rows, 9 of them carrying a live reading during a
+ * midday sample.
+ */
+@destinationController({category: 'Sesame Place'})
+export class SesamePlacePhiladelphia extends SeaworldDestination {
+  constructor(options?: DestinationConstructor) {
+    super(options);
+    this.resortIds = [
+      'F7408854-28CB-4B1E-98E5-4449FE600E85', // Sesame Place Langhorne
+    ];
+    this.timezone = 'America/New_York';
+    this.destinationName = 'Sesame Place Philadelphia';
+    this.destinationId = 'sesameplacephiladelphia';
+  }
+}
+
+/**
+ * Sesame Place San Diego
+ *
+ * Publishes a `WaitTimes` array covering all 7 rides, though a midday sample
+ * found every entry at the `Minutes: -1` sentinel. That is not peculiar to this
+ * park and is not a reason to treat it differently: the same sample had SeaWorld
+ * Orlando at 1 live reading out of 17 rows and Busch Gardens Williamsburg at 10
+ * of 33, both long-shipping destinations. The operator uses -1 widely for a ride
+ * it is not currently reporting, and the base class maps it to CLOSED, which is
+ * the established semantic here rather than a new judgement made for this park.
+ */
+@destinationController({category: 'Sesame Place'})
+export class SesamePlaceSanDiego extends SeaworldDestination {
+  constructor(options?: DestinationConstructor) {
+    super(options);
+    this.resortIds = [
+      'A988F4CE-6A81-4527-9535-DDB378689E52', // Sesame Place San Diego
+    ];
+    this.timezone = 'America/Los_Angeles';
+    this.destinationName = 'Sesame Place San Diego';
+    this.destinationId = 'sesameplacesandiego';
   }
 }


### PR DESCRIPTION
## What

The park directory is enumerable at `v1/park/` with no path parameter, returning every park's UUID, brand and name. The implementation never called it, so six parks the operator publishes were absent while the code needed to read them was already written and shipping.

| Destination | Parks after this change |
|---|---|
| `seaworldorlandoresort` | SeaWorld Orlando, Aquatica Orlando, **Discovery Cove** |
| `seaworldsanantonio` | SeaWorld San Antonio, **Aquatica San Antonio** |
| `buschgardenstampa` | Busch Gardens Tampa, **Adventure Island** |
| `buschgardenswillamsburg` | Busch Gardens Williamsburg, **Water Country USA** |
| `sesameplacephiladelphia` | **Sesame Place Philadelphia** (new destination) |
| `sesameplacesandiego` | **Sesame Place San Diego** (new destination) |
| `seaworldsandiego` | unchanged |

Grouping follows the precedent already in the file, where Aquatica Orlando sits as a second park under the Orlando destination rather than standing alone. No existing `destinationId` or display name changes.

Also maps the `Pools` POI type as an attraction — the water parks' own type for wave pools, lazy rivers and activity lagoons. Without it Discovery Cove had no attractions at all, and Aquatica Orlando, already live, was missing six. Cabanas stay out: 45 entries at one park, rentals rather than rides.

## Verification

All 7 destinations pass the harness 4/4 against the live API. Entity counts reconcile exactly with the published POI type census:

| Destination | Parks | Attractions | Shows | Restaurants | Live w/ waits |
|---|--:|--:|--:|--:|--:|
| SeaWorld Orlando | 3 | 40 | 49 | 47 | 1 |
| SeaWorld San Antonio | 2 | 35 | 22 | 24 | 8 |
| Busch Gardens Tampa | 2 | 41 | 36 | 25 | 8 |
| Busch Gardens Williamsburg | 2 | 59 | 28 | 27 | 10 |
| Sesame Place Philadelphia | 1 | 17 | 97 | 17 | 9 |
| Sesame Place San Diego | 1 | 8 | 100 | 8 | 0 |

Full suite: 74 files, 1642 tests passing. `tsc` clean.

## Two things worth knowing

**The water parks and Discovery Cove publish no queues.** They return an empty `WaitTimes` array while still serving a full POI list and calendar, so they are entity-and-schedule parks by design, not a broken join. Third-party aggregators claim wait times for some of them; the operator's own feed carries none. Nothing here should be read as a regression when no queues appear.

**Sesame Place San Diego is not a special case.** All 7 of its rides sat at the `Minutes: -1` no-reading sentinel during a midday sample, which looked like a park needing different handling. The same sample had SeaWorld Orlando at 1 live reading out of 17 rows and Busch Gardens Williamsburg at 10 of 33, both long-shipping destinations. The sentinel is used widely across the estate and the existing negative-minutes branch already maps it to CLOSED.

## Tests added

- `Pools` mapped as a `RIDE` attraction, and Cabanas / Restrooms / Shops explicitly not following it through
- One PARK per resort ID with distinct entity ids (the sibling mock now returns its own `Id` rather than a shared fixture, so a duplicate-park bug fails instead of hiding)
- No park UUID assigned to two destinations, and all 12 parks accounted for
- `resortIds[0]` pinned per destination, since `getDestinations()` takes the destination's coordinates from it

## Note for review

`sesameplacephiladelphia` is my naming call, not the API's: the feed still calls the park "Sesame Place Langhorne" (its town), which is what the PARK entity is named, while the park has traded publicly as Sesame Place Philadelphia since 2021. The destination carries the public brand. Free to change now, but the `destinationId` is the expensive one to rename once the collector opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)