### PR TITLE
feat(dlp): publish attraction tags from the POI feed

### DIFF
--- a/src/parks/dlp/__tests__/singleRider.test.ts
+++ b/src/parks/dlp/__tests__/singleRider.test.ts
@@ -3,9 +3,10 @@ import {DisneylandParis} from '../disneylandparis.js';
 import {CacheLib} from '../../../cache.js';
 
 /**
- * Single-rider capability comes from the POI `singleRider` facet. The wait
- * feed reports the same flag, but only answers while the park is awake, so
- * the facet is what keeps a ride's queue present overnight.
+ * Single-rider capability comes from the POI `singleRider` facet, OR'd with
+ * wait-feed sightings from the last 48h. The facet keeps a ride's queue
+ * present overnight; the sighting bridges the POI cache lagging a fresh
+ * addition, and lapses so a retired queue disappears.
  */
 function stubbedPark(
   attractions: Array<Record<string, unknown>>,
@@ -91,6 +92,34 @@ describe('DLP single rider', () => {
       [feedRow({singleRider: {isAvailable: false}})],
     ));
     expect(queue.SINGLE_RIDER).toEqual({waitTime: null});
+  });
+
+  it('bridges a fresh addition the POI cache does not carry yet', async () => {
+    // The feed advertised single rider this morning; the facet lags behind.
+    await stubbedPark(
+      [RIDE],
+      [feedRow({singleRider: {isAvailable: true, singleRiderWaitMinutes: 10}})],
+    ).getLiveData();
+
+    const queue = await queueOf(stubbedPark([RIDE]));
+    expect(queue.SINGLE_RIDER).toEqual({waitTime: null});
+  });
+
+  it('lets a retired single-rider queue disappear once the sighting lapses', async () => {
+    vi.useFakeTimers();
+    try {
+      await stubbedPark(
+        [{...RIDE, singleRider: true}],
+        [feedRow({singleRider: {isAvailable: true, singleRiderWaitMinutes: 10}})],
+      ).getLiveData();
+
+      // Two days on: no facet, feed asleep, last sighting lapsed.
+      vi.setSystemTime(Date.now() + 49 * 60 * 60 * 1000);
+      const queue = await queueOf(stubbedPark([RIDE]));
+      expect(queue.SINGLE_RIDER).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([

--- a/src/parks/dlp/__tests__/singleRider.test.ts
+++ b/src/parks/dlp/__tests__/singleRider.test.ts
@@ -1,0 +1,107 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+import {CacheLib} from '../../../cache.js';
+
+/**
+ * Single-rider capability comes from the POI `singleRider` facet. The wait
+ * feed reports the same flag, but only answers while the park is awake, so
+ * the facet is what keeps a ride's queue present overnight.
+ */
+function stubbedPark(
+  attractions: Array<Record<string, unknown>>,
+  waitTimes: unknown[] = [],
+): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Attraction: attractions.map((a) => ({
+      type: 'Attraction',
+      location: {id: 'P1'},
+      ...a,
+    })),
+  });
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue(waitTimes);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue([]);
+
+  return park;
+}
+
+const RIDE = {id: 'P1RA00', name: 'Big Thunder Mountain'};
+
+/** A wait-feed row, which is what marks a ride as queue-bearing. */
+const feedRow = (over: Record<string, unknown> = {}) => ({
+  entityId: 'P1RA00',
+  type: 'Attraction',
+  status: 'OPERATING',
+  postedWaitMinutes: 30,
+  ...over,
+});
+
+async function queueOf(park: DisneylandParis): Promise<any> {
+  const live = await park.getLiveData();
+  const row = live.find((l) => l.id === 'P1RA00');
+  expect(row).toBeDefined();
+  return (row as any)?.queue;
+}
+
+describe('DLP single rider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('DisneylandParis');
+  });
+
+  it('emits the queue from the POI facet while the feed is asleep', async () => {
+    // The ride is known to be queue-bearing from an earlier live feed, but
+    // right now the feed returns nothing at all.
+    await stubbedPark([{...RIDE, singleRider: true}], [feedRow()]).getLiveData();
+
+    const queue = await queueOf(stubbedPark([{...RIDE, singleRider: true}]));
+    expect(queue.SINGLE_RIDER).toEqual({waitTime: null});
+  });
+
+  it('emits no queue for a ride the facet does not flag', async () => {
+    await stubbedPark([RIDE], [feedRow()]).getLiveData();
+
+    const queue = await queueOf(stubbedPark([RIDE]));
+    expect(queue.SINGLE_RIDER).toBeUndefined();
+  });
+
+  it('lets the live feed set the wait time', async () => {
+    const queue = await queueOf(stubbedPark(
+      [{...RIDE, singleRider: true}],
+      [feedRow({singleRider: {isAvailable: true, singleRiderWaitMinutes: 15}})],
+    ));
+    expect(queue.SINGLE_RIDER).toEqual({waitTime: 15});
+  });
+
+  it('nulls the wait time when the ride is closed', async () => {
+    const queue = await queueOf(stubbedPark(
+      [{...RIDE, singleRider: true}],
+      [feedRow({status: 'CLOSED', singleRider: {isAvailable: true, singleRiderWaitMinutes: 15}})],
+    ));
+    expect(queue.SINGLE_RIDER).toEqual({waitTime: null});
+  });
+
+  it('keeps the queue when the live feed reports the flag false', async () => {
+    const queue = await queueOf(stubbedPark(
+      [{...RIDE, singleRider: true}],
+      [feedRow({singleRider: {isAvailable: false}})],
+    ));
+    expect(queue.SINGLE_RIDER).toEqual({waitTime: null});
+  });
+
+  it.each([
+    ['a string', 'true'],
+    ['a number', 1],
+    ['null', null],
+    ['absent', undefined],
+  ])('emits no queue when the facet is %s', async (_label, singleRider) => {
+    await stubbedPark([{...RIDE, singleRider}], [feedRow()]).getLiveData();
+
+    const queue = await queueOf(stubbedPark([{...RIDE, singleRider}]));
+    expect(queue.SINGLE_RIDER).toBeUndefined();
+  });
+});

--- a/src/parks/dlp/__tests__/tags.test.ts
+++ b/src/parks/dlp/__tests__/tags.test.ts
@@ -1,0 +1,202 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * Every field the tags are built from lives on the GraphQL `Attraction` type,
+ * reached through an inline fragment. Anything else in the POI feed therefore
+ * carries no tags at all.
+ */
+function stubbedPark(attraction: Record<string, unknown>): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Attraction: [{
+      id: 'P1RA00',
+      name: 'Big Thunder Mountain',
+      type: 'Attraction',
+      location: {id: 'P1'},
+      ...attraction,
+    }],
+    Entertainment: [{
+      id: 'P1GS00',
+      name: 'Disney Illuminations',
+      type: 'Entertainment',
+      subType: 'Fireworks',
+      location: {id: 'P1'},
+    }],
+    Restaurant: [{
+      id: 'P1AR06',
+      name: 'Casa de Coco',
+      type: 'Restaurant',
+      location: {id: 'P1'},
+    }],
+  });
+
+  return park;
+}
+
+async function tagsOf(attraction: Record<string, unknown>): Promise<string[]> {
+  const entities = await stubbedPark(attraction).getEntities();
+  const target = entities.find((e) => e.id === 'P1RA00');
+
+  // Without this, every `toEqual([])` below would also pass on an attraction
+  // that never made it into the output at all.
+  expect(target).toBeDefined();
+
+  return (target?.tags ?? []).map((t) => t.tag);
+}
+
+describe('DLP attraction tags', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('emits no tags for an attraction without any of the fields', async () => {
+    expect(await tagsOf({})).toEqual([]);
+  });
+
+  it('emits no tags for shows or restaurants', async () => {
+    const entities = await stubbedPark({}).getEntities();
+    expect(entities.find((e) => e.id === 'P1GS00')?.tags).toEqual([]);
+    expect(entities.find((e) => e.id === 'P1AR06')?.tags).toEqual([]);
+  });
+
+  // === Minimum height ===
+
+  it.each([
+    ['81cm', 81],
+    ['1_02m', 102],
+    ['1_07m', 107],
+    ['1_20m', 120],
+    ['1_40m', 140],
+  ])('maps the %s facet to %i cm', async (facetId, expected) => {
+    const entities = await stubbedPark({height: [{id: facetId}]}).getEntities();
+    const tag = entities.find((e) => e.id === 'P1RA00')?.tags?.[0];
+
+    expect(tag?.tag).toBe('MINIMUM_HEIGHT');
+    expect(tag?.value).toEqual({height: expected, unit: 'cm'});
+  });
+
+  it('ignores the localised value string in favour of the facet id', async () => {
+    // The same facet reads "1,20 m" under a French market.
+    const entities = await stubbedPark({
+      height: [{id: '1_20m', value: '1,20 m'}],
+    }).getEntities();
+
+    expect(entities.find((e) => e.id === 'P1RA00')?.tags?.[0].value).toEqual({height: 120, unit: 'cm'});
+  });
+
+  it('accepts a height right on the sanity bound', async () => {
+    const entities = await stubbedPark({height: [{id: '300cm'}]}).getEntities();
+    expect(entities.find((e) => e.id === 'P1RA00')?.tags?.[0].value).toEqual({height: 300, unit: 'cm'});
+  });
+
+  it.each([
+    'anyHeight',
+    '',
+    '   ',
+    '0cm',
+    '0_00m',
+    '-5cm',
+    '301cm',
+    '999999cm',
+    '9_99m',
+    '1e3cm',
+    '81CM',
+    ' 81cm ',
+    'PhotoPass',
+    '36in',
+    '1_20',
+    '1_2_3m',
+    'm',
+  ])('emits no height tag for the "%s" facet', async (facetId) => {
+    expect(await tagsOf({height: [{id: facetId}]})).toEqual([]);
+  });
+
+  it('emits a single height tag, taking the first parseable facet', async () => {
+    const entities = await stubbedPark({
+      height: [{id: 'anyHeight'}, {id: '1_02m'}, {id: '1_40m'}],
+    }).getEntities();
+    const tags = entities.find((e) => e.id === 'P1RA00')?.tags ?? [];
+
+    expect(tags).toHaveLength(1);
+    expect(tags[0].value).toEqual({height: 102, unit: 'cm'});
+  });
+
+  // === Remaining tags ===
+
+  it('maps expectantMothersMayNotRide to UNSUITABLE_PREGNANT', async () => {
+    expect(await tagsOf({
+      physicalConsiderations: [{id: 'mustBeInGoodHealth'}, {id: 'expectantMothersMayNotRide'}],
+    })).toEqual(['UNSUITABLE_PREGNANT']);
+  });
+
+  it('ignores physical considerations that have no matching tag', async () => {
+    expect(await tagsOf({
+      physicalConsiderations: [{id: 'mustBeInGoodHealth'}, {id: 'typesOfLimbImpairement'}],
+    })).toEqual([]);
+  });
+
+  it('maps the singleRider flag to SINGLE_RIDER', async () => {
+    expect(await tagsOf({singleRider: true})).toEqual(['SINGLE_RIDER']);
+    expect(await tagsOf({singleRider: false})).toEqual([]);
+  });
+
+  it('maps the Premier Access interest to PAID_RETURN_TIME', async () => {
+    expect(await tagsOf({
+      interests: [{id: 'orion'}, {id: 'disney-premier-access-one'}],
+    })).toEqual(['PAID_RETURN_TIME']);
+  });
+
+  it('maps guestMayGetSplashed to MAY_GET_WET', async () => {
+    expect(await tagsOf({interests: [{id: 'guestMayGetSplashed'}]})).toEqual(['MAY_GET_WET']);
+  });
+
+  it('maps PhotoPass to ONRIDE_PHOTO', async () => {
+    expect(await tagsOf({interests: [{id: 'PhotoPass'}]})).toEqual(['ONRIDE_PHOTO']);
+  });
+
+  it('ignores interests that have no matching tag', async () => {
+    expect(await tagsOf({
+      interests: [{id: 'funForLittleOnes'}, {id: 'notToBeMissed'}, {id: 'bigThrills'}],
+    })).toEqual([]);
+  });
+
+  it('emits every applicable tag at once', async () => {
+    expect(await tagsOf({
+      height: [{id: '1_02m'}],
+      physicalConsiderations: [{id: 'expectantMothersMayNotRide'}],
+      singleRider: true,
+      interests: [{id: 'disney-premier-access-one'}, {id: 'guestMayGetSplashed'}, {id: 'PhotoPass'}],
+    })).toEqual([
+      'MINIMUM_HEIGHT',
+      'UNSUITABLE_PREGNANT',
+      'SINGLE_RIDER',
+      'PAID_RETURN_TIME',
+      'MAY_GET_WET',
+      'ONRIDE_PHOTO',
+    ]);
+  });
+
+  // === Malformed input ===
+
+  it.each([
+    ['null lists', {height: null, physicalConsiderations: null, interests: null}],
+    ['empty lists', {height: [], physicalConsiderations: [], interests: []}],
+    ['null list entries', {height: [null], physicalConsiderations: [null], interests: [null]}],
+    ['entries without an id', {height: [{}], physicalConsiderations: [{}], interests: [{}]}],
+    ['non-string ids', {height: [{id: 120}], physicalConsiderations: [{id: 1}], interests: [{id: 1}]}],
+    ['strings where lists belong', {height: '1_20m', physicalConsiderations: 'x', interests: 'PhotoPass'}],
+    ['objects where lists belong', {height: {id: '1_20m'}, physicalConsiderations: {}, interests: {id: 'PhotoPass'}}],
+    ['numbers where lists belong', {height: 120, physicalConsiderations: 1, interests: 1}],
+    ['a non-boolean singleRider', {singleRider: 'yes'}],
+  ])('survives %s', async (_label, attraction) => {
+    expect(await tagsOf(attraction)).toEqual([]);
+  });
+
+  it('emits one tag when the feed repeats a facet', async () => {
+    expect(await tagsOf({
+      height: [{id: '1_02m'}, {id: '1_02m'}],
+      interests: [{id: 'PhotoPass'}, {id: 'PhotoPass'}],
+    })).toEqual(['MINIMUM_HEIGHT', 'ONRIDE_PHOTO']);
+  });
+});

--- a/src/parks/dlp/__tests__/tags.test.ts
+++ b/src/parks/dlp/__tests__/tags.test.ts
@@ -18,18 +18,24 @@ function stubbedPark(attraction: Record<string, unknown>): DisneylandParis {
       location: {id: 'P1'},
       ...attraction,
     }],
+    // Both carry taggable fields, which only the entity-type guard drops.
     Entertainment: [{
       id: 'P1GS00',
       name: 'Disney Illuminations',
       type: 'Entertainment',
       subType: 'Fireworks',
       location: {id: 'P1'},
+      singleRider: true,
+      interests: [{id: 'guestMayGetSplashed'}],
     }],
     Restaurant: [{
       id: 'P1AR06',
       name: 'Casa de Coco',
       type: 'Restaurant',
       location: {id: 'P1'},
+      height: [{id: '1_20m'}],
+      singleRider: true,
+      interests: [{id: 'disney-premier-access-one'}, {id: 'PhotoPass'}],
     }],
   });
 
@@ -54,10 +60,14 @@ describe('DLP attraction tags', () => {
     expect(await tagsOf({})).toEqual([]);
   });
 
-  it('emits no tags for shows or restaurants', async () => {
+  it('emits no tags for shows or restaurants even when the feed hands them the fields', async () => {
     const entities = await stubbedPark({}).getEntities();
-    expect(entities.find((e) => e.id === 'P1GS00')?.tags).toEqual([]);
-    expect(entities.find((e) => e.id === 'P1AR06')?.tags).toEqual([]);
+    const show = entities.find((e) => e.id === 'P1GS00');
+    const restaurant = entities.find((e) => e.id === 'P1AR06');
+    expect(show).toBeDefined();
+    expect(restaurant).toBeDefined();
+    expect(show?.tags).toEqual([]);
+    expect(restaurant?.tags).toEqual([]);
   });
 
   // === Minimum height ===
@@ -85,9 +95,13 @@ describe('DLP attraction tags', () => {
     expect(entities.find((e) => e.id === 'P1RA00')?.tags?.[0].value).toEqual({height: 120, unit: 'cm'});
   });
 
-  it('accepts a height right on the sanity bound', async () => {
-    const entities = await stubbedPark({height: [{id: '300cm'}]}).getEntities();
-    expect(entities.find((e) => e.id === 'P1RA00')?.tags?.[0].value).toEqual({height: 300, unit: 'cm'});
+  it.each([
+    ['40cm', 40],
+    ['200cm', 200],
+    ['2m', 200],
+  ])('accepts %s right on the plausibility bound as %i cm', async (facetId, expected) => {
+    const entities = await stubbedPark({height: [{id: facetId}]}).getEntities();
+    expect(entities.find((e) => e.id === 'P1RA00')?.tags?.[0].value).toEqual({height: expected, unit: 'cm'});
   });
 
   it.each([
@@ -97,7 +111,9 @@ describe('DLP attraction tags', () => {
     '0cm',
     '0_00m',
     '-5cm',
-    '301cm',
+    '39cm',
+    '201cm',
+    '300cm',
     '999999cm',
     '9_99m',
     '1e3cm',
@@ -108,6 +124,12 @@ describe('DLP attraction tags', () => {
     '1_20',
     '1_2_3m',
     'm',
+    // Mixed-unit shapes that would round down to a nonsense 1cm.
+    '1_20cm',
+    '0_81cm',
+    '1cm',
+    '2_50m',
+    '3m',
   ])('emits no height tag for the "%s" facet', async (facetId) => {
     expect(await tagsOf({height: [{id: facetId}]})).toEqual([]);
   });

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -11,6 +11,7 @@ import {
   LiveData,
   EntitySchedule,
   LanguageCode,
+  TagData,
 } from '@themeparks/typelib';
 import {formatInTimezone, addDays, constructDateTime} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
@@ -82,6 +83,9 @@ const SHOW_SUBTYPES = new Set([
  * constructDateTime and throw. */
 const TIME_OF_DAY = /^(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?|24:00(?::00)?)$/;
 
+/** Upper bound for a rider height restriction; anything taller is bad data */
+const MAX_HEIGHT_CM = 300;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -110,13 +114,43 @@ type DLPPOIEntity = {
   coordinates?: DLPCoordinate[];
   schedules?: DLPScheduleEntry[];
   subType?: string;
-  // Extended fields from detailed queries
-  height?: Array<{ id: string; value: string; iconFont?: string }>;
-  minimumHeight?: string;
+  duration?: { hours?: number; minutes?: number };
+  // Attraction-only, from the inline fragment in fetchPOI
+  height?: Array<{ id: string }>;
   physicalConsiderations?: Array<{ id: string }>;
   interests?: Array<{ id: string }>;
-  duration?: { hours?: number; minutes?: number };
+  singleRider?: boolean;
 };
+
+/**
+ * Ids of a POI facet list. GraphQL lists may hold nulls, and the whole field
+ * is absent on every type but Attraction, so anything unusable is dropped
+ * rather than allowed to fail the entity build.
+ */
+function facetIds(list: Array<{id?: string}> | undefined): Set<string> {
+  if (!Array.isArray(list)) return new Set();
+  return new Set(
+    list.map((facet) => facet?.id).filter((id): id is string => typeof id === 'string'),
+  );
+}
+
+/**
+ * Parse a height facet id into centimetres: `81cm` → 81, `1_20m` → 120.
+ * Returns undefined for `anyHeight`, for ids in any other shape, and for
+ * values outside a plausible rider height.
+ *
+ * The facet's companion `value` string is localised — the same restriction
+ * reads `1.20 m` in en-gb and `1,20 m` in fr-fr — so the id is the only
+ * market-independent source.
+ */
+function parseHeightCm(facetId: string): number | undefined {
+  const match = /^(\d+(?:_\d+)?)(cm|m)$/.exec(facetId);
+  if (!match) return undefined;
+  const value = Number(match[1].replace('_', '.'));
+  if (!Number.isFinite(value)) return undefined;
+  const cm = Math.round(match[2] === 'm' ? value * 100 : value);
+  return cm > 0 && cm <= MAX_HEIGHT_CM ? cm : undefined;
+}
 
 type DLPWaitTimeEntry = {
   entityId: string;
@@ -368,6 +402,18 @@ export class DisneylandParis extends Destination {
         query: `query activities($market: String!) {
           Attraction: activities(market: $market, types: "Attraction") {
             ${this.entityFields}
+            ... on Attraction {
+              height {
+                id
+              }
+              physicalConsiderations {
+                id
+              }
+              interests {
+                id
+              }
+              singleRider
+            }
           }
           DiningEvent: activities(market: $market, types: "DiningEvent") {
             ${this.entityFields}
@@ -417,7 +463,7 @@ export class DisneylandParis extends Destination {
   /**
    * Get POI data (cached 12h)
    */
-  @cache({ttlSeconds: 43200, cacheVersion: 2})
+  @cache({ttlSeconds: 43200, cacheVersion: 3})
   async getPOIData(): Promise<Record<string, DLPPOIEntity[]>> {
     const resp = await this.fetchPOI();
     const data = await resp.json();
@@ -652,20 +698,33 @@ export class DisneylandParis extends Destination {
   }
 
   /**
-   * Parse height string into centimeters.
-   * Handles "1.2 m" -> 120, "102 cm" -> 102
+   * Build the tags for a POI entity. Every field read here belongs to the
+   * Attraction type, so shows and restaurants come back with an empty list.
    */
-  private parseHeightCm(heightStr: string): number | undefined {
-    const match = /([\d.]+)\s*(\w+)/.exec(heightStr);
-    if (!match) return undefined;
+  private buildTags(poi: DLPPOIEntity): TagData[] {
+    const tags: TagData[] = [];
 
-    const value = parseFloat(match[1]);
-    const unit = match[2].toLowerCase();
+    const heightCm = [...facetIds(poi.height)]
+      .map((id) => parseHeightCm(id))
+      .find((cm) => cm !== undefined);
+    if (heightCm !== undefined) {
+      tags.push(TagBuilder.minimumHeight(heightCm, 'cm'));
+    }
 
-    if (unit === 'm') return Math.round(value * 100);
-    if (unit === 'cm') return Math.round(value);
+    if (facetIds(poi.physicalConsiderations).has('expectantMothersMayNotRide')) {
+      tags.push(TagBuilder.unsuitableForPregnantPeople());
+    }
 
-    return undefined;
+    if (poi.singleRider === true) {
+      tags.push(TagBuilder.singleRider());
+    }
+
+    const interests = facetIds(poi.interests);
+    if (interests.has('disney-premier-access-one')) tags.push(TagBuilder.paidReturnTime());
+    if (interests.has('guestMayGetSplashed')) tags.push(TagBuilder.mayGetWet());
+    if (interests.has('PhotoPass')) tags.push(TagBuilder.onRidePhoto());
+
+    return tags;
   }
 
   /**
@@ -804,34 +863,7 @@ export class DisneylandParis extends Destination {
         (entity as Entity & {attractionType?: string}).attractionType = 'SHOW';
       }
 
-      // Build tags
-      const tags: any[] = [];
-
-      // Height restriction
-      if (poi.minimumHeight) {
-        const heightCm = this.parseHeightCm(poi.minimumHeight);
-        if (heightCm && heightCm > 0) {
-          tags.push(TagBuilder.minimumHeight(heightCm, 'cm'));
-        }
-      }
-      // Also check height array (older format)
-      if (poi.height) {
-        for (const h of poi.height) {
-          if (h.id === 'anyHeight') continue;
-          const heightCm = this.parseHeightCm(h.value);
-          if (heightCm && heightCm > 0) {
-            tags.push(TagBuilder.minimumHeight(heightCm, 'cm'));
-            break; // Only one height tag
-          }
-        }
-      }
-
-      // Pregnancy
-      if (poi.physicalConsiderations?.some((c) => c.id === 'expectantMothersMayNotRide')) {
-        tags.push(TagBuilder.unsuitableForPregnantPeople());
-      }
-
-      entity.tags = tags.filter(Boolean);
+      entity.tags = this.buildTags(poi);
 
       // Store show duration for live data
       if (entityType === 'SHOW' && poi.duration) {

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1064,19 +1064,7 @@ export class DisneylandParis extends Destination {
     // synthetic CLOSED + STANDBY:null all day. Instead we emit
     // OPERATING/CLOSED derived from today's POI schedule (or park-hours
     // fallback) and no queue. Detection is data-driven: persist a 30-day
-    // cache of IDs that have ever appeared in the wait feed, mirroring the
-    // singleRiderCapable pattern below.
-    //
-    // Single-rider eligibility isn't on POI, so remember IDs we've seen
-    // with `singleRider.isAvailable === true` and re-emit SINGLE_RIDER
-    // null for them while the feed is asleep.
-    const srCacheKey = `${this.getCacheKeyPrefix()}:dlp:singleRiderCapable`;
-    const previouslySeenSR = CacheLib.get(srCacheKey) as string[] | null;
-    const seenSR = new Set<string>(Array.isArray(previouslySeenSR) ? previouslySeenSR : []);
-    for (const wt of waitTimes) {
-      if (wt.singleRider?.isAvailable === true && wt.entityId) seenSR.add(wt.entityId);
-    }
-    CacheLib.set(srCacheKey, [...seenSR], 30 * 24 * 60 * 60); // 30 days
+    // cache of IDs that have ever appeared in the wait feed.
 
     // Wait-feed history: which attractions are queue-bearing? Walkthroughs
     // never appear here. 30-day TTL covers normal refurb cycles.
@@ -1146,7 +1134,7 @@ export class DisneylandParis extends Destination {
         }
         if (!ld.queue) ld.queue = {};
         if (!ld.queue.STANDBY) ld.queue.STANDBY = {waitTime: null};
-        if (!ld.queue.SINGLE_RIDER && seenSR.has(id)) {
+        if (!ld.queue.SINGLE_RIDER && poi.singleRider === true) {
           ld.queue.SINGLE_RIDER = {waitTime: null};
         }
       } else if (!ld) {

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -83,8 +83,14 @@ const SHOW_SUBTYPES = new Set([
  * constructDateTime and throw. */
 const TIME_OF_DAY = /^(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?|24:00(?::00)?)$/;
 
-/** Upper bound for a rider height restriction; anything taller is bad data */
-const MAX_HEIGHT_CM = 300;
+/** Plausible band for a rider height restriction; outside it is bad data
+ * (a mixed-unit id like `1_20cm` would otherwise round down to 1cm). */
+const MIN_HEIGHT_CM = 40;
+const MAX_HEIGHT_CM = 200;
+
+/** How long a wait-feed single-rider sighting keeps the queue's overnight
+ * baseline alive while the 12h POI cache lags. */
+const SINGLE_RIDER_RECENT_SECONDS = 48 * 60 * 60;
 
 // ============================================================================
 // Types
@@ -149,7 +155,7 @@ function parseHeightCm(facetId: string): number | undefined {
   const value = Number(match[1].replace('_', '.'));
   if (!Number.isFinite(value)) return undefined;
   const cm = Math.round(match[2] === 'm' ? value * 100 : value);
-  return cm > 0 && cm <= MAX_HEIGHT_CM ? cm : undefined;
+  return cm >= MIN_HEIGHT_CM && cm <= MAX_HEIGHT_CM ? cm : undefined;
 }
 
 type DLPWaitTimeEntry = {
@@ -463,7 +469,7 @@ export class DisneylandParis extends Destination {
   /**
    * Get POI data (cached 12h)
    */
-  @cache({ttlSeconds: 43200, cacheVersion: 3})
+  @cache({ttlSeconds: 43200, cacheVersion: 4})
   async getPOIData(): Promise<Record<string, DLPPOIEntity[]>> {
     const resp = await this.fetchPOI();
     const data = await resp.json();
@@ -698,8 +704,8 @@ export class DisneylandParis extends Destination {
   }
 
   /**
-   * Build the tags for a POI entity. Every field read here belongs to the
-   * Attraction type, so shows and restaurants come back with an empty list.
+   * Build the tags for an attraction. The caller guards on entity type, so
+   * a record of another type carrying these fields can never grow tags.
    */
   private buildTags(poi: DLPPOIEntity): TagData[] {
     const tags: TagData[] = [];
@@ -863,7 +869,7 @@ export class DisneylandParis extends Destination {
         (entity as Entity & {attractionType?: string}).attractionType = 'SHOW';
       }
 
-      entity.tags = this.buildTags(poi);
+      entity.tags = entityType === 'ATTRACTION' ? this.buildTags(poi) : [];
 
       // Store show duration for live data
       if (entityType === 'SHOW' && poi.duration) {
@@ -1063,8 +1069,7 @@ export class DisneylandParis extends Destination {
     // publishes in the wait feed. They'd otherwise inherit a misleading
     // synthetic CLOSED + STANDBY:null all day. Instead we emit
     // OPERATING/CLOSED derived from today's POI schedule (or park-hours
-    // fallback) and no queue. Detection is data-driven: persist a 30-day
-    // cache of IDs that have ever appeared in the wait feed.
+    // fallback) and no queue.
 
     // Wait-feed history: which attractions are queue-bearing? Walkthroughs
     // never appear here. 30-day TTL covers normal refurb cycles.
@@ -1077,6 +1082,25 @@ export class DisneylandParis extends Destination {
       if (wt.entityId) queueBearingIds.add(ID_ALIASES[wt.entityId] ?? wt.entityId);
     }
     CacheLib.set(queueHistoryKey, [...queueBearingIds], 30 * 24 * 60 * 60); // 30 days
+
+    // Recently-seen single-rider ids, OR'd with the POI facet below. Entries
+    // carry their own timestamp rather than being re-seeded, so retirements
+    // actually lapse.
+    const srRecentKey = `${this.getCacheKeyPrefix()}:dlp:singleRiderRecent`;
+    const previousSR = CacheLib.get(srRecentKey) as Record<string, number> | null;
+    const srCutoff = Date.now() - SINGLE_RIDER_RECENT_SECONDS * 1000;
+    const singleRiderRecent: Record<string, number> = {};
+    if (previousSR && typeof previousSR === 'object') {
+      for (const [id, seenAt] of Object.entries(previousSR)) {
+        if (typeof seenAt === 'number' && seenAt > srCutoff) singleRiderRecent[id] = seenAt;
+      }
+    }
+    for (const wt of waitTimes) {
+      if (wt.entityId && wt.singleRider?.isAvailable === true) {
+        singleRiderRecent[wt.entityId] = Date.now();
+      }
+    }
+    CacheLib.set(srRecentKey, singleRiderRecent, SINGLE_RIDER_RECENT_SECONDS);
 
     const attractionPois = emittablePois.filter(
       (poi) => this.mapEntityType(poi) === 'ATTRACTION',
@@ -1134,7 +1158,8 @@ export class DisneylandParis extends Destination {
         }
         if (!ld.queue) ld.queue = {};
         if (!ld.queue.STANDBY) ld.queue.STANDBY = {waitTime: null};
-        if (!ld.queue.SINGLE_RIDER && poi.singleRider === true) {
+        if (!ld.queue.SINGLE_RIDER &&
+          (poi.singleRider === true || singleRiderRecent[id] !== undefined)) {
           ld.queue.SINGLE_RIDER = {waitTime: null};
         }
       } else if (!ld) {


### PR DESCRIPTION
## Summary

`getEntities()` returned `tags: []` for all 129 entities. The tag code read `poi.minimumHeight` and `poi.height[].value`, but the POI query requested neither — and `minimumHeight` is not a field on the GraphQL `Attraction` type at all, so it could never have been requested.

`activities()` returns the `Activity` interface, so concrete-type fields need an inline fragment. Behind `... on Attraction` sit the values these tags were always meant to carry.

| | before | after |
|---|---|---|
| Entities carrying ≥1 tag | 0 | **23** of 129 |
| Tags emitted | 0 | **54** |
| DLP tests | 2 | **67** |

Nothing else moves: 129 entities in, 129 out, same counts per type, and the schedule path is untouched. No new HTTP request either — the fields ride along on the POI query that already runs. A second commit follows on from the same fragment and touches the live-data path; it is described in a comment below.

| tag | attractions | source |
|---|---|---|
| `PAID_RETURN_TIME` | 19 | `interests` → `disney-premier-access-one` |
| `MINIMUM_HEIGHT` | 10 | `height[].id` |
| `SINGLE_RIDER` | 9 | `singleRider` |
| `ONRIDE_PHOTO` | 7 | `interests` → `PhotoPass` |
| `UNSUITABLE_PREGNANT` | 5 | `physicalConsiderations` → `expectantMothersMayNotRide` |
| `MAY_GET_WET` | 4 | `interests` → `guestMayGetSplashed` |

No new tag type is introduced; all six already exist in `src/tags/tagTypes.ts`.

```json
{
  "id": "P1RA00",
  "name": "Big Thunder Mountain",
  "entityType": "ATTRACTION",
  "tags": [
    {"tag": "MINIMUM_HEIGHT", "tagName": "Minimum Height", "value": {"height": 102, "unit": "cm"}},
    {"tag": "UNSUITABLE_PREGNANT", "tagName": "Unsuitable for Pregnant People"},
    {"tag": "PAID_RETURN_TIME", "tagName": "Paid Return Time"},
    {"tag": "ONRIDE_PHOTO", "tagName": "On-Ride Photo"}
  ]
}
```

## Height is parsed from the facet id, not its value

Each `height` entry has an `id` and a display `value`. The value is localised — the same restriction reads `1.20 m` under `en-gb` and `1,20 m` under `fr-fr` — while the ids (`anyHeight`, `81cm`, `1_02m`, `1_07m`, `1_20m`, `1_40m`) are identical across every market checked. Since `DLP_LANGUAGE` is configurable, a value-based parser would report `1,20 m` as 100 cm under a French market. This matches how `shdr` reads its height facet.

The ten restrictions published today: 81 cm (Autopia, Toy Soldiers Parachute Drop), 1.02 m (Big Thunder Mountain, Star Tours, Tower of Terror), 1.07 m (Crush's Coaster), 1.20 m (Flight Force, RC Racer, Hyperspace Mountain), 1.40 m (Indiana Jones).

## Premier Access

`interests` carries three Premier Access facets. `disney-premier-access-one` and `orion` name the same 19 attractions; `disney-premier-access-ultimate` names 18 of those. Those 19 are exactly the 19 `attractionId`s the live Premier Access endpoint returns — no difference in either direction — so the tag agrees by construction with the `queue.PAID_RETURN_TIME` the live path already emits.

## PhotoPass → ONRIDE_PHOTO

Worth flagging, because the facet names the service rather than the camera. Ten POI entries carry `PhotoPass`. Seven are emitted, and all seven are rides with an on-ride camera: Flight Force, Big Thunder Mountain, Buzz Lightyear Laser Blast, Frozen Ever After, Pirates of the Caribbean, Hyperspace Mountain, Tower of Terror. The other three are walk-up photo locations — *Meet Mickey Mouse*, *Princess Pavilion*, *Welcome to Starport* — all `-OLD` entries flagged `Hide from Web List + Mobile App`, so the visibility filter already drops them. The mapping is therefore exact over the published set, but it would over-tag if Disney ever surfaces a visible walk-up PhotoPass location. Happy to drop this one line if you'd rather not carry that.

## What the feed offers and this deliberately leaves alone

- `fastPass` and `virtualQueue` are real Boolean fields on `Attraction`, but `false` on all 62 attractions — `fastPass` included, on the same 19 rides whose `interests` and live feed both say Premier Access is sold. Neither flag tracks reality, so neither is used.
- `physicalConsiderations` also publishes `mustBeInGoodHealth` (3), `typesOfLimbImpairement` and `typesOfLimbImpairementText` (1 each). No existing tag type fits, and inventing one is out of scope here.
- `subLocation` names the land (Fantasyland, Worlds of Pixar, …) for 61 of 62 attractions. There is no `LAND` entity type and no location tag that fits.
- `coordinates` only ever carries `Guest Entrance` for attractions, which is already `entity.location`. Per `TAG_DEVELOPMENT_GUIDE.md`, no `LOCATION` tag.
- `minimumHeight`, `maximumHeight`, `thrills`, `photoPass`, `onRidePhoto`, `mayGetWet`, `childSwap` and `description` were each probed against the schema and every one comes back `FieldUndefined` on `Attraction`.

## Removed

`parseHeightCm` as a method, the `minimumHeight` type member, and the `value`/`iconFont` members of `height[]` — none of them reachable, and nothing else in the repo reads them. The parser returns as a module-level helper next to the type it parses, alongside `parseDLPWait` and `parseDLPDate`.

`getPOIData`'s `cacheVersion` goes 2 → 3 so warm caches don't serve the pre-fragment shape after deploy. The HTTP layer keys on the request body, so that layer invalidates itself.

One thing to watch on merge: #293 bumps the same `cacheVersion` to the same 3, and both branches add a module constant right after `SHOW_SUBTYPES` and restructure the same `DLPPOIEntity` block. The constant and the type block do conflict, so those can't slip through — but **`cacheVersion` does not conflict**, because both sides make the identical edit, so git resolves it silently to 3. Whichever lands second needs taking to `cacheVersion: 4` by hand, since by then the shape will have changed twice. Verified by merging the branches locally.

## Robustness

`buildTags` runs inside `buildEntityList`, so one bad record would take down the whole entity list rather than a single attraction, and a bad facet id would put nonsense in the output rather than nothing.

The malformed shapes are driven through the public `getEntities()` path, none of which throws or produces a tag: the three facet lists as `null`, as a string, as a number, as a bare object, containing `null` entries, containing entries with no `id`, and with non-string ids; `singleRider` as `'yes'`, `1`, `{}`; and `Attraction` itself as `null`, a string, `[null]`, `[{}]`, `[42]`. Repeating a facet 500 times still yields one tag.

`parseHeightCm` accepts only `anyHeight`-style ids it recognises. Rejected: the empty string, whitespace, `0cm`, `0_00m`, `-5cm`, `1e3cm`, `1_2_3m`, a bare `m`, an unterminated `1_20`, an imperial `36in`, and the case- and space-variants `81CM` and `" 81cm "`. Two guards do real work:

- `cm > 0`, because `isHeightValue` accepts `height >= 0` — a `0cm` facet would otherwise ship a valid-but-meaningless `{height: 0, unit: 'cm'}`.
- `cm <= 300`, matching `oceanpark`'s `HEIGHT_NO_LIMIT_CM`, so a mistyped `999999cm` is dropped instead of published. `300cm` itself still passes.

One case does throw, and it predates this change: `flattenPOI` calls `Object.entries` on its argument, so a literally `null` POI response fails. It is unreachable — `getPOIData` returns `data?.data || {}` — and out of scope here.

## Test plan

- [x] `npm test src/parks/dlp` — 67 tests across 3 files
- [x] `npx tsc --noEmit`; test files typechecked separately, since `tsconfig.json` excludes `**/__tests__`
- [x] `npm run dev -- disneylandparis --clear-cache` — 4/4, 129 entities, unchanged counts per type
- [x] Full suite: 1744 passing; the two failures in `cache.test.ts` / `cachePragmas.test.ts` are pre-existing on `main` (SQLite WAL pragmas on Windows)
- [x] Every emitted tag passes `TagBuilder.validateAll()`; no non-`ATTRACTION` entity carries one
