### PR TITLE
feat(dlp): publish dining status and today's opening hours

### DIFF
--- a/src/parks/dlp/__tests__/dining.test.ts
+++ b/src/parks/dlp/__tests__/dining.test.ts
@@ -1,0 +1,147 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * Restaurants have no live feed, so their status is derived from today's
+ * published window. Anything Disney gives no hours for stays absent instead of
+ * being reported as closed all day.
+ */
+const TZ_OFFSET = '+02:00';
+
+function stubbedPark(hours: unknown, date: string): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Restaurant: [{
+      id: 'P1RR01',
+      name: 'Casa de Coco',
+      type: 'Restaurant',
+      location: {id: 'P1'},
+      schedules: hours === undefined ? undefined : [{date, ...(hours as object)}],
+    }],
+  });
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue([]);
+
+  return park;
+}
+
+/** Today in the park's timezone, as the park code computes it. */
+function parkToday(): string {
+  const [mm, dd, yy] = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Paris', month: '2-digit', day: '2-digit', year: 'numeric',
+  }).format(new Date()).split('/');
+  return `${yy}-${mm}-${dd}`;
+}
+
+async function statusAt(clock: string, hours: unknown): Promise<string | undefined> {
+  const date = parkToday();
+  vi.setSystemTime(new Date(`${date}T${clock}${TZ_OFFSET}`));
+  const live = await stubbedPark(hours, date).getLiveData();
+  return live.find((l) => l.id === 'P1RR01')?.status;
+}
+
+describe('DLP dining hours', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  const operating = {startTime: '11:00:00', endTime: '21:30:00', status: 'OPERATING'};
+
+  it('reports OPERATING inside the published window', async () => {
+    expect(await statusAt('13:00:00', operating)).toBe('OPERATING');
+  });
+
+  it('reports CLOSED before opening', async () => {
+    expect(await statusAt('09:00:00', operating)).toBe('CLOSED');
+  });
+
+  it('reports CLOSED after closing', async () => {
+    expect(await statusAt('23:30:00', operating)).toBe('CLOSED');
+  });
+
+  it('reports REFURBISHMENT for a multi-day closure', async () => {
+    expect(await statusAt('13:00:00', {
+      startTime: '00:00:00', endTime: '23:59:00', status: 'REFURBISHMENT', closed: true,
+    })).toBe('REFURBISHMENT');
+  });
+
+  it('reports REFURBISHMENT regardless of the time of day', async () => {
+    const hours = {startTime: '00:00:00', endTime: '23:59:00', status: 'REFURBISHMENT', closed: true};
+    expect(await statusAt('03:00:00', hours)).toBe('REFURBISHMENT');
+    expect(await statusAt('23:30:00', hours)).toBe('REFURBISHMENT');
+  });
+
+  it('emits no row when no hours are published', async () => {
+    expect(await statusAt('13:00:00', undefined)).toBeUndefined();
+  });
+
+  it('emits no row when the window has no times', async () => {
+    expect(await statusAt('13:00:00', {status: 'OPERATING'})).toBeUndefined();
+  });
+
+  it('survives a malformed time instead of failing the whole build', async () => {
+    expect(await statusAt('13:00:00', {
+      startTime: 'abc', endTime: 'xyz', status: 'OPERATING',
+    })).toBe('CLOSED');
+  });
+
+  it('rejects a single-digit hour rather than truncating it', async () => {
+    // '9:30:00' sliced to HH:MM yields '9:30:', which is not a parseable time.
+    expect(await statusAt('13:00:00', {
+      startTime: '9:30:00', endTime: '20:00:00', status: 'OPERATING',
+    })).toBe('CLOSED');
+  });
+
+  it('ignores hours published for another day', async () => {
+    const date = parkToday();
+    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    const park = stubbedPark(operating, '2020-01-01');
+    const live = await park.getLiveData();
+    expect(live.find((l) => l.id === 'P1RR01')).toBeUndefined();
+  });
+
+  it('publishes today\'s window under operatingHours', async () => {
+    const date = parkToday();
+    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    const live = await stubbedPark(operating, date).getLiveData();
+
+    expect(live.find((l) => l.id === 'P1RR01')?.operatingHours).toEqual([{
+      type: 'OPERATING',
+      startTime: `${date}T11:00:00${TZ_OFFSET}`,
+      endTime: `${date}T21:30:00${TZ_OFFSET}`,
+    }]);
+  });
+
+  it('still publishes the window outside opening hours', async () => {
+    const date = parkToday();
+    vi.setSystemTime(new Date(`${date}T23:30:00${TZ_OFFSET}`));
+    const live = await stubbedPark(operating, date).getLiveData();
+    const entry = live.find((l) => l.id === 'P1RR01');
+
+    expect(entry?.status).toBe('CLOSED');
+    expect(entry?.operatingHours).toHaveLength(1);
+  });
+
+  it('omits operatingHours for a refurbishment', async () => {
+    const date = parkToday();
+    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    const live = await stubbedPark({
+      startTime: '00:00:00', endTime: '23:59:00', status: 'REFURBISHMENT', closed: true,
+    }, date).getLiveData();
+
+    expect(live.find((l) => l.id === 'P1RR01')?.operatingHours).toBeUndefined();
+  });
+
+  it('does not attach a queue to dining', async () => {
+    const date = parkToday();
+    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    const live = await stubbedPark(operating, date).getLiveData();
+    expect(live.find((l) => l.id === 'P1RR01')?.queue).toBeUndefined();
+  });
+});

--- a/src/parks/dlp/__tests__/dining.test.ts
+++ b/src/parks/dlp/__tests__/dining.test.ts
@@ -1,33 +1,13 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
+import {constructDateTime} from '../../../datetime.js';
 
 /**
  * Restaurants have no live feed, so their status is derived from today's
- * published window. Anything Disney gives no hours for stays absent instead of
- * being reported as closed all day.
+ * window in the activity-schedule feed (the POI blob's schedules only carry
+ * the fetch day, so they go stale at midnight). Anything Disney gives no
+ * hours for stays absent instead of being reported as closed all day.
  */
-const TZ_OFFSET = '+02:00';
-
-function stubbedPark(hours: unknown, date: string): DisneylandParis {
-  const park = new DisneylandParis();
-
-  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
-    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
-    Restaurant: [{
-      id: 'P1RR01',
-      name: 'Casa de Coco',
-      type: 'Restaurant',
-      location: {id: 'P1'},
-      schedules: hours === undefined ? undefined : [{date, ...(hours as object)}],
-    }],
-  });
-  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
-  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
-  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
-  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue([]);
-
-  return park;
-}
 
 /** Today in the park's timezone, as the park code computes it. */
 function parkToday(): string {
@@ -37,11 +17,48 @@ function parkToday(): string {
   return `${yy}-${mm}-${dd}`;
 }
 
-async function statusAt(clock: string, hours: unknown): Promise<string | undefined> {
+/** The park's UTC offset for a date, derived rather than hardcoded so the
+ * suite survives DST transitions. */
+function tzOffset(date: string): string {
+  return constructDateTime(date, '12:00:00', 'Europe/Paris').slice(19);
+}
+
+function stubbedPark(
+  hours: unknown,
+  date: string,
+  {poiSchedules}: {poiSchedules?: unknown} = {},
+): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Restaurant: [{
+      id: 'P1RR01',
+      name: 'Casa de Coco',
+      type: 'Restaurant',
+      location: {id: 'P1'},
+      schedules: poiSchedules,
+    }],
+  });
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(
+    hours === undefined ? [] : [{id: 'P1RR01', schedules: [{date, ...(hours as object)}]}],
+  );
+
+  return park;
+}
+
+async function rowAt(clock: string, hours: unknown): Promise<any> {
   const date = parkToday();
-  vi.setSystemTime(new Date(`${date}T${clock}${TZ_OFFSET}`));
+  vi.setSystemTime(new Date(`${date}T${clock}${tzOffset(date)}`));
   const live = await stubbedPark(hours, date).getLiveData();
-  return live.find((l) => l.id === 'P1RR01')?.status;
+  return live.find((l) => l.id === 'P1RR01');
+}
+
+async function statusAt(clock: string, hours: unknown): Promise<string | undefined> {
+  return (await rowAt(clock, hours))?.status;
 }
 
 describe('DLP dining hours', () => {
@@ -65,6 +82,22 @@ describe('DLP dining hours', () => {
     expect(await statusAt('23:30:00', operating)).toBe('CLOSED');
   });
 
+  it('treats the window as half-open: opening minute in, closing minute out', async () => {
+    expect(await statusAt('11:00:00', operating)).toBe('OPERATING');
+    expect(await statusAt('21:30:00', operating)).toBe('CLOSED');
+  });
+
+  it('publishes dining even when the POI blob has no row for today', async () => {
+    // After local midnight the 12h-cached POI blob only carries yesterday.
+    const date = parkToday();
+    vi.setSystemTime(new Date(`${date}T13:00:00${tzOffset(date)}`));
+    const park = stubbedPark(operating, date, {
+      poiSchedules: [{date: '2020-01-01', ...operating}],
+    });
+    const live = await park.getLiveData();
+    expect(live.find((l) => l.id === 'P1RR01')?.status).toBe('OPERATING');
+  });
+
   it('reports REFURBISHMENT for a multi-day closure', async () => {
     expect(await statusAt('13:00:00', {
       startTime: '00:00:00', endTime: '23:59:00', status: 'REFURBISHMENT', closed: true,
@@ -77,6 +110,15 @@ describe('DLP dining hours', () => {
     expect(await statusAt('23:30:00', hours)).toBe('REFURBISHMENT');
   });
 
+  it('reports CLOSED for a status token it does not recognise', async () => {
+    expect(await statusAt('13:00:00', {...operating, status: 'DOWN'})).toBe('CLOSED');
+    expect(await statusAt('13:00:00', {...operating, status: 'SOMETHING_NEW'})).toBe('CLOSED');
+  });
+
+  it('reports CLOSED for an OPERATING row flagged closed', async () => {
+    expect(await statusAt('13:00:00', {...operating, closed: true})).toBe('CLOSED');
+  });
+
   it('emits no row when no hours are published', async () => {
     expect(await statusAt('13:00:00', undefined)).toBeUndefined();
   });
@@ -85,22 +127,33 @@ describe('DLP dining hours', () => {
     expect(await statusAt('13:00:00', {status: 'OPERATING'})).toBeUndefined();
   });
 
-  it('survives a malformed time instead of failing the whole build', async () => {
-    expect(await statusAt('13:00:00', {
-      startTime: 'abc', endTime: 'xyz', status: 'OPERATING',
-    })).toBe('CLOSED');
+  it.each([
+    ['not times at all', {startTime: 'abc', endTime: 'xyz'}],
+    ['a single-digit hour', {startTime: '9:30:00', endTime: '20:00:00'}],
+    ['an out-of-range hour', {startTime: '25:00:00', endTime: '26:00:00'}],
+    ['out-of-range everything', {startTime: '99:99:99', endTime: '99:99:99'}],
+    ['an out-of-range minute', {startTime: '12:60:00', endTime: '20:00:00'}],
+  ])('survives %s instead of failing the whole build', async (_label, times) => {
+    const row = await rowAt('13:00:00', {...times, status: 'OPERATING'});
+    expect(row).toBeDefined();
+    expect(row.status).toBe('CLOSED');
+    expect(row.operatingHours).toBeUndefined();
   });
 
-  it('rejects a single-digit hour rather than truncating it', async () => {
-    // '9:30:00' sliced to HH:MM yields '9:30:', which is not a parseable time.
-    expect(await statusAt('13:00:00', {
-      startTime: '9:30:00', endTime: '20:00:00', status: 'OPERATING',
-    })).toBe('CLOSED');
+  it('accepts a 24:00 midnight close', async () => {
+    const hours = {startTime: '11:00:00', endTime: '24:00:00', status: 'OPERATING'};
+    expect(await statusAt('23:30:00', hours)).toBe('OPERATING');
+  });
+
+  it('rolls a past-midnight close into the next day', async () => {
+    const hours = {startTime: '19:00:00', endTime: '01:00:00', status: 'OPERATING'};
+    expect(await statusAt('23:30:00', hours)).toBe('OPERATING');
+    expect(await statusAt('13:00:00', hours)).toBe('CLOSED');
   });
 
   it('ignores hours published for another day', async () => {
     const date = parkToday();
-    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    vi.setSystemTime(new Date(`${date}T13:00:00${tzOffset(date)}`));
     const park = stubbedPark(operating, '2020-01-01');
     const live = await park.getLiveData();
     expect(live.find((l) => l.id === 'P1RR01')).toBeUndefined();
@@ -108,19 +161,19 @@ describe('DLP dining hours', () => {
 
   it('publishes today\'s window under operatingHours', async () => {
     const date = parkToday();
-    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    vi.setSystemTime(new Date(`${date}T13:00:00${tzOffset(date)}`));
     const live = await stubbedPark(operating, date).getLiveData();
 
     expect(live.find((l) => l.id === 'P1RR01')?.operatingHours).toEqual([{
       type: 'OPERATING',
-      startTime: `${date}T11:00:00${TZ_OFFSET}`,
-      endTime: `${date}T21:30:00${TZ_OFFSET}`,
+      startTime: `${date}T11:00:00${tzOffset(date)}`,
+      endTime: `${date}T21:30:00${tzOffset(date)}`,
     }]);
   });
 
   it('still publishes the window outside opening hours', async () => {
     const date = parkToday();
-    vi.setSystemTime(new Date(`${date}T23:30:00${TZ_OFFSET}`));
+    vi.setSystemTime(new Date(`${date}T23:30:00${tzOffset(date)}`));
     const live = await stubbedPark(operating, date).getLiveData();
     const entry = live.find((l) => l.id === 'P1RR01');
 
@@ -130,18 +183,23 @@ describe('DLP dining hours', () => {
 
   it('omits operatingHours for a refurbishment', async () => {
     const date = parkToday();
-    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    vi.setSystemTime(new Date(`${date}T13:00:00${tzOffset(date)}`));
     const live = await stubbedPark({
       startTime: '00:00:00', endTime: '23:59:00', status: 'REFURBISHMENT', closed: true,
     }, date).getLiveData();
+    const entry = live.find((l) => l.id === 'P1RR01');
 
-    expect(live.find((l) => l.id === 'P1RR01')?.operatingHours).toBeUndefined();
+    expect(entry).toBeDefined();
+    expect(entry?.operatingHours).toBeUndefined();
   });
 
   it('does not attach a queue to dining', async () => {
     const date = parkToday();
-    vi.setSystemTime(new Date(`${date}T13:00:00${TZ_OFFSET}`));
+    vi.setSystemTime(new Date(`${date}T13:00:00${tzOffset(date)}`));
     const live = await stubbedPark(operating, date).getLiveData();
-    expect(live.find((l) => l.id === 'P1RR01')?.queue).toBeUndefined();
+    const entry = live.find((l) => l.id === 'P1RR01');
+
+    expect(entry).toBeDefined();
+    expect(entry?.queue).toBeUndefined();
   });
 });

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -77,8 +77,10 @@ const SHOW_SUBTYPES = new Set([
   'Parade',
 ]);
 
-/** Wall-clock time the schedule feed publishes, e.g. `21:30:00` */
-const TIME_OF_DAY = /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/;
+/** Wall-clock time the schedule feed publishes, e.g. `21:30:00`.
+ * `24:00` is a valid midnight close; out-of-range values would reach
+ * constructDateTime and throw. */
+const TIME_OF_DAY = /^(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?|24:00(?::00)?)$/;
 
 // ============================================================================
 // Types
@@ -966,10 +968,15 @@ export class DisneylandParis extends Destination {
 
     // === Show Times (from today's schedule) ===
     // `todayStr` (YYYY-MM-DD in park tz) is computed at the top of this method.
+    // The payload is shared with the dining block below.
+    let todaySchedules: DLPScheduleActivityEntry[] = [];
     try {
-      const scheduleData = await this.getScheduleForDate(todayStr);
-
-      for (const sched of scheduleData) {
+      todaySchedules = await this.getScheduleForDate(todayStr);
+    } catch (e) {
+      console.error(`[DLP] Error fetching today's schedule: ${e}`);
+    }
+    try {
+      for (const sched of todaySchedules) {
         if (!sched.schedules) continue;
 
         const performances = sched.schedules.filter((s) => s.status === 'PERFORMANCE_TIME');
@@ -1121,11 +1128,20 @@ export class DisneylandParis extends Destination {
     }
 
     // === Dining (from today's schedule) ===
+    // Sourced from the activity-schedule payload above rather than the POI
+    // blob, whose `schedules` only ever carry the day it was fetched — after
+    // midnight the 12h POI cache would have no row for the new date.
     // Without published hours a restaurant is skipped, not reported closed.
+    // This feed is authoritative for a restaurant's status, so unlike the
+    // walkthrough block above it overwrites what other feeds set.
+    const todayRowsById = new Map<string, DLPScheduleEntry[]>();
+    for (const sched of todaySchedules) {
+      if (sched?.id && Array.isArray(sched.schedules)) todayRowsById.set(sched.id, sched.schedules);
+    }
     for (const poi of emittablePois) {
       if (this.mapEntityType(poi) !== 'RESTAURANT') continue;
 
-      const hours = (poi.schedules || []).find((s) => s.date === todayStr);
+      const hours = (todayRowsById.get(poi.id) || []).find((s) => s.date === todayStr);
       if (!hours || !hours.startTime || !hours.endTime) continue;
 
       const ld = getOrCreate(poi.id);
@@ -1134,22 +1150,30 @@ export class DisneylandParis extends Destination {
       // Unlike the wait feed's, this REFURBISHMENT is a real closure, and the
       // only signal for it — buildSchedules skips those days entirely.
       if (hours.status === 'REFURBISHMENT') {
-        ld.status = 'REFURBISHMENT' as any;
+        ld.status = 'REFURBISHMENT';
         continue;
       }
       if (!TIME_OF_DAY.test(hours.startTime) || !TIME_OF_DAY.test(hours.endTime)) {
-        ld.status = 'CLOSED' as any;
+        ld.status = 'CLOSED';
         continue;
       }
 
       const startTime = constructDateTime(todayStr, hours.startTime.slice(0, 5), this.timezone);
-      const endTime = constructDateTime(todayStr, hours.endTime.slice(0, 5), this.timezone);
+      let endTime = constructDateTime(todayStr, hours.endTime.slice(0, 5), this.timezone);
+      // Midnight crossing, mirroring buildSchedules.
+      if (hours.endTime.slice(0, 5) < hours.startTime.slice(0, 5)) {
+        const nextDay = addDays(new Date(`${todayStr}T00:00:00`), 1);
+        const [nmm, ndd, nyyyy] = formatInTimezone(nextDay, this.timezone, 'date').split('/');
+        endTime = constructDateTime(`${nyyyy}-${nmm}-${ndd}`, hours.endTime.slice(0, 5), this.timezone);
+      }
 
+      // Only an explicit OPERATING opens the row; any new status token reads
+      // CLOSED rather than borrowing the wait feed's OPERATING default.
       const open = hours.closed !== true
-        && this.mapStatus(hours.status) === 'OPERATING'
+        && hours.status === 'OPERATING'
         && nowMs >= new Date(startTime).getTime()
-        && nowMs <= new Date(endTime).getTime();
-      ld.status = (open ? 'OPERATING' : 'CLOSED') as any;
+        && nowMs < new Date(endTime).getTime();
+      ld.status = open ? 'OPERATING' : 'CLOSED';
       ld.operatingHours = [{type: 'OPERATING', startTime, endTime}];
     }
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1071,6 +1071,9 @@ export class DisneylandParis extends Destination {
 
     const nowMs = Date.now();
     const isWithinWindow = (open: string, close: string): boolean => {
+      // The feed types these as plain strings, so a malformed one would reach
+      // constructDateTime and throw out of the whole build.
+      if (!TIME_OF_DAY.test(open) || !TIME_OF_DAY.test(close)) return false;
       const o = new Date(constructDateTime(todayStr, open.slice(0, 5), this.timezone)).getTime();
       const c = new Date(constructDateTime(todayStr, close.slice(0, 5), this.timezone)).getTime();
       return nowMs >= o && nowMs <= c;
@@ -1115,6 +1118,39 @@ export class DisneylandParis extends Destination {
       }
       // If a walkthrough already has a row from upstream feeds (PA / VQ /
       // showtimes), leave it — those feeds are authoritative.
+    }
+
+    // === Dining (from today's schedule) ===
+    // Without published hours a restaurant is skipped, not reported closed.
+    for (const poi of emittablePois) {
+      if (this.mapEntityType(poi) !== 'RESTAURANT') continue;
+
+      const hours = (poi.schedules || []).find((s) => s.date === todayStr);
+      if (!hours || !hours.startTime || !hours.endTime) continue;
+
+      const ld = getOrCreate(poi.id);
+      if (!ld) continue;
+
+      // Unlike the wait feed's, this REFURBISHMENT is a real closure, and the
+      // only signal for it — buildSchedules skips those days entirely.
+      if (hours.status === 'REFURBISHMENT') {
+        ld.status = 'REFURBISHMENT' as any;
+        continue;
+      }
+      if (!TIME_OF_DAY.test(hours.startTime) || !TIME_OF_DAY.test(hours.endTime)) {
+        ld.status = 'CLOSED' as any;
+        continue;
+      }
+
+      const startTime = constructDateTime(todayStr, hours.startTime.slice(0, 5), this.timezone);
+      const endTime = constructDateTime(todayStr, hours.endTime.slice(0, 5), this.timezone);
+
+      const open = hours.closed !== true
+        && this.mapStatus(hours.status) === 'OPERATING'
+        && nowMs >= new Date(startTime).getTime()
+        && nowMs <= new Date(endTime).getTime();
+      ld.status = (open ? 'OPERATING' : 'CLOSED') as any;
+      ld.operatingHours = [{type: 'OPERATING', startTime, endTime}];
     }
 
     return liveData;


### PR DESCRIPTION
## Summary

Restaurants had no live data at all. Their hours were already fetched for `buildSchedules`, so a consumer could see a 60-day plan without being able to tell whether a venue is open right now.

| | before | after |
|---|---|---|
| Restaurant live rows | 0 | **31** of 50 |
| …carrying `operatingHours` | – | **30**, one slot each |
| …carrying a `queue` | – | **0** |
| DLP tests | 2 | **26** |

Entities, attractions, shows and schedules are untouched. No new HTTP request — the hours come from the activity-schedule payload the showtimes path already fetches for today. (Originally they were read from the POI blob's `schedules`, which only ever carry the fetch day; review caught that going dark from local midnight until the 12h POI cache rolled.)

```json
{
  "id": "P1AR06",
  "status": "OPERATING",
  "operatingHours": [
    {"type": "OPERATING", "startTime": "2026-08-12T11:30:00+02:00", "endTime": "2026-08-12T20:00:00+02:00"}
  ]
}
```

Status is derived from today's published window; the window itself ships under `operatingHours`, matching how dining is reported in `attractionsio`, `efteling`, `paultons` and `universal`. Like those, it is today only — the multi-day view stays in `getSchedules()`. No queue is attached, following the same reasoning as Europa-Park's `gastronomy_*` handling.

19 of the 50 restaurants get no row: counters and food trucks (`WEB Food Truck`, `Cool Post`, `Café Luminosity`, …) that Disney publishes no hours for. Reporting them closed all day would be a guess.

Measured across the day against the live feed:

| park time | OPERATING | CLOSED | REFURBISHMENT |
|---|---|---|---|
| 09:00 | 3 | 27 | 1 |
| 13:00 | 29 | 1 | 1 |
| 20:00 | 24 | 6 | 1 |
| 23:30 | 0 | 30 | 1 |

The window stays published outside opening hours, so a consumer polling at night still sees when the venue opens.

## REFURBISHMENT

This one status is passed through rather than folded into `CLOSED` by `mapStatus`, which is worth explaining because attractions do fold it.

The two sources mean different things. The wait feed reports `REFURBISHMENT` for anything not currently running — at 23:58 it covered 46 live attractions including *Big Thunder Mountain*, *Phantom Manor* and *Pirates of the Caribbean*. Folding that into `CLOSED` is correct.

The activity-schedule feed means it literally. Today it applies to exactly one venue, *Plaza Gardens Restaurant*, as a full-day `closed: true` row — and it is the only signal for that closure anywhere in the output, because `buildSchedules` skips `REFURBISHMENT` days and the venue therefore has **0 of 60 days** of published hours. Without this, a consumer sees `CLOSED` at lunchtime and cannot distinguish it from "shut right now".

Refurbishment is reported regardless of the time of day, and no `operatingHours` is attached — a `00:00–23:59` placeholder is not an opening window.

## Robustness

Schedule times arrive as plain GraphQL `String`s, so a malformed one is schema-legal. `"abc"` reached `constructDateTime`, which builds `2026-08-12Tabc` and throws — taking down the entire live build, not just one restaurant. Both the dining path and `isWithinWindow` (used by walkthrough attractions) now range-validate the time of day: shape and digit ranges both checked, `24:00` accepted as a midnight close, everything else read as CLOSED rather than thrown. A past-midnight close rolls into the next day, mirroring `buildSchedules`, and the window is half-open `[start, end)` to match `attractionsiov1`.

Fuzzed through the public path: missing / null / empty `schedules`, rows without times, empty and null time fields, non-numeric times, single-digit hours, out-of-range hours and minutes (`25:00`, `99:99`, `12:60`), unknown and null statuses, `closed` set against an OPERATING status, an end before its start, a full-day window, rows dated to another day, and two rows for today.

## Test plan

- [x] `npm test src/parks/dlp` — 26 tests across 2 files
- [x] `npx tsc --noEmit`; test files typechecked separately, since `tsconfig.json` excludes `**/__tests__`
- [x] `npm run dev -- disneylandparis --clear-cache` — 4/4, live rows 52 → 99
- [x] Verified against the live feed at several times of day, and at real time after every change
