### PR TITLE
feat(dlp): publish all shows and give showtimes a real end time

### DIFF
--- a/src/parks/dlp/__tests__/scheduleSweepCache.test.ts
+++ b/src/parks/dlp/__tests__/scheduleSweepCache.test.ts
@@ -1,0 +1,69 @@
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+import {CacheLib} from '../../../cache.js';
+
+/**
+ * The 60-day sweep behind the meet & greet gate is reached from all three
+ * public entry points, so it has to survive in the cache — including when the
+ * schedule feed is down, which is when re-running it is most expensive.
+ *
+ * CacheLib reads a cached null back as a miss, so the outage cannot be
+ * signalled by returning null; it travels as `answered: false` alongside the
+ * ids instead. These tests count calls into getScheduleForDate, which is what
+ * a real outage would turn into failed upstream requests.
+ */
+describe('DLP schedule sweep caching', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearAll();
+  });
+
+  const sweepingPark = (rows: unknown[]) => {
+    CacheLib.clearAll();
+    const park = new DisneylandParis();
+    const fetch = vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(rows);
+    return {park, fetch};
+  };
+
+  it('sweeps once across repeated calls while the feed is down', async () => {
+    const {park, fetch} = sweepingPark([]);
+
+    const first = await (park as any).getScheduledActivityIds();
+    const perSweep = fetch.mock.calls.length;
+    expect(perSweep).toBeGreaterThan(0);
+
+    await (park as any).getScheduledActivityIds();
+    await (park as any).getScheduledActivityIds();
+
+    // The assertion that matters: three calls, one sweep. A null return here
+    // would read back as a cache miss and make it three.
+    expect(fetch.mock.calls.length).toBe(perSweep);
+    expect(first).toEqual({answered: false, ids: []});
+  });
+
+  it('sweeps once across repeated calls while the feed is healthy', async () => {
+    const {park, fetch} = sweepingPark([
+      {id: 'P1MG05', schedules: [{startTime: '10:00:00', endTime: '10:30:00'}]},
+      {id: 'P1MG99', schedules: []},
+    ]);
+
+    const first = await (park as any).getScheduledActivityIds();
+    const perSweep = fetch.mock.calls.length;
+
+    await (park as any).getScheduledActivityIds();
+
+    expect(fetch.mock.calls.length).toBe(perSweep);
+    expect(first.answered).toBe(true);
+    // A row with no performances is not a reason to publish the entity.
+    expect(first.ids).toEqual(['P1MG05']);
+    expect(fetch.mock.calls.length).toBe(perSweep);
+  });
+
+  it('reports the outage rather than an empty estate', async () => {
+    const {park} = sweepingPark([]);
+    const withData = await (park as any).getMeetAndGreetIdsWithData();
+    // null is the caller's "publish all of them"; an empty Set would unpublish
+    // every meet & greet for the 12h the sweep is cached.
+    expect(withData).toBeNull();
+  });
+});

--- a/src/parks/dlp/__tests__/showtimes.test.ts
+++ b/src/parks/dlp/__tests__/showtimes.test.ts
@@ -1,0 +1,158 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * The schedule feed reports every PERFORMANCE_TIME slot with endTime equal to
+ * startTime, so a show's window has to come from its POI duration. Shows
+ * without a published duration keep the feed's own endTime.
+ */
+function stubbedPark(): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Entertainment: [
+      {
+        id: 'P1GS21',
+        name: 'Disney Stars on Parade',
+        type: 'Entertainment',
+        subType: 'Parade',
+        location: {id: 'P1'},
+        duration: {hours: 0, minutes: 30},
+      },
+      {
+        id: 'P1GS99',
+        name: 'Disney Tales of Magic',
+        type: 'Entertainment',
+        subType: 'Fireworks',
+        location: {id: 'P1'},
+        duration: {hours: 1, minutes: 5},
+      },
+      {
+        // No duration published — must fall back to the feed's endTime.
+        id: 'P2GS54',
+        name: 'Animation Academy',
+        type: 'Entertainment',
+        subType: 'Stage Show',
+        location: {id: 'P1'},
+      },
+    ],
+  });
+
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockImplementation(async (date) => [
+    {
+      id: 'P1GS21',
+      schedules: [{date, startTime: '17:30:00', endTime: '17:30:00', status: 'PERFORMANCE_TIME'}],
+    },
+    {
+      id: 'P1GS99',
+      schedules: [{date, startTime: '22:45:00', endTime: '22:45:00', status: 'PERFORMANCE_TIME'}],
+    },
+    {
+      id: 'P2GS54',
+      schedules: [{date, startTime: '10:30:00', endTime: '10:50:00', status: 'PERFORMANCE_TIME'}],
+    },
+  ]);
+
+  return park;
+}
+
+/** Minutes between two ISO timestamps. */
+function spanMinutes(startTime: string, endTime: string): number {
+  return (new Date(endTime).getTime() - new Date(startTime).getTime()) / 60000;
+}
+
+describe('DLP showtimes', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('derives the end time from the POI duration', async () => {
+    const live = await stubbedPark().getLiveData();
+
+    const parade = live.find((l) => l.id === 'P1GS21');
+    expect(parade?.showtimes).toHaveLength(1);
+    expect(spanMinutes(parade!.showtimes![0].startTime!, parade!.showtimes![0].endTime!)).toBe(30);
+  });
+
+  it('adds hours and minutes together', async () => {
+    const live = await stubbedPark().getLiveData();
+
+    const fireworks = live.find((l) => l.id === 'P1GS99');
+    expect(spanMinutes(fireworks!.showtimes![0].startTime!, fireworks!.showtimes![0].endTime!)).toBe(65);
+  });
+
+  it('keeps the feed end time when no duration is published', async () => {
+    const live = await stubbedPark().getLiveData();
+
+    const show = live.find((l) => l.id === 'P2GS54');
+    expect(spanMinutes(show!.showtimes![0].startTime!, show!.showtimes![0].endTime!)).toBe(20);
+  });
+
+  it('resolves durations without a preceding getEntities call', async () => {
+    // getLiveData is a standalone entry point; durations must not depend on
+    // entity building having run first.
+    const park = stubbedPark();
+    const live = await park.getLiveData();
+
+    const parade = live.find((l) => l.id === 'P1GS21');
+    expect(spanMinutes(parade!.showtimes![0].startTime!, parade!.showtimes![0].endTime!)).toBe(30);
+  });
+});
+
+/** Feeds one show with the given duration through the live-data path. */
+function parkWithDuration(duration: unknown): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Entertainment: [{
+      id: 'P1GS21',
+      name: 'Disney Stars on Parade',
+      type: 'Entertainment',
+      subType: 'Parade',
+      location: {id: 'P1'},
+      duration,
+    }],
+  });
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockImplementation(async (date) => [
+    {
+      id: 'P1GS21',
+      schedules: [{date, startTime: '17:30:00', endTime: '17:35:00', status: 'PERFORMANCE_TIME'}],
+    },
+  ]);
+
+  return park;
+}
+
+async function spanFor(duration: unknown): Promise<number> {
+  const live = await parkWithDuration(duration).getLiveData();
+  const show = live.find((l) => l.id === 'P1GS21');
+  return spanMinutes(show!.showtimes![0].startTime!, show!.showtimes![0].endTime!);
+}
+
+describe('DLP showtime duration parsing', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  // The feed reports 17:30 to 17:35, so a 5 minute span means the duration was
+  // rejected and the feed's own end time survived.
+  it.each([
+    ['missing', undefined],
+    ['empty', {}],
+    ['null members', {hours: null, minutes: null}],
+    ['negative', {hours: 0, minutes: -20}],
+    ['not a number', {hours: 'soon', minutes: 'later'}],
+    ['longer than a day', {hours: 99999, minutes: 0}],
+  ])('falls back to the feed end time when the duration is %s', async (_label, duration) => {
+    expect(await spanFor(duration)).toBe(5);
+  });
+
+  it('coerces numeric strings instead of concatenating them', async () => {
+    expect(await spanFor({hours: '1', minutes: '30'})).toBe(90);
+    expect(await spanFor({minutes: '45'})).toBe(45);
+  });
+});

--- a/src/parks/dlp/__tests__/showtimes.test.ts
+++ b/src/parks/dlp/__tests__/showtimes.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
@@ -52,8 +52,9 @@ function stubbedPark(): DisneylandParis {
       schedules: [{date, startTime: '22:45:00', endTime: '22:45:00', status: 'PERFORMANCE_TIME'}],
     },
     {
+      // No duration published — the feed's zero-length slot survives.
       id: 'P2GS54',
-      schedules: [{date, startTime: '10:30:00', endTime: '10:50:00', status: 'PERFORMANCE_TIME'}],
+      schedules: [{date, startTime: '10:30:00', endTime: '10:30:00', status: 'PERFORMANCE_TIME'}],
     },
   ]);
 
@@ -66,7 +67,7 @@ function spanMinutes(startTime: string, endTime: string): number {
 }
 
 describe('DLP showtimes', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   it('derives the end time from the POI duration', async () => {
     const live = await stubbedPark().getLiveData();
@@ -87,17 +88,25 @@ describe('DLP showtimes', () => {
     const live = await stubbedPark().getLiveData();
 
     const show = live.find((l) => l.id === 'P2GS54');
-    expect(spanMinutes(show!.showtimes![0].startTime!, show!.showtimes![0].endTime!)).toBe(20);
+    expect(show?.showtimes).toHaveLength(1);
+    expect(spanMinutes(show!.showtimes![0].startTime!, show!.showtimes![0].endTime!)).toBe(0);
   });
 
-  it('resolves durations without a preceding getEntities call', async () => {
-    // getLiveData is a standalone entry point; durations must not depend on
-    // entity building having run first.
-    const park = stubbedPark();
-    const live = await park.getLiveData();
+  it('resolves the same durations with and without a preceding getEntities call', async () => {
+    // getLiveData is a standalone entry point; both call orders must agree.
+    const cold = stubbedPark();
+    const coldLive = await cold.getLiveData();
 
-    const parade = live.find((l) => l.id === 'P1GS21');
-    expect(spanMinutes(parade!.showtimes![0].startTime!, parade!.showtimes![0].endTime!)).toBe(30);
+    const warm = stubbedPark();
+    await warm.getEntities();
+    const warmLive = await warm.getLiveData();
+
+    for (const live of [coldLive, warmLive]) {
+      const parade = live.find((l) => l.id === 'P1GS21');
+      expect(spanMinutes(parade!.showtimes![0].startTime!, parade!.showtimes![0].endTime!)).toBe(30);
+    }
+    expect(warmLive.find((l) => l.id === 'P1GS21')?.showtimes)
+      .toEqual(coldLive.find((l) => l.id === 'P1GS21')?.showtimes);
   });
 });
 
@@ -136,7 +145,7 @@ async function spanFor(duration: unknown): Promise<number> {
 }
 
 describe('DLP showtime duration parsing', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   // The feed reports 17:30 to 17:35, so a 5 minute span means the duration was
   // rejected and the feed's own end time survived.
@@ -144,6 +153,7 @@ describe('DLP showtime duration parsing', () => {
     ['missing', undefined],
     ['empty', {}],
     ['null members', {hours: null, minutes: null}],
+    ['zero', {hours: 0, minutes: 0}],
     ['negative', {hours: 0, minutes: -20}],
     ['not a number', {hours: 'soon', minutes: 'later'}],
     ['longer than a day', {hours: 99999, minutes: 0}],

--- a/src/parks/dlp/__tests__/virtualQueue.test.ts
+++ b/src/parks/dlp/__tests__/virtualQueue.test.ts
@@ -130,6 +130,27 @@ describe('DLP virtual queue', () => {
     expect(row.queue?.RETURN_TIME).toBeUndefined();
   });
 
+  // A dormant configuration row: Disney leaves these in the wave list with
+  // both dates nulled, so they carry no evidence of having run.
+  const dormant = {waveId: 'w0', name: 'EMT', openAt: null, closedAt: null, status: 'FINISHED'};
+
+  it('does not read a dateless FINISHED wave as the day having started', async () => {
+    const row = await liveRowOf(
+      stubbedPark([morning('CLOSED'), afternoon('CLOSED'), dormant]),
+    );
+    expect(row).toBeDefined();
+    expect(row.status).toBe('CLOSED');
+    expect(row.queue?.RETURN_TIME).toBeUndefined();
+  });
+
+  it('still counts a FINISHED wave that kept its dates', async () => {
+    const row = await liveRowOf(
+      stubbedPark([morning('FINISHED'), afternoon('CLOSED'), dormant]),
+    );
+    expect(row.queue?.RETURN_TIME).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+    expect(row.status).toBe('OPERATING');
+  });
+
   it('finishes once the last wave is full', async () => {
     const row = await liveRowOf(
       stubbedPark([morning('FINISHED'), afternoon('FULL')], {nextWaveId: 'w2'}),

--- a/src/parks/dlp/__tests__/virtualQueue.test.ts
+++ b/src/parks/dlp/__tests__/virtualQueue.test.ts
@@ -118,6 +118,9 @@ describe('DLP virtual queue', () => {
       stubbedPark([morning('FULL'), afternoon('CLOSED')], {nextWaveId: 'w1'}),
     );
     expect(row.queue?.RETURN_TIME).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+    // "Come back later" says the experience is running, so the seeded CLOSED
+    // would contradict the queue it is published next to.
+    expect(row.status).toBe('OPERATING');
   });
 
   it('publishes no return time before the first wave of the day has opened', async () => {
@@ -132,11 +135,14 @@ describe('DLP virtual queue', () => {
       stubbedPark([morning('FINISHED'), afternoon('FULL')], {nextWaveId: 'w2'}),
     );
     expect(row.queue?.RETURN_TIME).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+    // Nothing left to open, so the seeded CLOSED is the honest answer.
+    expect(row.status).toBe('CLOSED');
   });
 
   it('finishes when every wave is done', async () => {
     const row = await liveRowOf(stubbedPark([morning('FINISHED'), afternoon('FINISHED')]));
     expect(row.queue?.RETURN_TIME).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+    expect(row.status).toBe('CLOSED');
   });
 
   it('never claims availability for a status it does not recognise', async () => {

--- a/src/parks/dlp/__tests__/virtualQueue.test.ts
+++ b/src/parks/dlp/__tests__/virtualQueue.test.ts
@@ -1,14 +1,18 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
  * A virtual queue's waves are the day's booking windows. Only an OPEN wave
  * takes bookings, so it alone publishes a return window; once a wave's
  * allocation is gone the queue is temporarily full for as long as a later
- * wave is still scheduled, and finished once none is.
+ * wave is still scheduled, and finished once none is. Before the first wave
+ * of the day has opened, no RETURN_TIME is published at all.
+ *
+ * The fixture is a Stage Show so these tests don't depend on which
+ * Entertainment subtypes happen to be publishable.
  */
 function stubbedPark(
-  waves: Array<Record<string, unknown>>,
+  waves: Array<Record<string, unknown>> | unknown,
   queue: Record<string, unknown> = {},
 ): DisneylandParis {
   const park = new DisneylandParis();
@@ -18,9 +22,9 @@ function stubbedPark(
     Entertainment: [
       {
         id: 'P1M115',
-        name: 'Meet Mickey Mouse',
+        name: 'Some Virtual Queue Show',
         type: 'Entertainment',
-        subType: 'Character Experience - Meet & Greet',
+        subType: 'Stage Show',
         location: {id: 'P1'},
       },
     ],
@@ -59,83 +63,123 @@ const afternoon = (status: string) => ({
   status,
 });
 
-async function returnTimeOf(park: DisneylandParis): Promise<any> {
+const MORNING_WINDOW = {
+  state: 'AVAILABLE',
+  returnStart: '2026-08-12T09:45:00+02:00',
+  returnEnd: '2026-08-12T13:30:00+02:00',
+};
+
+const AFTERNOON_WINDOW = {
+  state: 'AVAILABLE',
+  returnStart: '2026-08-12T14:00:00+02:00',
+  returnEnd: '2026-08-12T17:35:00+02:00',
+};
+
+async function liveRowOf(park: DisneylandParis): Promise<any> {
   const live = await park.getLiveData();
-  return live.find((l) => l.id === 'P1M115')?.queue?.RETURN_TIME;
+  return live.find((l) => l.id === 'P1M115');
 }
 
 describe('DLP virtual queue', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
-  it('publishes the window of an OPEN wave', async () => {
-    const queue = await returnTimeOf(stubbedPark([morning('OPEN'), afternoon('CLOSED')]));
-    expect(queue).toEqual({
-      state: 'AVAILABLE',
-      returnStart: '2026-08-12T09:45:00+02:00',
-      returnEnd: '2026-08-12T13:30:00+02:00',
-    });
+  it('publishes the window of an OPEN wave and reports the experience operating', async () => {
+    const row = await liveRowOf(stubbedPark([morning('OPEN'), afternoon('CLOSED')]));
+    expect(row).toBeDefined();
+    expect(row.queue?.RETURN_TIME).toEqual(MORNING_WINDOW);
+    expect(row.status).toBe('OPERATING');
   });
 
   it('follows nextWaveId rather than the wave order', async () => {
-    const queue = await returnTimeOf(
+    const row = await liveRowOf(
       stubbedPark([morning('FULL'), afternoon('OPEN')], {nextWaveId: 'w2'}),
     );
-    expect(queue).toEqual({
-      state: 'AVAILABLE',
-      returnStart: '2026-08-12T14:00:00+02:00',
-      returnEnd: '2026-08-12T17:35:00+02:00',
-    });
+    expect(row.queue?.RETURN_TIME).toEqual(AFTERNOON_WINDOW);
+    expect(row.status).toBe('OPERATING');
   });
+
+  // `nextWaveId` can lag a wave transition; an OPEN wave must win over it.
+  it.each([
+    ['FINISHED', 'OPEN', 'w1', AFTERNOON_WINDOW],
+    ['FULL', 'OPEN', 'w1', AFTERNOON_WINDOW],
+    ['OPEN', 'FULL', 'w2', MORNING_WINDOW],
+    ['OPEN', 'CLOSED', 'w2', MORNING_WINDOW],
+  ])('trusts a live OPEN wave over a stale nextWaveId ([%s,%s] next=%s)',
+    async (w1Status, w2Status, nextWaveId, expected) => {
+      const row = await liveRowOf(
+        stubbedPark([morning(w1Status), afternoon(w2Status)], {nextWaveId}),
+      );
+      expect(row.queue?.RETURN_TIME).toEqual(expected);
+      expect(row.status).toBe('OPERATING');
+    });
 
   it('reports temporarily full when a full wave has a later one scheduled', async () => {
-    const queue = await returnTimeOf(
+    const row = await liveRowOf(
       stubbedPark([morning('FULL'), afternoon('CLOSED')], {nextWaveId: 'w1'}),
     );
-    expect(queue).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+    expect(row.queue?.RETURN_TIME).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
   });
 
-  it('reports temporarily full before the first wave opens', async () => {
-    const queue = await returnTimeOf(stubbedPark([morning('CLOSED'), afternoon('CLOSED')]));
-    expect(queue).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+  it('publishes no return time before the first wave of the day has opened', async () => {
+    const row = await liveRowOf(stubbedPark([morning('CLOSED'), afternoon('CLOSED')]));
+    expect(row).toBeDefined();
+    expect(row.status).toBe('CLOSED');
+    expect(row.queue?.RETURN_TIME).toBeUndefined();
   });
 
   it('finishes once the last wave is full', async () => {
-    const queue = await returnTimeOf(
+    const row = await liveRowOf(
       stubbedPark([morning('FINISHED'), afternoon('FULL')], {nextWaveId: 'w2'}),
     );
-    expect(queue).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+    expect(row.queue?.RETURN_TIME).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
   });
 
   it('finishes when every wave is done', async () => {
-    const queue = await returnTimeOf(stubbedPark([morning('FINISHED'), afternoon('FINISHED')]));
-    expect(queue).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+    const row = await liveRowOf(stubbedPark([morning('FINISHED'), afternoon('FINISHED')]));
+    expect(row.queue?.RETURN_TIME).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
   });
 
   it('never claims availability for a status it does not recognise', async () => {
-    const queue = await returnTimeOf(stubbedPark([morning('SOMETHING_NEW'), afternoon('CLOSED')]));
-    expect(queue).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+    const row = await liveRowOf(stubbedPark([morning('SOMETHING_NEW'), afternoon('CLOSED')]));
+    expect(row).toBeDefined();
+    expect(row.queue?.RETURN_TIME).toBeUndefined();
   });
 
   it('accepts a status the feed reports in lower case', async () => {
-    const queue = await returnTimeOf(stubbedPark([morning('open'), afternoon('closed')]));
-    expect(queue?.state).toBe('AVAILABLE');
+    const row = await liveRowOf(stubbedPark([morning('open'), afternoon('closed')]));
+    expect(row.queue?.RETURN_TIME).toEqual(MORNING_WINDOW);
+    expect(row.status).toBe('OPERATING');
   });
 
   it.each([
     ['the waves are missing', undefined],
     ['the waves are not an array', 'nope'],
-    ['a wave is null', [null]],
-    ['a status is not a string', [{waveId: 'w1', status: 7}]],
-    ['an open wave has an unusable window', [{...morning('OPEN'), openAt: 'banana'}]],
-  ])('never publishes a bookable window when %s', async (_label, waves) => {
-    const queue = await returnTimeOf(stubbedPark(waves as any));
-    expect(queue?.state).not.toBe('AVAILABLE');
+  ])('publishes no live row when %s', async (_label, waves) => {
+    const row = await liveRowOf(stubbedPark(waves));
+    expect(row).toBeUndefined();
   });
 
-  it('publishes no queue at all while the queue is disabled', async () => {
-    const queue = await returnTimeOf(
+  it.each([
+    ['a wave is null', [null]],
+    ['a status is not a string', [{waveId: 'w1', status: 7}]],
+  ])('publishes a closed row without a return time when %s', async (_label, waves) => {
+    const row = await liveRowOf(stubbedPark(waves as any));
+    expect(row).toBeDefined();
+    expect(row.status).toBe('CLOSED');
+    expect(row.queue?.RETURN_TIME).toBeUndefined();
+  });
+
+  it('falls back to FINISHED when an open wave has an unusable window', async () => {
+    const row = await liveRowOf(stubbedPark([{...morning('OPEN'), openAt: 'banana'}]));
+    expect(row).toBeDefined();
+    expect(row.queue?.RETURN_TIME).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+    expect(row.status).toBe('CLOSED');
+  });
+
+  it('publishes no live row at all while the queue is disabled', async () => {
+    const row = await liveRowOf(
       stubbedPark([morning('OPEN'), afternoon('CLOSED')], {enabled: false}),
     );
-    expect(queue).toBeUndefined();
+    expect(row).toBeUndefined();
   });
 });

--- a/src/parks/dlp/__tests__/virtualQueue.test.ts
+++ b/src/parks/dlp/__tests__/virtualQueue.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
+import {constructDateTime, formatInTimezone} from '../../../datetime.js';
 
 /**
  * A virtual queue's waves are the day's booking windows. Only an OPEN wave
@@ -47,32 +48,52 @@ function stubbedPark(
   return park;
 }
 
-const morning = (status: string) => ({
+/**
+ * Waves are dated on the park's current date. A FINISHED wave only counts as
+ * evidence the day has started while its openAt still falls on that date, so
+ * a fixture pinned to a fixed date would stop exercising that the day after it
+ * was written.
+ */
+const PARK_TZ = 'Europe/Paris';
+const [pMM, pDD, pYYYY] = formatInTimezone(new Date(), PARK_TZ, 'date').split('/');
+const TODAY = `${pYYYY}-${pMM}-${pDD}`;
+
+const YESTERDAY = (() => {
+  const d = new Date(`${TODAY}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+})();
+
+// Park-local wall clock to an instant, so the fixture carries the offset in
+// force on that date rather than a hardcoded one.
+const at = (date: string, time: string) => constructDateTime(date, time, PARK_TZ);
+
+const morning = (status: string, date: string = TODAY) => ({
   waveId: 'w1',
   name: 'morning',
-  openAt: '2026-08-12T09:45:00.000+0200',
-  closedAt: '2026-08-12T13:30:00.000+0200',
+  openAt: at(date, '09:45'),
+  closedAt: at(date, '13:30'),
   status,
 });
 
-const afternoon = (status: string) => ({
+const afternoon = (status: string, date: string = TODAY) => ({
   waveId: 'w2',
   name: 'afternoon',
-  openAt: '2026-08-12T14:00:00.000+0200',
-  closedAt: '2026-08-12T17:35:00.000+0200',
+  openAt: at(date, '14:00'),
+  closedAt: at(date, '17:35'),
   status,
 });
 
 const MORNING_WINDOW = {
   state: 'AVAILABLE',
-  returnStart: '2026-08-12T09:45:00+02:00',
-  returnEnd: '2026-08-12T13:30:00+02:00',
+  returnStart: at(TODAY, '09:45'),
+  returnEnd: at(TODAY, '13:30'),
 };
 
 const AFTERNOON_WINDOW = {
   state: 'AVAILABLE',
-  returnStart: '2026-08-12T14:00:00+02:00',
-  returnEnd: '2026-08-12T17:35:00+02:00',
+  returnStart: at(TODAY, '14:00'),
+  returnEnd: at(TODAY, '17:35'),
 };
 
 async function liveRowOf(park: DisneylandParis): Promise<any> {
@@ -137,6 +158,24 @@ describe('DLP virtual queue', () => {
   it('does not read a dateless FINISHED wave as the day having started', async () => {
     const row = await liveRowOf(
       stubbedPark([morning('CLOSED'), afternoon('CLOSED'), dormant]),
+    );
+    expect(row).toBeDefined();
+    expect(row.status).toBe('CLOSED');
+    expect(row.queue?.RETURN_TIME).toBeUndefined();
+  });
+
+  // Yesterday's wave, still dated, as the feed would hold it past midnight.
+  const stale = {
+    waveId: 'wY',
+    name: 'yesterday',
+    openAt: at(YESTERDAY, '09:45'),
+    closedAt: at(YESTERDAY, '13:30'),
+    status: 'FINISHED',
+  };
+
+  it('does not read yesterday\'s dated FINISHED wave as the day having started', async () => {
+    const row = await liveRowOf(
+      stubbedPark([stale, morning('CLOSED'), afternoon('CLOSED')]),
     );
     expect(row).toBeDefined();
     expect(row.status).toBe('CLOSED');

--- a/src/parks/dlp/__tests__/virtualQueue.test.ts
+++ b/src/parks/dlp/__tests__/virtualQueue.test.ts
@@ -1,0 +1,141 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * A virtual queue's waves are the day's booking windows. Only an OPEN wave
+ * takes bookings, so it alone publishes a return window; once a wave's
+ * allocation is gone the queue is temporarily full for as long as a later
+ * wave is still scheduled, and finished once none is.
+ */
+function stubbedPark(
+  waves: Array<Record<string, unknown>>,
+  queue: Record<string, unknown> = {},
+): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Entertainment: [
+      {
+        id: 'P1M115',
+        name: 'Meet Mickey Mouse',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P1'},
+      },
+    ],
+  });
+
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([
+    {
+      queueId: 'q1',
+      enabled: true,
+      queueContentId: 'P1M115',
+      activityId: 'HeroTrainingCenter',
+      waves,
+      ...queue,
+    },
+  ]);
+
+  return park;
+}
+
+const morning = (status: string) => ({
+  waveId: 'w1',
+  name: 'morning',
+  openAt: '2026-08-12T09:45:00.000+0200',
+  closedAt: '2026-08-12T13:30:00.000+0200',
+  status,
+});
+
+const afternoon = (status: string) => ({
+  waveId: 'w2',
+  name: 'afternoon',
+  openAt: '2026-08-12T14:00:00.000+0200',
+  closedAt: '2026-08-12T17:35:00.000+0200',
+  status,
+});
+
+async function returnTimeOf(park: DisneylandParis): Promise<any> {
+  const live = await park.getLiveData();
+  return live.find((l) => l.id === 'P1M115')?.queue?.RETURN_TIME;
+}
+
+describe('DLP virtual queue', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('publishes the window of an OPEN wave', async () => {
+    const queue = await returnTimeOf(stubbedPark([morning('OPEN'), afternoon('CLOSED')]));
+    expect(queue).toEqual({
+      state: 'AVAILABLE',
+      returnStart: '2026-08-12T09:45:00+02:00',
+      returnEnd: '2026-08-12T13:30:00+02:00',
+    });
+  });
+
+  it('follows nextWaveId rather than the wave order', async () => {
+    const queue = await returnTimeOf(
+      stubbedPark([morning('FULL'), afternoon('OPEN')], {nextWaveId: 'w2'}),
+    );
+    expect(queue).toEqual({
+      state: 'AVAILABLE',
+      returnStart: '2026-08-12T14:00:00+02:00',
+      returnEnd: '2026-08-12T17:35:00+02:00',
+    });
+  });
+
+  it('reports temporarily full when a full wave has a later one scheduled', async () => {
+    const queue = await returnTimeOf(
+      stubbedPark([morning('FULL'), afternoon('CLOSED')], {nextWaveId: 'w1'}),
+    );
+    expect(queue).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+  });
+
+  it('reports temporarily full before the first wave opens', async () => {
+    const queue = await returnTimeOf(stubbedPark([morning('CLOSED'), afternoon('CLOSED')]));
+    expect(queue).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+  });
+
+  it('finishes once the last wave is full', async () => {
+    const queue = await returnTimeOf(
+      stubbedPark([morning('FINISHED'), afternoon('FULL')], {nextWaveId: 'w2'}),
+    );
+    expect(queue).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+  });
+
+  it('finishes when every wave is done', async () => {
+    const queue = await returnTimeOf(stubbedPark([morning('FINISHED'), afternoon('FINISHED')]));
+    expect(queue).toEqual({state: 'FINISHED', returnStart: null, returnEnd: null});
+  });
+
+  it('never claims availability for a status it does not recognise', async () => {
+    const queue = await returnTimeOf(stubbedPark([morning('SOMETHING_NEW'), afternoon('CLOSED')]));
+    expect(queue).toEqual({state: 'TEMP_FULL', returnStart: null, returnEnd: null});
+  });
+
+  it('accepts a status the feed reports in lower case', async () => {
+    const queue = await returnTimeOf(stubbedPark([morning('open'), afternoon('closed')]));
+    expect(queue?.state).toBe('AVAILABLE');
+  });
+
+  it.each([
+    ['the waves are missing', undefined],
+    ['the waves are not an array', 'nope'],
+    ['a wave is null', [null]],
+    ['a status is not a string', [{waveId: 'w1', status: 7}]],
+    ['an open wave has an unusable window', [{...morning('OPEN'), openAt: 'banana'}]],
+  ])('never publishes a bookable window when %s', async (_label, waves) => {
+    const queue = await returnTimeOf(stubbedPark(waves as any));
+    expect(queue?.state).not.toBe('AVAILABLE');
+  });
+
+  it('publishes no queue at all while the queue is disabled', async () => {
+    const queue = await returnTimeOf(
+      stubbedPark([morning('OPEN'), afternoon('CLOSED')], {enabled: false}),
+    );
+    expect(queue).toBeUndefined();
+  });
+});

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -11,7 +11,10 @@ import {DisneylandParis} from '../disneylandparis.js';
 function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
   vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
-    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    ThemePark: [
+      {id: 'P1', name: 'Disneyland Park', type: 'ThemePark'},
+      {id: 'P2', name: 'Disney Adventure World', type: 'ThemePark'},
+    ],
     Attraction: [
       {
         id: 'P1DA10',
@@ -88,6 +91,32 @@ function stubbedPark(): DisneylandParis {
         type: 'Entertainment',
         subType: 'Stage Show',
         location: {id: 'P1'},
+      },
+      {
+        id: 'P2MG33',
+        name: 'Spider-Man Heroic Encounter',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P2'},
+        hideFunctionality: 'Hide from the Service',
+      },
+      {
+        id: 'P2MG43',
+        name: 'MARVEL Super Hero Heroic Encounter',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P2'},
+        hideFunctionality: 'Hide from the Service',
+      },
+      {
+        // Control: the retired twin of a published meet & greet, carrying the
+        // same flag but no virtual queue — must stay dropped.
+        id: 'P2MG59',
+        name: 'Meet a Toy Story Character',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P2'},
+        hideFunctionality: 'Hide from the Service',
       },
     ],
   });
@@ -174,5 +203,20 @@ describe('DLP visibility exceptions', () => {
   it('publishes a show flagged "Hide from the Mobile App"', async () => {
     const entities = await stubbedPark().getEntities();
     expect(entities.find((e) => e.id === 'P1G108')?.entityType).toBe('SHOW');
+  });
+
+  it('surfaces the two Heroic Encounters despite their "Hide from the Service" flag', async () => {
+    const entities = await stubbedPark().getEntities();
+    for (const id of ['P2MG33', 'P2MG43']) {
+      const meet = entities.find((e) => e.id === id);
+      expect(meet, id).toBeDefined();
+      expect(meet?.entityType).toBe('SHOW');
+      expect((meet as any)?.parkId).toBe('P2');
+    }
+  });
+
+  it('still drops a retired meet & greet carrying the same flag', async () => {
+    const entities = await stubbedPark().getEntities();
+    expect(entities.find((e) => e.id === 'P2MG59')).toBeUndefined();
   });
 });

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -8,12 +8,35 @@ import {DisneylandParis} from '../disneylandparis.js';
  * Heroic Encounters are all live despite their flags, so each must be
  * force-surfaced while flagged records outside the set stay filtered.
  *
+ * Meet & greets carry a second gate on top: Disney lists 22 and 8 of them have
+ * no performance in the published window and no virtual queue switched on, so
+ * those wait until they have something to show.
+ *
  * Mickey's PhilharMagic exists twice in POI — published Entertainment record
  * P1G103 and hidden Attraction twin P1DA13 — and must surface exactly once, as
  * P1G103, with the twin's live and schedule data folded onto it.
  */
-function stubbedPark(): DisneylandParis {
+
+/**
+ * Ids the schedule feed carries rows for. Stubbed at the sweep rather than at
+ * getScheduleForDate: the sweep is cached under a fixed key, so a real one
+ * would leak the first test's answer into every later test in this file.
+ *
+ * P1G108 is deliberately absent — it is a Stage Show, and the gate must leave
+ * everything that is not a meet & greet alone. P2MG59 is deliberately present,
+ * so that it can only be dropped by its retirement flag.
+ */
+const SCHEDULED_IDS = ['P1MG10', 'P2MG31', 'P1MG21', 'P1MG05', 'P2MG59', 'P1G103', 'P1DA13'];
+
+function stubbedPark(opts: {
+  scheduledIds?: string[] | null;
+  queues?: unknown[];
+} = {}): DisneylandParis {
   const park = new DisneylandParis();
+  vi.spyOn(park as any, 'getScheduledActivityIds').mockResolvedValue(
+    opts.scheduledIds === undefined ? SCHEDULED_IDS : opts.scheduledIds,
+  );
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue(opts.queues ?? []);
   vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
     ThemePark: [
       {id: 'P1', name: 'Disneyland Park', type: 'ThemePark'},
@@ -154,15 +177,24 @@ function stubbedPark(): DisneylandParis {
         subType: 'Character Experience - Meet & Greet',
         location: {id: 'P1'},
       },
+      {
+        // Unflagged too, but no performance anywhere in the window and no
+        // queue: one of the 8 that would publish as a bare record.
+        id: 'P1MG99',
+        name: 'Meet Nobody in Particular',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P1'},
+      },
     ],
   });
   return park;
 }
 
-function stubLiveFeeds(park: DisneylandParis, waitTimes: unknown[] = []): void {
+function stubLiveFeeds(park: DisneylandParis, waitTimes: unknown[] = [], queues: unknown[] = []): void {
   vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue(waitTimes);
   vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
-  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue(queues);
 }
 
 describe('DLP visibility exceptions', () => {
@@ -259,18 +291,77 @@ describe('DLP visibility exceptions', () => {
     expect(entities.find((e) => e.id === 'P1G108')?.entityType).toBe('SHOW');
   });
 
-  it('surfaces the two Heroic Encounters despite their "Hide from the Service" flag', async () => {
+  it('still drops a retired meet & greet carrying the same flag', async () => {
+    // P2MG59 is in SCHEDULED_IDS, so only its flag can be dropping it.
     const entities = await stubbedPark().getEntities();
-    for (const id of ['P2MG33', 'P2MG43']) {
-      const meet = entities.find((e) => e.id === id);
-      expect(meet, id).toBeDefined();
-      expect(meet?.entityType).toBe('SHOW');
-      expect((meet as any)?.parkId).toBe('P2');
+    expect(entities.find((e) => e.id === 'P2MG59')).toBeUndefined();
+  });
+});
+
+describe('DLP meet & greets without data', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('holds back a meet & greet with no performance and no queue', async () => {
+    const entities = await stubbedPark().getEntities();
+    // Unflagged, and flagged-but-excepted, alike: the gate is the data.
+    for (const id of ['P1MG99', 'P2MG33', 'P2MG43']) {
+      expect(entities.find((e) => e.id === id), id).toBeUndefined();
     }
   });
 
-  it('still drops a retired meet & greet carrying the same flag', async () => {
+  it('publishes a meet & greet once its virtual queue is switched on', async () => {
+    const park = stubbedPark({
+      queues: [{queueContentId: 'P2MG33', enabled: true, queueId: 'q1', activityId: 'a1', waves: []}],
+    });
+    const entities = await park.getEntities();
+    const meet = entities.find((e) => e.id === 'P2MG33');
+    expect(meet).toBeDefined();
+    expect(meet?.entityType).toBe('SHOW');
+    expect((meet as any)?.parkId).toBe('P2');
+    // Its twin has no queue of its own and stays out.
+    expect(entities.find((e) => e.id === 'P2MG43')).toBeUndefined();
+  });
+
+  it('keeps a disabled queue out', async () => {
+    const park = stubbedPark({
+      queues: [{queueContentId: 'P2MG33', enabled: false, queueId: 'q1', activityId: 'a1', waves: []}],
+    });
+    const entities = await park.getEntities();
+    expect(entities.find((e) => e.id === 'P2MG33')).toBeUndefined();
+  });
+
+  it('leaves entities that are not meet & greets alone', async () => {
+    // P1G108 carries no schedule rows in the fixture and must publish anyway.
     const entities = await stubbedPark().getEntities();
-    expect(entities.find((e) => e.id === 'P2MG59')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'P1G108')?.entityType).toBe('SHOW');
+    expect(entities.find((e) => e.id === 'P1DA10')?.entityType).toBe('ATTRACTION');
+  });
+
+  it('publishes every meet & greet when the schedule feed answers with nothing', async () => {
+    // An outage must widen the set, not empty it — a cached empty answer would
+    // otherwise unpublish 22 entities for 12 hours.
+    const entities = await stubbedPark({scheduledIds: null}).getEntities();
+    for (const id of ['P1MG99', 'P2MG33', 'P2MG43', 'P1MG10']) {
+      expect(entities.find((e) => e.id === id), id).toBeDefined();
+    }
+  });
+
+  it('leaves no orphan schedule behind for a held-back meet & greet', async () => {
+    // buildSchedules filters on the same gate, so a schedule row the feed
+    // does carry must not outlive the entity it belongs to.
+    const park = stubbedPark();
+    vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue([
+      {
+        id: 'P1MG99',
+        name: 'Meet Nobody in Particular',
+        location: {id: 'P1'},
+        schedules: [{
+          date: '2026-08-20', startTime: '11:00', endTime: '11:30',
+          status: 'PERFORMANCE_TIME',
+        }],
+      },
+    ]);
+    const schedules = await park.getSchedules();
+    expect(schedules.find((s) => s.id === 'P1MG99')).toBeUndefined();
   });
 });

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -2,11 +2,15 @@ import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
- * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES); entities
- * in VISIBILITY_EXCEPTIONS bypass that. Mickey's PhilharMagic exists twice in
- * POI — published Entertainment record P1G103 and hidden Attraction twin
- * P1DA13 — and must surface exactly once, as P1G103, with the twin's live
- * and schedule data folded onto it.
+ * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES). Entities
+ * listed in VISIBILITY_EXCEPTIONS bypass that: P1GS93 ("Live Your Story"), the
+ * two railroad stations, three schedule-backed meet & greets and the two
+ * Heroic Encounters are all live despite their flags, so each must be
+ * force-surfaced while flagged records outside the set stay filtered.
+ *
+ * Mickey's PhilharMagic exists twice in POI — published Entertainment record
+ * P1G103 and hidden Attraction twin P1DA13 — and must surface exactly once, as
+ * P1G103, with the twin's live and schedule data folded onto it.
  */
 function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
@@ -118,6 +122,38 @@ function stubbedPark(): DisneylandParis {
         location: {id: 'P2'},
         hideFunctionality: 'Hide from the Service',
       },
+      {
+        id: 'P2MG31',
+        name: 'Meet Goofy, the Movie Director',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P2'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+      {
+        id: 'P1MG21',
+        name: 'An Encounter with Captain Hook',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+      {
+        id: 'P1MG05',
+        name: 'Meet Donald Duck or his friends',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from Web List + Mobile App',
+      },
+      {
+        // Unflagged meet & greet — the common case this branch turns on.
+        id: 'P1MG10',
+        name: 'Meet Mickey Mouse',
+        type: 'Entertainment',
+        subType: 'Character Experience - Meet & Greet',
+        location: {id: 'P1'},
+      },
     ],
   });
   return park;
@@ -131,6 +167,24 @@ function stubLiveFeeds(park: DisneylandParis, waitTimes: unknown[] = []): void {
 
 describe('DLP visibility exceptions', () => {
   afterEach(() => vi.restoreAllMocks());
+
+  it('publishes an unflagged meet & greet as a SHOW entity', async () => {
+    const entities = await stubbedPark().getEntities();
+    const meet = entities.find((e) => e.id === 'P1MG10');
+    expect(meet).toBeDefined();
+    expect(meet?.entityType).toBe('SHOW');
+    expect((meet as any)?.parkId).toBe('P1');
+  });
+
+  it('surfaces the three schedule-backed meet & greets despite their retirement flag', async () => {
+    const entities = await stubbedPark().getEntities();
+    for (const [id, parkId] of [['P2MG31', 'P2'], ['P1MG21', 'P1'], ['P1MG05', 'P1']]) {
+      const meet = entities.find((e) => e.id === id);
+      expect(meet, id).toBeDefined();
+      expect(meet?.entityType).toBe('SHOW');
+      expect((meet as any)?.parkId).toBe(parkId);
+    }
+  });
 
   it('surfaces railroad stations flagged Hide from Web List + Mobile App', async () => {
     const entities = await stubbedPark().getEntities();

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -33,8 +33,14 @@ function stubbedPark(opts: {
   queues?: unknown[];
 } = {}): DisneylandParis {
   const park = new DisneylandParis();
+  // null stands for the outage: the sweep reports it as answered: false rather
+  // than as a null return, because a cached null reads back as a cache miss.
   vi.spyOn(park as any, 'getScheduledActivityIds').mockResolvedValue(
-    opts.scheduledIds === undefined ? SCHEDULED_IDS : opts.scheduledIds,
+    opts.scheduledIds === undefined
+      ? {answered: true, ids: SCHEDULED_IDS}
+      : opts.scheduledIds === null
+        ? {answered: false, ids: []}
+        : {answered: true, ids: opts.scheduledIds},
   );
   vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue(opts.queues ?? []);
   vi.spyOn(park as any, 'getPOIData').mockResolvedValue({

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -96,6 +96,9 @@ const MAX_HEIGHT_CM = 200;
  * baseline alive while the 12h POI cache lags. */
 const SINGLE_RIDER_RECENT_SECONDS = 48 * 60 * 60;
 
+/** Upper bound for a show length; a slot longer than a day is bad data */
+const MAX_SHOW_DURATION_MINUTES = 24 * 60;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -178,6 +181,20 @@ function parseDLPWait(v: unknown): number | undefined {
   if (v === null || v === undefined || v === '') return undefined;
   const n = typeof v === 'number' ? v : Number(v);
   return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Total length of a show in whole minutes, or 0 when the API omits the
+ * duration or reports something unusable. Callers fall back to the schedule
+ * feed's own end time on 0.
+ */
+function showDurationMinutes(duration: DLPPOIEntity['duration']): number {
+  if (!duration) return 0;
+  const hours = Number(duration.hours ?? 0);
+  const minutes = Number(duration.minutes ?? 0);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return 0;
+  const total = Math.round(hours * 60 + minutes);
+  return total > 0 && total <= MAX_SHOW_DURATION_MINUTES ? total : 0;
 }
 
 /**
@@ -274,9 +291,6 @@ export class DisneylandParis extends Destination {
 
   @config
   timezone: string = 'Europe/Paris';
-
-  /** Cache of show entities with duration data (populated during entity building) */
-  private showDurationMap: Map<string, number> = new Map();
 
   constructor(options?: DestinationConstructor) {
     super(options);
@@ -433,6 +447,12 @@ export class DisneylandParis extends Destination {
           }
           Entertainment: activities(market: $market, types: "Entertainment") {
             ${this.entityFields}
+            ... on Entertainment {
+              duration {
+                hours
+                minutes
+              }
+            }
           }
           Event: activities(market: $market, types: "Event") {
             ${this.entityFields}
@@ -844,9 +864,6 @@ export class DisneylandParis extends Destination {
       },
     });
 
-    // Clear show duration map (rebuilt each time)
-    this.showDurationMap.clear();
-
     // Build attraction, show, and restaurant entities
     const entityEntries: Entity[] = [];
     for (const poi of filteredEntities) {
@@ -874,14 +891,6 @@ export class DisneylandParis extends Destination {
       }
 
       entity.tags = entityType === 'ATTRACTION' ? this.buildTags(poi) : [];
-
-      // Store show duration for live data
-      if (entityType === 'SHOW' && poi.duration) {
-        const durationMinutes = (poi.duration.minutes || 0) + ((poi.duration.hours || 0) * 60);
-        if (durationMinutes > 0) {
-          this.showDurationMap.set(poi.id, durationMinutes);
-        }
-      }
 
       entityEntries.push(entity);
     }
@@ -1012,6 +1021,13 @@ export class DisneylandParis extends Destination {
     // `todayStr` (YYYY-MM-DD in park tz) is computed at the top of this method.
     // The payload is shared with the dining block below.
     let todaySchedules: DLPScheduleActivityEntry[] = [];
+
+    const showDurations = new Map<string, number>();
+    for (const poi of emittablePois) {
+      const minutes = showDurationMinutes(poi.duration);
+      if (minutes > 0) showDurations.set(poi.id, minutes);
+    }
+
     try {
       todaySchedules = await this.getScheduleForDate(todayStr);
     } catch (e) {
@@ -1024,7 +1040,7 @@ export class DisneylandParis extends Destination {
         const performances = sched.schedules.filter((s) => s.status === 'PERFORMANCE_TIME');
         if (performances.length === 0) continue;
 
-        const showDuration = this.showDurationMap.get(sched.id) || 0;
+        const showDuration = showDurations.get(sched.id) || 0;
 
         const showtimes = performances.map((p) => {
           const startTime = constructDateTime(todayStr, p.startTime, this.timezone);

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -196,7 +196,6 @@ function showDurationMinutes(duration: DLPPOIEntity['duration']): number {
   if (!duration) return 0;
   const hours = Number(duration.hours ?? 0);
   const minutes = Number(duration.minutes ?? 0);
-  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return 0;
   const total = Math.round(hours * 60 + minutes);
   return total > 0 && total <= MAX_SHOW_DURATION_MINUTES ? total : 0;
 }
@@ -1006,27 +1005,41 @@ export class DisneylandParis extends Destination {
       const waves = Array.isArray(q.waves) ? q.waves : [];
       if (waves.length === 0) continue;
 
+      // A live OPEN wave wins over `nextWaveId`, which can lag a transition.
       const pending = waves.filter((w) => waveStatus(w) !== 'FINISHED');
       const activeWave =
-        (q.nextWaveId && waves.find((w) => w?.waveId === q.nextWaveId)) || pending[0];
+        waves.find((w) => waveStatus(w) === 'OPEN') ||
+        (q.nextWaveId && waves.find((w) => w?.waveId === q.nextWaveId)) ||
+        pending[0];
 
       const ld = getOrCreate(q.queueContentId);
       if (!ld) continue;
-      if (!ld.queue) ld.queue = {};
+
+      // Overnight every wave reads CLOSED; publishing TEMP_FULL there would
+      // be wrong, so no RETURN_TIME until a wave has actually been in play.
+      const dayStarted = waves.some((w) =>
+        ['OPEN', 'FULL', 'FINISHED'].includes(waveStatus(w)));
+      if (!dayStarted) continue;
 
       const open = waveStatus(activeWave) === 'OPEN';
       const from = open ? parseDLPDate(activeWave?.openAt ?? null) : null;
       const until = open ? parseDLPDate(activeWave?.closedAt ?? null) : null;
 
+      if (!ld.queue) ld.queue = {};
+
       // AVAILABLE has to carry a window, so a wave that reads open without a
       // usable one falls back with the rest.
-      ld.queue.RETURN_TIME = from && until
-        ? this.buildReturnTimeQueue('AVAILABLE', from, until)
-        : this.buildReturnTimeQueue(
+      if (from && until) {
+        // A bookable window means the experience is running.
+        ld.status = 'OPERATING';
+        ld.queue.RETURN_TIME = this.buildReturnTimeQueue('AVAILABLE', from, until);
+      } else {
+        ld.queue.RETURN_TIME = this.buildReturnTimeQueue(
           waves.some((w) => waveStatus(w) === 'CLOSED') ? 'TEMP_FULL' : 'FINISHED',
           null,
           null,
         );
+      }
     }
 
     // === Show Times (from today's schedule) ===

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1091,10 +1091,21 @@ export class DisneylandParis extends Destination {
       const ld = getOrCreate(q.queueContentId);
       if (!ld) continue;
 
-      // Overnight every wave reads CLOSED; publishing TEMP_FULL there would
-      // be wrong, so no RETURN_TIME until a wave has actually been in play.
-      const dayStarted = waves.some((w) =>
-        ['OPEN', 'FULL', 'FINISHED'].includes(waveStatus(w)));
+      // Overnight every wave that matters reads CLOSED; publishing TEMP_FULL
+      // there would be wrong, so no RETURN_TIME until a wave has actually
+      // been in play.
+      //
+      // A FINISHED wave only counts as evidence of that while it still holds
+      // its dates. The list is not today's waves: Disney keeps dormant rows
+      // in it, FINISHED with openAt and closedAt nulled, and retires the
+      // day's real waves into that same shape once they have passed. Reading
+      // a dateless one as history is enough to publish "temporarily full,
+      // come back later" through a night when nothing has opened.
+      const dayStarted = waves.some((w) => {
+        const status = waveStatus(w);
+        if (status === 'OPEN' || status === 'FULL') return true;
+        return status === 'FINISHED' && parseDLPDate(w?.openAt ?? null) !== null;
+      });
       if (!dayStarted) continue;
 
       const open = waveStatus(activeWave) === 'OPEN';

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -44,6 +44,10 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P2MG31', // Meet Goofy, the Movie Director
   'P1MG21', // An Encounter with Captain Hook
   'P1MG05', // Meet Donald Duck or his friends
+  // Also flagged "Hide from the Service", but both run a live virtual queue:
+  // enabled, with booking waves dated to the day being served.
+  'P2MG33', // Spider-Man Heroic Encounter
+  'P2MG43', // MARVEL Super Hero Heroic Encounter
 ]);
 
 /**

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -239,6 +239,15 @@ type DLPVQueueResponse = {
   queues?: DLPVQueueEntry[];
 };
 
+/**
+ * A wave's status, upper-cased: `OPEN`, `CLOSED`, `FULL` or `FINISHED`.
+ * Anything the feed reports in another shape becomes the empty string, which
+ * no caller treats as bookable.
+ */
+function waveStatus(wave: DLPVQueueWave | null | undefined): string {
+  return typeof wave?.status === 'string' ? wave.status.toUpperCase() : '';
+}
+
 type DLPScheduleActivityEntry = {
   id: string;
   name?: string;
@@ -981,40 +990,39 @@ export class DisneylandParis extends Destination {
     }
 
     // === Virtual Queue (free return time) ===
-    // Each queue's waves array is ordered chronologically by openAt; the
-    // next wave that still has capacity is the one to surface. If all
-    // waves have status FINISHED, the queue's done for the day.
+    // Waves are the day's booking windows, ordered chronologically, with
+    // `nextWaveId` marking the one in play. Only an OPEN wave takes
+    // bookings: CLOSED is scheduled to open later, FULL is that wave's
+    // allocation gone, FINISHED is done with. A return window is therefore
+    // published only for an OPEN wave, and the queue counts as temporarily
+    // full for as long as a CLOSED wave is still to come.
     const vqueueData = await this.getVirtualQueueData();
     for (const q of vqueueData) {
-      if (!q.queueContentId || q.enabled === false) continue;
-      const waves = q.waves ?? [];
+      if (!q?.queueContentId || q.enabled === false) continue;
+      const waves = Array.isArray(q.waves) ? q.waves : [];
       if (waves.length === 0) continue;
 
+      const pending = waves.filter((w) => waveStatus(w) !== 'FINISHED');
       const activeWave =
-        (q.nextWaveId && waves.find((w) => w.waveId === q.nextWaveId)) ||
-        waves.find((w) => (w.status || '').toUpperCase() !== 'FINISHED');
-
-      const allFinished = waves.every(
-        (w) => (w.status || '').toUpperCase() === 'FINISHED',
-      );
+        (q.nextWaveId && waves.find((w) => w?.waveId === q.nextWaveId)) || pending[0];
 
       const ld = getOrCreate(q.queueContentId);
       if (!ld) continue;
       if (!ld.queue) ld.queue = {};
 
-      if (allFinished || !activeWave) {
-        ld.queue.RETURN_TIME = this.buildReturnTimeQueue('FINISHED', null, null);
-      } else {
-        // Wave statuses observed: CLOSED (scheduled, not yet open), FINISHED,
-        // and presumably OPEN/AVAILABLE when actively booking. Anything
-        // non-FINISHED surfaces as AVAILABLE with the wave's window so the
-        // wiki can render the upcoming slot.
-        ld.queue.RETURN_TIME = this.buildReturnTimeQueue(
-          'AVAILABLE',
-          parseDLPDate(activeWave.openAt ?? null),
-          parseDLPDate(activeWave.closedAt ?? null),
+      const open = waveStatus(activeWave) === 'OPEN';
+      const from = open ? parseDLPDate(activeWave?.openAt ?? null) : null;
+      const until = open ? parseDLPDate(activeWave?.closedAt ?? null) : null;
+
+      // AVAILABLE has to carry a window, so a wave that reads open without a
+      // usable one falls back with the rest.
+      ld.queue.RETURN_TIME = from && until
+        ? this.buildReturnTimeQueue('AVAILABLE', from, until)
+        : this.buildReturnTimeQueue(
+          waves.some((w) => waveStatus(w) === 'CLOSED') ? 'TEMP_FULL' : 'FINISHED',
+          null,
+          null,
         );
-      }
     }
 
     // === Show Times (from today's schedule) ===

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -825,9 +825,9 @@ export class DisneylandParis extends Destination {
    */
   private async getMeetAndGreetIdsWithData(): Promise<Set<string> | null> {
     const scheduled = await this.getScheduledActivityIds();
-    if (scheduled === null) return null;
+    if (!scheduled.answered) return null;
 
-    const ids = new Set(scheduled);
+    const ids = new Set(scheduled.ids);
     try {
       for (const queue of await this.getVirtualQueueData()) {
         if (queue?.queueContentId && queue.enabled !== false) ids.add(queue.queueContentId);
@@ -842,13 +842,17 @@ export class DisneylandParis extends Destination {
    * Ids the schedule feed carries rows for, across the same window
    * buildSchedules publishes.
    *
-   * Returns null when no day in that window came back with a single row.
-   * DLP always publishes park hours, so that is an outage rather than a quiet
-   * estate — and a cached empty answer must not be allowed to unpublish
+   * `answered` is false when no day in that window came back with a single
+   * row. DLP always publishes park hours, so that is an outage rather than a
+   * quiet estate — and a cached empty answer must not be allowed to unpublish
    * entities, the same trap #296 closed for schedules.
+   *
+   * The outage carries a flag rather than a null return because CacheLib reads
+   * a cached null as a miss: a null here would re-run the 60-day sweep on every
+   * call, from all three public entry points, for as long as the feed is down.
    */
   @cache({ttlSeconds: 43200, key: 'dlp:getScheduledActivityIds'})
-  private async getScheduledActivityIds(): Promise<string[] | null> {
+  private async getScheduledActivityIds(): Promise<{answered: boolean; ids: string[]}> {
     const now = new Date();
     const ids = new Set<string>();
     let answered = false;
@@ -868,7 +872,7 @@ export class DisneylandParis extends Destination {
       }
     }
 
-    return answered ? [...ids] : null;
+    return {answered, ids: [...ids]};
   }
 
   /**

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1080,6 +1080,12 @@ export class DisneylandParis extends Destination {
     // published only for an OPEN wave, and the queue counts as temporarily
     // full for as long as a CLOSED wave is still to come.
     const vqueueData = await this.getVirtualQueueData();
+    const openedToday = (v: string | null | undefined): boolean => {
+      const d = parseDLPDate(v);
+      if (!d) return false;
+      const [wMM, wDD, wYYYY] = formatInTimezone(d, this.timezone, 'date').split('/');
+      return `${wYYYY}-${wMM}-${wDD}` === todayStr;
+    };
     for (const q of vqueueData) {
       if (!q?.queueContentId || q.enabled === false) continue;
       const waves = Array.isArray(q.waves) ? q.waves : [];
@@ -1100,15 +1106,17 @@ export class DisneylandParis extends Destination {
       // been in play.
       //
       // A FINISHED wave only counts as evidence of that while it still holds
-      // its dates. The list is not today's waves: Disney keeps dormant rows
-      // in it, FINISHED with openAt and closedAt nulled, and retires the
-      // day's real waves into that same shape once they have passed. Reading
-      // a dateless one as history is enough to publish "temporarily full,
-      // come back later" through a night when nothing has opened.
+      // an openAt falling on the current park date. The list is not today's
+      // waves: Disney keeps dormant rows in it, FINISHED with openAt and
+      // closedAt nulled, and retires the day's real waves into that same
+      // shape once they have passed. Reading a dateless one as history is
+      // enough to publish "temporarily full, come back later" through a night
+      // when nothing has opened, and a stale dated one would do the same if
+      // the feed ever held yesterday's waves past midnight.
       const dayStarted = waves.some((w) => {
         const status = waveStatus(w);
         if (status === 'OPEN' || status === 'FULL') return true;
-        return status === 'FINISHED' && parseDLPDate(w?.openAt ?? null) !== null;
+        return status === 'FINISHED' && openedToday(w?.openAt ?? null);
       });
       if (!dayStarted) continue;
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -510,7 +510,7 @@ export class DisneylandParis extends Destination {
   /**
    * Get POI data (cached 12h)
    */
-  @cache({ttlSeconds: 43200, cacheVersion: 4})
+  @cache({ttlSeconds: 43200, cacheVersion: 5})
   async getPOIData(): Promise<Record<string, DLPPOIEntity[]>> {
     const resp = await this.fetchPOI();
     const data = await resp.json();

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1109,12 +1109,14 @@ export class DisneylandParis extends Destination {
         // A bookable window means the experience is running.
         ld.status = 'OPERATING';
         ld.queue.RETURN_TIME = this.buildReturnTimeQueue('AVAILABLE', from, until);
+      } else if (waves.some((w) => waveStatus(w) === 'CLOSED')) {
+        // "Full, come back later" says the experience is running too — a
+        // later wave is still scheduled to open.
+        ld.status = 'OPERATING';
+        ld.queue.RETURN_TIME = this.buildReturnTimeQueue('TEMP_FULL', null, null);
       } else {
-        ld.queue.RETURN_TIME = this.buildReturnTimeQueue(
-          waves.some((w) => waveStatus(w) === 'CLOSED') ? 'TEMP_FULL' : 'FINISHED',
-          null,
-          null,
-        );
+        // Nothing left to open today, so the seeded CLOSED is the truth.
+        ld.queue.RETURN_TIME = this.buildReturnTimeQueue('FINISHED', null, null);
       }
     }
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -37,10 +37,13 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P2DA00', // Tangled Spin
   'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
   // Disney flags these "Hide from Web List + Mobile App", which it otherwise uses as a
-  // retirement marker (every old-/-OLD record carries it). These two are live and still
-  // report wait times, so they are the only members of that flag we surface.
+  // retirement marker (every old-/-OLD record carries it). Each one is live even so:
+  // the stations report wait times, the meet & greets hold performance times.
   'P1DA10', // Disneyland Railroad Discoveryland Station
   'P1NA16', // Disneyland Railroad Fantasyland Station
+  'P2MG31', // Meet Goofy, the Movie Director
+  'P1MG21', // An Encounter with Captain Hook
+  'P1MG05', // Meet Donald Duck or his friends
 ]);
 
 /**
@@ -76,6 +79,7 @@ const SHOW_SUBTYPES = new Set([
   'Fireworks',
   'Atmosphere',
   'Parade',
+  'Character Experience - Meet & Greet',
 ]);
 
 /** Wall-clock time the schedule feed publishes, e.g. `21:30:00`.

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -77,14 +77,19 @@ const HIDE_RULES = new Set([
   'Hide from the Service',
 ]);
 
+const MEET_AND_GREET_SUBTYPE = 'Character Experience - Meet & Greet';
+
 /** Entertainment subtypes that map to SHOW entity type */
 const SHOW_SUBTYPES = new Set([
   'Stage Show',
   'Fireworks',
   'Atmosphere',
   'Parade',
-  'Character Experience - Meet & Greet',
+  MEET_AND_GREET_SUBTYPE,
 ]);
+
+/** How many days ahead buildSchedules publishes. */
+const SCHEDULE_DAYS = 60;
 
 /** Wall-clock time the schedule feed publishes, e.g. `21:30:00`.
  * `24:00` is a valid midnight close; out-of-range values would reach
@@ -793,7 +798,77 @@ export class DisneylandParis extends Destination {
   private async getEmittablePOIEntities(): Promise<Array<DLPPOIEntity & {category: string}>> {
     const poiData = await this.getPOIData();
     const allEntities = this.flattenPOI(poiData);
-    return this.filterPOIEntities(allEntities).filter((poi) => this.mapEntityType(poi) !== undefined);
+    const emittable = this.filterPOIEntities(allEntities)
+      .filter((poi) => this.mapEntityType(poi) !== undefined);
+
+    const withData = await this.getMeetAndGreetIdsWithData();
+    if (withData === null) return emittable;
+    return emittable.filter(
+      (poi) => poi.subType !== MEET_AND_GREET_SUBTYPE || withData.has(poi.id),
+    );
+  }
+
+  /**
+   * Meet & greets that have something to publish: a performance somewhere in
+   * the window buildSchedules covers, or a virtual queue Disney has switched
+   * on. Null means "publish all of them" — see getScheduledActivityIds.
+   *
+   * Disney lists 22, and 8 of those carry neither. Publishing them puts bare
+   * records on the wiki with no live data and no schedule day, and because the
+   * entity gate and the schedule window are the same, an entity we publish is
+   * one we can also attach hours to.
+   *
+   * The queue clause is what lets the six virtual-queue meet & greets appear
+   * on their own: they hold no schedule rows at all, so while every queue
+   * reads `enabled: false` they stay out, and the day Disney turns one back on
+   * it returns without a code change.
+   */
+  private async getMeetAndGreetIdsWithData(): Promise<Set<string> | null> {
+    const scheduled = await this.getScheduledActivityIds();
+    if (scheduled === null) return null;
+
+    const ids = new Set(scheduled);
+    try {
+      for (const queue of await this.getVirtualQueueData()) {
+        if (queue?.queueContentId && queue.enabled !== false) ids.add(queue.queueContentId);
+      }
+    } catch {
+      // The queue feed is optional; a failure only narrows what we publish.
+    }
+    return ids;
+  }
+
+  /**
+   * Ids the schedule feed carries rows for, across the same window
+   * buildSchedules publishes.
+   *
+   * Returns null when no day in that window came back with a single row.
+   * DLP always publishes park hours, so that is an outage rather than a quiet
+   * estate — and a cached empty answer must not be allowed to unpublish
+   * entities, the same trap #296 closed for schedules.
+   */
+  @cache({ttlSeconds: 43200, key: 'dlp:getScheduledActivityIds'})
+  private async getScheduledActivityIds(): Promise<string[] | null> {
+    const now = new Date();
+    const ids = new Set<string>();
+    let answered = false;
+
+    for (let i = 0; i < SCHEDULE_DAYS; i++) {
+      const [mm, dd, yyyy] = formatInTimezone(addDays(now, i), this.timezone, 'date').split('/');
+      let rows: DLPScheduleActivityEntry[];
+      try {
+        rows = await this.getScheduleForDate(`${yyyy}-${mm}-${dd}`);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(rows) || rows.length === 0) continue;
+      answered = true;
+      for (const row of rows) {
+        if (row?.id && Array.isArray(row.schedules) && row.schedules.length > 0) ids.add(row.id);
+      }
+    }
+
+    return answered ? [...ids] : null;
   }
 
   /**
@@ -845,7 +920,8 @@ export class DisneylandParis extends Destination {
   protected async buildEntityList(): Promise<Entity[]> {
     const poiData = await this.getPOIData();
     const allEntities = this.flattenPOI(poiData);
-    const filteredEntities = this.filterPOIEntities(allEntities);
+    // The same gate the live and schedule paths use, so the three cannot drift.
+    const filteredEntities = await this.getEmittablePOIEntities();
 
     const destinationId = 'dlp';
 
@@ -1281,8 +1357,8 @@ export class DisneylandParis extends Destination {
     // When POI is unavailable, schedules publish unfiltered rather than empty.
     const publishedIds = await this.getPublishedEntityIds();
 
-    // Fetch 60 days of schedule data
-    for (let i = 0; i < 60; i++) {
+    // Fetch SCHEDULE_DAYS of schedule data
+    for (let i = 0; i < SCHEDULE_DAYS; i++) {
       const date = addDays(now, i);
       const dateStr = formatInTimezone(date, this.timezone, 'date');
       // Convert MM/DD/YYYY to YYYY-MM-DD


### PR DESCRIPTION
## Summary

Two changes to Disneyland Paris entertainment data:

- **Character meet & greets are published as shows.** They were dropped by `mapEntityType` because their `subType` was missing from `SHOW_SUBTYPES` — nothing to do with the hide rules.
- **Showtimes with a published POI `duration` get a real end time.** The schedule feed reports every `PERFORMANCE_TIME` slot with `endTime` equal to `startTime`, so a window has to come from the POI `duration`; shows without one keep their zero-length slot.

| | `main` | this branch |
|---|---|---|
| Entities | 127 | **147** |
| `SHOW` | 23 | **43** |
| Showtime slots | 90 | **177** |
| …with a real window | 0 | **41** (the rest publish no `duration`) |
| DLP tests | 2 | **202** |

`ATTRACTION` (51), `RESTAURANT` (50) and `PARK` (2) are unchanged. No new HTTP request — `duration` and the meet & greet records ride along on the POI query that already runs.

Both columns measured back to back against `main` at `1c8a739d`, which is merged in here. Slot totals move through the day as performances pass.

### What this costs, and what it does not fix

Two things worth having in front of you rather than in a thread:

- **A cold `getEntities()` now runs the 60-day schedule sweep**, because the meet & greet gate needs to know what has performances. Measured here, both back to back: **43s cold against ~1s on `main`**, warm 7ms. It is the same 60 days `buildSchedules` already fetches and `getScheduleForDate` caches for 12h, so a full pass pays it once instead of twice — but a consumer that only ever calls `getEntities()` pays a sweep it never asked for. Reported as high as 75s depending on the upstream.
- **The 20 new entities carry no coordinates.** Disney publishes no location for meet & greets, so there is nothing to fix here, but the harness warning goes `SHOW:20` to `SHOW:40`.

## Meet & greets

59 in-park records carry `subType: "Character Experience - Meet & Greet"`. 17 pass the existing hide rules unchanged.

Three more are added to `VISIBILITY_EXCEPTIONS`. All three are flagged `Hide from Web List + Mobile App`, but the schedule feed lists them on nearly every day of the next 60:

| ID | days with performances | name |
|---|---|---|
| `P2MG31` | 51 / 60 | Meet Goofy, the Movie Director |
| `P1MG21` | 46 / 60 | An Encounter with Captain Hook |
| `P1MG05` | 46 / 60 | Meet Donald Duck or his friends |

This is deliberately narrow, and it does not reopen the question settled in #292. I cross-referenced all 128 in-park `Entertainment` records against 60 days of the feed:

- Of the 33 hide-filtered show subtypes (Stage Show / Fireworks / Parade / Atmosphere), exactly **one** has an upcoming performance — `P1GS93`, already an exception. The other 32 are seasonal-out-of-window (10, e.g. Christmas Parade, Halloween Celebration) or retired/test records (22, including literal `FakeID` and `asgardPedestral`). The retirement-marker reading holds for shows, so the hide rules stay as they are.
- For meet & greets it does not hold, which is why these three are listed individually rather than by relaxing a rule.

No `-old` / `-OLD` / `old-` record enters the set. Magic Shots (13) stay out: they are PhotoPass photo spots where the character is composited into the picture afterwards — Disney's own copy says *"The Disney Character is not physically present"* — and they have no duration, no coordinates and no schedule entry on any of the 60 days checked.

Six of the 20 publish no performance times because they run on the virtual queue (`virtualQueue: true`): Hero Training Center, Meet Mickey Mouse, Princess Pavilion, Rencontre Royale, Meet a Toy Story Character. Starport is a walk-up meet with no published times. They are real, operating experiences and are emitted as entities without showtimes.

## Showtime durations

`duration` lives on the concrete `Entertainment` type, not the shared `Activity` interface, so it needs an inline fragment — requesting it from the common selection fails schema validation.

16 of 44 shows publish a duration; the remaining 28 keep a zero-length slot, which matches how meet & greets and drop-in formats such as Animation Academy actually work.

```
P1GS21  11:30 +33min   Disney Stars on Parade
P1GS99  22:00 +22min   Disney Tales of Magic
P1GS34  12:30 +30min   The Lion King: Rhythms of the Pride Lands
P2GS78  10:00 +28min   Disney Princess Cavalcade
```

One defect fixed and one hardening along the way:

- Durations were read from state only `buildEntityList` populated, so they were empty whenever `getLiveData()` ran on its own. They now come from the POI records `buildLiveData` already loads.
- Lengths are parsed rather than trusted. This is hardening of the new path, not a shipped-bug fix: on `main` the old `(minutes || 0) + ((hours || 0) * 60)` expression was unreachable because `fetchPOI` never requested `duration` — the operative change is adding the field to the query. Numeric strings are coerced (the old expression would have concatenated them), and negative or longer-than-a-day values fall back to the feed's end time.

`getPOIData` moves to `cacheVersion: 5` because the cached shape gains a field. #295 took 4 and the two query texts differ, so they need separate keys.

## Test plan

- [x] `npm test src/parks/dlp` — 202 tests across 10 files; full suite 1955 across 89 files
- [x] `npx tsc --noEmit`
- [x] `npm run dev -- disneylandparis --clear-cache` — 4/4, entities 147, zero orphans in both directions
- [x] New `showtimes.test.ts` verified to fail against the previous code (`expected +0 to be 30`), including a case that calls `getLiveData()` without a preceding `getEntities()`
- [x] Duration parsing fuzzed through the public path: missing, empty, null members, negative, non-numeric, numeric strings, longer than a day

