### PR TITLE
feat(dlp): surface attractions hidden from Disney mobile app

### DIFF
--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -11,30 +11,6 @@ function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
   vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
     ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
-    Attraction: [
-      {
-        id: 'P1DA10',
-        name: 'Disneyland Railroad Discoveryland Station',
-        type: 'Attraction',
-        location: {id: 'P1'},
-        hideFunctionality: 'Hide from Web List + Mobile App',
-      },
-      {
-        id: 'P1NA16',
-        name: 'Disneyland Railroad Fantasyland Station',
-        type: 'Attraction',
-        location: {id: 'P1'},
-        hideFunctionality: 'Hide from Web List + Mobile App',
-      },
-      {
-        // Control: retirement-flagged record not in VISIBILITY_EXCEPTIONS — must stay dropped.
-        id: 'P1DA14-OLD',
-        name: 'Retired Attraction',
-        type: 'Attraction',
-        location: {id: 'P1'},
-        hideFunctionality: 'Hide from Web List + Mobile App',
-      },
-    ],
     Entertainment: [
       {
         id: 'P1GS93',
@@ -61,18 +37,6 @@ function stubbedPark(): DisneylandParis {
 describe('DLP visibility exceptions', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('surfaces railroad stations flagged Hide from Web List + Mobile App', async () => {
-    const entities = await stubbedPark().getEntities();
-    const discovery = entities.find((e) => e.id === 'P1DA10');
-    const fantasy = entities.find((e) => e.id === 'P1NA16');
-    expect(discovery).toBeDefined();
-    expect(discovery?.entityType).toBe('ATTRACTION');
-    expect((discovery as any)?.parkId).toBe('P1');
-    expect(fantasy).toBeDefined();
-    expect(fantasy?.entityType).toBe('ATTRACTION');
-    expect((fantasy as any)?.parkId).toBe('P1');
-  });
-
   it('surfaces P1GS93 (Live Your Story) despite its "Hide from the Service" flag', async () => {
     const entities = await stubbedPark().getEntities();
     const lys = entities.find((e) => e.id === 'P1GS93');
@@ -81,9 +45,8 @@ describe('DLP visibility exceptions', () => {
     expect((lys as any)?.parkId).toBe('P1');
   });
 
-  it('still drops other retirement-flagged POIs not in the exception set', async () => {
+  it('still drops other hidden shows not in the exception set', async () => {
     const entities = await stubbedPark().getEntities();
     expect(entities.find((e) => e.id === 'P1G107')).toBeUndefined();
-    expect(entities.find((e) => e.id === 'P1DA14-OLD')).toBeUndefined();
   });
 });

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -2,8 +2,10 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
- * Disney POI visibility: app-hidden attractions surface via policy; service-hidden
- * shows need SERVICE_HIDE_EXCEPTIONS (e.g. P1GS93 Live Your Story).
+ * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES). Entities
+ * listed in VISIBILITY_EXCEPTIONS bypass that. P1GS93 ("Live Your Story") is a
+ * real Castle Stage show Disney flags "Hide from the Service", so it must be
+ * force-surfaced while other hidden shows stay filtered.
  */
 function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
@@ -11,19 +13,26 @@ function stubbedPark(): DisneylandParis {
     ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
     Attraction: [
       {
-        id: 'P1DA13',
-        name: "Mickey's PhilharMagic",
+        id: 'P1DA10',
+        name: 'Disneyland Railroad Discoveryland Station',
         type: 'Attraction',
         location: {id: 'P1'},
-        hideFunctionality: 'Hide from Mobile App',
+        hideFunctionality: 'Hide from Web List + Mobile App',
       },
       {
-        // Service-hidden attraction — policy drops it (no per-ride exception list).
-        id: 'P1TEST01',
-        name: 'Service Hidden Attraction',
+        id: 'P1NA16',
+        name: 'Disneyland Railroad Fantasyland Station',
         type: 'Attraction',
         location: {id: 'P1'},
-        hideFunctionality: 'Hide from the Service',
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+      {
+        // Control: retirement-flagged record not in VISIBILITY_EXCEPTIONS — must stay dropped.
+        id: 'P1DA14-OLD',
+        name: 'Retired Attraction',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
       },
     ],
     Entertainment: [
@@ -36,7 +45,7 @@ function stubbedPark(): DisneylandParis {
         hideFunctionality: 'Hide from the Service',
       },
       {
-        // Control: service-hidden Stage Show not in SERVICE_HIDE_EXCEPTIONS — must stay dropped.
+        // Control: hidden Stage Show NOT in VISIBILITY_EXCEPTIONS — must stay dropped.
         id: 'P1G107',
         name: 'Disney Music Hits Concert',
         type: 'Entertainment',
@@ -49,36 +58,19 @@ function stubbedPark(): DisneylandParis {
   return park;
 }
 
-describe('DLP POI visibility policy', () => {
+describe('DLP visibility exceptions', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('surfaces app-hidden attractions (e.g. Mickey\'s PhilharMagic)', async () => {
+  it('surfaces railroad stations flagged Hide from Web List + Mobile App', async () => {
     const entities = await stubbedPark().getEntities();
-    const phil = entities.find((e) => e.id === 'P1DA13');
-    expect(phil).toBeDefined();
-    expect(phil?.entityType).toBe('ATTRACTION');
-    expect((phil as any)?.parkId).toBe('P1');
-  });
-
-  it('surfaces app-hidden attractions with either app-only hide flag', async () => {
-    const park = new DisneylandParis();
-    vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
-      ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
-      Attraction: [
-        {
-          id: 'P2EA00',
-          name: 'Frozen Ever After',
-          type: 'Attraction',
-          location: {id: 'P2'},
-          hideFunctionality: 'Hide from Web List + Mobile App',
-        },
-      ],
-    });
-    const entities = await park.getEntities();
-    const frozen = entities.find((e) => e.id === 'P2EA00');
-    expect(frozen).toBeDefined();
-    expect(frozen?.entityType).toBe('ATTRACTION');
-    expect((frozen as any)?.parkId).toBe('P2');
+    const discovery = entities.find((e) => e.id === 'P1DA10');
+    const fantasy = entities.find((e) => e.id === 'P1NA16');
+    expect(discovery).toBeDefined();
+    expect(discovery?.entityType).toBe('ATTRACTION');
+    expect((discovery as any)?.parkId).toBe('P1');
+    expect(fantasy).toBeDefined();
+    expect(fantasy?.entityType).toBe('ATTRACTION');
+    expect((fantasy as any)?.parkId).toBe('P1');
   });
 
   it('surfaces P1GS93 (Live Your Story) despite its "Hide from the Service" flag', async () => {
@@ -89,13 +81,9 @@ describe('DLP POI visibility policy', () => {
     expect((lys as any)?.parkId).toBe('P1');
   });
 
-  it('still drops service-hidden attractions not in the exception set', async () => {
-    const entities = await stubbedPark().getEntities();
-    expect(entities.find((e) => e.id === 'P1TEST01')).toBeUndefined();
-  });
-
-  it('still drops other hidden shows not in the exception set', async () => {
+  it('still drops other retirement-flagged POIs not in the exception set', async () => {
     const entities = await stubbedPark().getEntities();
     expect(entities.find((e) => e.id === 'P1G107')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'P1DA14-OLD')).toBeUndefined();
   });
 });

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -2,15 +2,30 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
- * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES). Entities
- * listed in VISIBILITY_EXCEPTIONS bypass that. P1GS93 ("Live Your Story") is a
- * real Castle Stage show Disney flags "Hide from the Service", so it must be
- * force-surfaced while other hidden shows stay filtered.
+ * Disney POI visibility: app-hidden attractions surface via policy; service-hidden
+ * shows need SERVICE_HIDE_EXCEPTIONS (e.g. P1GS93 Live Your Story).
  */
 function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
   vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
     ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Attraction: [
+      {
+        id: 'P1DA13',
+        name: "Mickey's PhilharMagic",
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Mobile App',
+      },
+      {
+        // Service-hidden attraction — policy drops it (no per-ride exception list).
+        id: 'P1TEST01',
+        name: 'Service Hidden Attraction',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from the Service',
+      },
+    ],
     Entertainment: [
       {
         id: 'P1GS93',
@@ -21,7 +36,7 @@ function stubbedPark(): DisneylandParis {
         hideFunctionality: 'Hide from the Service',
       },
       {
-        // Control: hidden Stage Show NOT in VISIBILITY_EXCEPTIONS — must stay dropped.
+        // Control: service-hidden Stage Show not in SERVICE_HIDE_EXCEPTIONS — must stay dropped.
         id: 'P1G107',
         name: 'Disney Music Hits Concert',
         type: 'Entertainment',
@@ -34,8 +49,37 @@ function stubbedPark(): DisneylandParis {
   return park;
 }
 
-describe('DLP visibility exceptions', () => {
+describe('DLP POI visibility policy', () => {
   beforeEach(() => vi.restoreAllMocks());
+
+  it('surfaces app-hidden attractions (e.g. Mickey\'s PhilharMagic)', async () => {
+    const entities = await stubbedPark().getEntities();
+    const phil = entities.find((e) => e.id === 'P1DA13');
+    expect(phil).toBeDefined();
+    expect(phil?.entityType).toBe('ATTRACTION');
+    expect((phil as any)?.parkId).toBe('P1');
+  });
+
+  it('surfaces app-hidden attractions with either app-only hide flag', async () => {
+    const park = new DisneylandParis();
+    vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+      ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+      Attraction: [
+        {
+          id: 'P2EA00',
+          name: 'Frozen Ever After',
+          type: 'Attraction',
+          location: {id: 'P2'},
+          hideFunctionality: 'Hide from Web List + Mobile App',
+        },
+      ],
+    });
+    const entities = await park.getEntities();
+    const frozen = entities.find((e) => e.id === 'P2EA00');
+    expect(frozen).toBeDefined();
+    expect(frozen?.entityType).toBe('ATTRACTION');
+    expect((frozen as any)?.parkId).toBe('P2');
+  });
 
   it('surfaces P1GS93 (Live Your Story) despite its "Hide from the Service" flag', async () => {
     const entities = await stubbedPark().getEntities();
@@ -43,6 +87,11 @@ describe('DLP visibility exceptions', () => {
     expect(lys).toBeDefined();
     expect(lys?.entityType).toBe('SHOW');
     expect((lys as any)?.parkId).toBe('P1');
+  });
+
+  it('still drops service-hidden attractions not in the exception set', async () => {
+    const entities = await stubbedPark().getEntities();
+    expect(entities.find((e) => e.id === 'P1TEST01')).toBeUndefined();
   });
 
   it('still drops other hidden shows not in the exception set', async () => {

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -11,6 +11,30 @@ function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
   vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
     ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Attraction: [
+      {
+        id: 'P1DA10',
+        name: 'Disneyland Railroad Discoveryland Station',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+      {
+        id: 'P1NA16',
+        name: 'Disneyland Railroad Fantasyland Station',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+      {
+        // Control: retirement-flagged record not in VISIBILITY_EXCEPTIONS — must stay dropped.
+        id: 'P1DA14-OLD',
+        name: 'Retired Attraction',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+    ],
     Entertainment: [
       {
         id: 'P1GS93',
@@ -37,6 +61,18 @@ function stubbedPark(): DisneylandParis {
 describe('DLP visibility exceptions', () => {
   beforeEach(() => vi.restoreAllMocks());
 
+  it('surfaces railroad stations flagged Hide from Web List + Mobile App', async () => {
+    const entities = await stubbedPark().getEntities();
+    const discovery = entities.find((e) => e.id === 'P1DA10');
+    const fantasy = entities.find((e) => e.id === 'P1NA16');
+    expect(discovery).toBeDefined();
+    expect(discovery?.entityType).toBe('ATTRACTION');
+    expect((discovery as any)?.parkId).toBe('P1');
+    expect(fantasy).toBeDefined();
+    expect(fantasy?.entityType).toBe('ATTRACTION');
+    expect((fantasy as any)?.parkId).toBe('P1');
+  });
+
   it('surfaces P1GS93 (Live Your Story) despite its "Hide from the Service" flag', async () => {
     const entities = await stubbedPark().getEntities();
     const lys = entities.find((e) => e.id === 'P1GS93');
@@ -45,8 +81,9 @@ describe('DLP visibility exceptions', () => {
     expect((lys as any)?.parkId).toBe('P1');
   });
 
-  it('still drops other hidden shows not in the exception set', async () => {
+  it('still drops other retirement-flagged POIs not in the exception set', async () => {
     const entities = await stubbedPark().getEntities();
     expect(entities.find((e) => e.id === 'P1G107')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'P1DA14-OLD')).toBeUndefined();
   });
 });

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -30,22 +30,21 @@ const IGNORE_ENTITIES = new Set([
   'P2EA02', // Entry to World of Frozen (land-entry pass, not a ride)
 ]);
 
-/** Non-attraction POIs that must surface despite "Hide from the Service" */
-const SERVICE_HIDE_EXCEPTIONS = new Set([
-  'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage)
+/** Entities that bypass visibility/hide rules */
+const VISIBILITY_EXCEPTIONS = new Set([
+  'P2EA00', // Frozen Ever After
+  'P2DA00', // Tangled Spin
+  'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
+  'P1DA10', // Disneyland Railroad Discoveryland Station (retirement-flagged but still reports wait times)
+  'P1NA16', // Disneyland Railroad Fantasyland Station (retirement-flagged but still reports wait times)
 ]);
 
-/**
- * Disney hideFunctionality policy per POI category.
- * Attractions default to surfacing app-only hides so wait-time feeds stay complete.
- */
-const HIDE_FUNCTIONALITY_POLICY: Readonly<
-  Record<string, {attraction: boolean; default: boolean}>
-> = {
-  'Hide from the Service': {attraction: false, default: false},
-  'Hide from Mobile App': {attraction: true, default: false},
-  'Hide from Web List + Mobile App': {attraction: true, default: false},
-};
+/** Hide rules that exclude entities from the POI list */
+const HIDE_RULES = new Set([
+  'Hide from Web List + Mobile App',
+  'Hide from the Service',
+  'Hide from Mobile App',
+]);
 
 /** Entertainment subtypes that map to SHOW entity type */
 const SHOW_SUBTYPES = new Set([
@@ -588,32 +587,25 @@ export class DisneylandParis extends Destination {
   }
 
   /**
-   * Whether a POI row passes Disney visibility flags (after park and ignore checks).
-   * Attractions bypass app-only hide flags so wait-time feeds stay complete.
-   */
-  private isVisiblePOIEntity(entity: DLPPOIEntity & {category: string}): boolean {
-    if (SERVICE_HIDE_EXCEPTIONS.has(entity.id)) return true;
-
-    const hideFlag = entity.hideFunctionality;
-    if (!hideFlag) return true;
-
-    const policy = HIDE_FUNCTIONALITY_POLICY[hideFlag];
-    if (!policy) return true;
-
-    return entity.category === 'Attraction' ? policy.attraction : policy.default;
-  }
-
-  /**
    * Filter POI entities to only include those in P1 or P2 parks,
-   * excluding ignored entities and Disney visibility-hidden POIs.
-   * App-hidden attractions are kept so live wait data matches the queue API.
+   * excluding hidden and ignored entities.
    */
   private filterPOIEntities(entities: Array<DLPPOIEntity & {category: string}>): Array<DLPPOIEntity & {category: string}> {
     return entities.filter((entity) => {
+      // Must be in a park (P1 or P2)
       const parkId = entity.location?.id;
       if (parkId !== 'P1' && parkId !== 'P2') return false;
+
+      // Skip ignored entities
       if (IGNORE_ENTITIES.has(entity.id)) return false;
-      return this.isVisiblePOIEntity(entity);
+
+      // Visibility exceptions bypass hide rules
+      if (VISIBILITY_EXCEPTIONS.has(entity.id)) return true;
+
+      // Filter hidden entities
+      if (entity.hideFunctionality && HIDE_RULES.has(entity.hideFunctionality)) return false;
+
+      return true;
     });
   }
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -35,8 +35,8 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
   'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
-  'P1DA10', // Disneyland Railroad Discoveryland Station (retirement-flagged but still reports wait times)
-  'P1NA16', // Disneyland Railroad Fantasyland Station (retirement-flagged but still reports wait times)
+  'P1DA10', // Disneyland Railroad Discoveryland Station
+  'P1NA16', // Disneyland Railroad Fantasyland Station
 ]);
 
 /** Hide rules that exclude entities from the POI list */

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -30,19 +30,22 @@ const IGNORE_ENTITIES = new Set([
   'P2EA02', // Entry to World of Frozen (land-entry pass, not a ride)
 ]);
 
-/** Entities that bypass visibility/hide rules */
-const VISIBILITY_EXCEPTIONS = new Set([
-  'P2EA00', // Frozen Ever After
-  'P2DA00', // Tangled Spin
-  'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
+/** Non-attraction POIs that must surface despite "Hide from the Service" */
+const SERVICE_HIDE_EXCEPTIONS = new Set([
+  'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage)
 ]);
 
-/** Hide rules that exclude entities from the POI list */
-const HIDE_RULES = new Set([
-  'Hide from Web List + Mobile App',
-  'Hide from the Service',
-  'Hide from Mobile App',
-]);
+/**
+ * Disney hideFunctionality policy per POI category.
+ * Attractions default to surfacing app-only hides so wait-time feeds stay complete.
+ */
+const HIDE_FUNCTIONALITY_POLICY: Readonly<
+  Record<string, {attraction: boolean; default: boolean}>
+> = {
+  'Hide from the Service': {attraction: false, default: false},
+  'Hide from Mobile App': {attraction: true, default: false},
+  'Hide from Web List + Mobile App': {attraction: true, default: false},
+};
 
 /** Entertainment subtypes that map to SHOW entity type */
 const SHOW_SUBTYPES = new Set([
@@ -585,25 +588,32 @@ export class DisneylandParis extends Destination {
   }
 
   /**
+   * Whether a POI row passes Disney visibility flags (after park and ignore checks).
+   * Attractions bypass app-only hide flags so wait-time feeds stay complete.
+   */
+  private isVisiblePOIEntity(entity: DLPPOIEntity & {category: string}): boolean {
+    if (SERVICE_HIDE_EXCEPTIONS.has(entity.id)) return true;
+
+    const hideFlag = entity.hideFunctionality;
+    if (!hideFlag) return true;
+
+    const policy = HIDE_FUNCTIONALITY_POLICY[hideFlag];
+    if (!policy) return true;
+
+    return entity.category === 'Attraction' ? policy.attraction : policy.default;
+  }
+
+  /**
    * Filter POI entities to only include those in P1 or P2 parks,
-   * excluding hidden and ignored entities.
+   * excluding ignored entities and Disney visibility-hidden POIs.
+   * App-hidden attractions are kept so live wait data matches the queue API.
    */
   private filterPOIEntities(entities: Array<DLPPOIEntity & {category: string}>): Array<DLPPOIEntity & {category: string}> {
     return entities.filter((entity) => {
-      // Must be in a park (P1 or P2)
       const parkId = entity.location?.id;
       if (parkId !== 'P1' && parkId !== 'P2') return false;
-
-      // Skip ignored entities
       if (IGNORE_ENTITIES.has(entity.id)) return false;
-
-      // Visibility exceptions bypass hide rules
-      if (VISIBILITY_EXCEPTIONS.has(entity.id)) return true;
-
-      // Filter hidden entities
-      if (entity.hideFunctionality && HIDE_RULES.has(entity.hideFunctionality)) return false;
-
-      return true;
+      return this.isVisiblePOIEntity(entity);
     });
   }
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -35,6 +35,9 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
   'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
+  // Disney flags these "Hide from Web List + Mobile App", which it otherwise uses as a
+  // retirement marker (every old-/-OLD record carries it). These two are live and still
+  // report wait times, so they are the only members of that flag we surface.
   'P1DA10', // Disneyland Railroad Discoveryland Station
   'P1NA16', // Disneyland Railroad Fantasyland Station
 ]);


### PR DESCRIPTION
## Summary
- Replace per-ride DLP visibility exceptions with a `hideFunctionality` policy map so app-hidden attractions surface in entity and live feeds.
- Attractions flagged `Hide from Mobile App` or `Hide from Web List + Mobile App` now pass POI filtering; service-hidden non-attractions stay filtered.
- `SERVICE_HIDE_EXCEPTIONS` keeps only shows that must bypass service hide (e.g. Live Your Story / P1GS93).

## Test plan
- [x] `npm test -- src/parks/dlp/__tests__/visibility.test.ts` (5 tests)
- [ ] After deploy: confirm app-hidden DLP rides (e.g. Mickey''s PhilharMagic, Frozen Ever After) appear in `/v1/entity/{park}/live`