### PR TITLE
fix(dlp): publish only schedules that can be attached to something

### DIFF
--- a/src/parks/dlp/__tests__/schedules.test.ts
+++ b/src/parks/dlp/__tests__/schedules.test.ts
@@ -1,0 +1,112 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * The schedule feed covers far more than the POI set the park publishes —
+ * hotel and Disney Village restaurants, character meets, and records the
+ * visibility filter drops. Only entities that actually get emitted may carry
+ * schedules.
+ */
+const OPERATING = {startTime: '09:30:00', endTime: '22:00:00', status: 'OPERATING'};
+
+function stubbedPark(activities: unknown): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Attraction: [
+      {id: 'P1RA00', name: 'Big Thunder Mountain', type: 'Attraction', location: {id: 'P1'}},
+      {
+        id: 'P1DA13',
+        name: 'Mickey’s PhilharMagic',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from the Service',
+      },
+      {id: 'P2AC00', name: 'Ignored', type: 'Attraction', location: {id: 'P2'}},
+    ],
+    Entertainment: [
+      {id: 'P1MG03', name: 'Meet Goofy', type: 'Entertainment', subType: 'Meet', location: {id: 'P1'}},
+    ],
+    Restaurant: [
+      {id: 'H01R01', name: 'La Table de Lumière', type: 'Restaurant', location: {id: 'H01'}},
+    ],
+  });
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(activities);
+
+  return park;
+}
+
+/** Ids that end up with a schedule, given what the schedule feed returned. */
+async function scheduledIds(activities: unknown): Promise<string[]> {
+  const schedules = await stubbedPark(activities).getSchedules();
+  return schedules.map((s) => s.id).sort();
+}
+
+const feedFor = (ids: string[], hours: unknown = OPERATING) =>
+  ids.map((id) => ({id, name: id, schedules: [hours]}));
+
+describe('DLP schedules', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  // === Only published entities ===
+
+  it('keeps a schedule for a published attraction', async () => {
+    expect(await scheduledIds(feedFor(['P1RA00']))).toEqual(['P1RA00']);
+  });
+
+  it('keeps park schedules', async () => {
+    expect(await scheduledIds(feedFor(['P1']))).toEqual(['P1']);
+  });
+
+  it.each([
+    ['a hotel restaurant outside the parks', 'H01R01'],
+    ['an attraction the visibility filter drops', 'P1DA13'],
+    ['an entity on the ignore list', 'P2AC00'],
+    ['entertainment that is not a show subtype', 'P1MG03'],
+    ['an id absent from the POI feed entirely', 'D01R02'],
+  ])('drops the schedule for %s', async (_label, id) => {
+    expect(await scheduledIds(feedFor([id]))).toEqual([]);
+  });
+
+  it('keeps only the published ids when the feed mixes them', async () => {
+    expect(await scheduledIds(feedFor(['P1', 'P1RA00', 'H01R01', 'P1DA13', 'D01R02'])))
+      .toEqual(['P1', 'P1RA00']);
+  });
+
+  // === Schedule contents ===
+
+  it('publishes one entry per day of the 60-day window', async () => {
+    const schedules = await stubbedPark(feedFor(['P1RA00'])).getSchedules();
+    expect(schedules[0].schedule).toHaveLength(60);
+  });
+
+  it('maps EXTRA_MAGIC_HOURS and PERFORMANCE_TIME to their own types', async () => {
+    const magic = await stubbedPark(feedFor(['P1'], {
+      startTime: '08:30:00', endTime: '09:30:00', status: 'EXTRA_MAGIC_HOURS',
+    })).getSchedules();
+    expect(magic[0].schedule[0]).toMatchObject({type: 'EXTRA_HOURS', description: 'Extra Magic Hours'});
+
+    const show = await stubbedPark(feedFor(['P1RA00'], {
+      startTime: '21:00:00', endTime: '21:30:00', status: 'PERFORMANCE_TIME',
+    })).getSchedules();
+    expect(show[0].schedule[0]).toMatchObject({type: 'INFO', description: 'Performance Time'});
+  });
+
+  it.each(['REFURBISHMENT', 'CLOSED'])('skips %s days', async (status) => {
+    expect(await scheduledIds(feedFor(['P1RA00'], {...OPERATING, status}))).toEqual([]);
+  });
+
+  it('keeps the seconds the feed publishes', async () => {
+    const schedules = await stubbedPark(feedFor(['P1RA00'], {
+      startTime: '00:00:00', endTime: '23:59:00', status: 'OPERATING',
+    })).getSchedules();
+    expect(schedules[0].schedule[0].closingTime).toMatch(/T23:59:00/);
+  });
+
+  it('survives a schedule fetch that rejects', async () => {
+    const park = stubbedPark(null);
+    vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream down'));
+    await expect(park.getSchedules()).resolves.toEqual([]);
+  });
+});

--- a/src/parks/dlp/__tests__/schedules.test.ts
+++ b/src/parks/dlp/__tests__/schedules.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
@@ -47,7 +47,25 @@ const feedFor = (ids: string[], hours: unknown = OPERATING) =>
   ids.map((id) => ({id, name: id, schedules: [hours]}));
 
 describe('DLP schedules', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  // === POI unavailability must not empty the feed ===
+
+  it.each([
+    ['getPOIData rejects', () => Promise.reject(new Error('POI upstream 503'))],
+    ['getPOIData returns an empty object', () => Promise.resolve({})],
+    ['POI carries only the park records', () => Promise.resolve({
+      ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    })],
+  ])('publishes unfiltered schedules when %s', async (_label, poi) => {
+    const park = new DisneylandParis();
+    vi.spyOn(park as any, 'getPOIData').mockImplementation(poi as any);
+    vi.spyOn(park as any, 'getScheduleForDate')
+      .mockResolvedValue(feedFor(['P1', 'P1RA00', 'H01R01']));
+
+    const schedules = await park.getSchedules();
+    expect(schedules.map((s) => s.id).sort()).toEqual(['H01R01', 'P1', 'P1RA00']);
+  });
 
   // === Only published entities ===
 

--- a/src/parks/dlp/__tests__/schedules.test.ts
+++ b/src/parks/dlp/__tests__/schedules.test.ts
@@ -5,7 +5,7 @@ import {DisneylandParis} from '../disneylandparis.js';
  * The schedule feed covers far more than the POI set the park publishes —
  * hotel and Disney Village restaurants, character meets, and records the
  * visibility filter drops. Only entities that actually get emitted may carry
- * schedules.
+ * schedules, and one unusable row may not cost the other sixty days.
  */
 const OPERATING = {startTime: '09:30:00', endTime: '22:00:00', status: 'OPERATING'};
 
@@ -102,6 +102,46 @@ describe('DLP schedules', () => {
       startTime: '00:00:00', endTime: '23:59:00', status: 'OPERATING',
     })).getSchedules();
     expect(schedules[0].schedule[0].closingTime).toMatch(/T23:59:00/);
+  });
+
+  // === Malformed input ===
+
+  it.each([
+    ['the feed returns null', null],
+    ['the feed returns a string', 'text'],
+    ['the feed returns a null entry', [null]],
+    ['an entry has no id or schedules', [{}]],
+    ['schedules is null', [{id: 'P1RA00', schedules: null}]],
+    ['schedules is a string', [{id: 'P1RA00', schedules: 'text'}]],
+    ['schedules is a number', [{id: 'P1RA00', schedules: 42}]],
+    ['schedules is an object', [{id: 'P1RA00', schedules: {}}]],
+    ['a row is null', [{id: 'P1RA00', schedules: [null]}]],
+    ['a row has no times', [{id: 'P1RA00', schedules: [{status: 'OPERATING'}]}]],
+  ])('survives when %s', async (_label, activities) => {
+    expect(await scheduledIds(activities)).toEqual([]);
+  });
+
+  it.each([
+    'abc',
+    '9:30:00',
+    '25:00:00',
+    '09:99:00',
+    '09:30:99',
+    '0930',
+    '',
+  ])('skips a row whose time reads "%s"', async (startTime) => {
+    expect(await scheduledIds(feedFor(['P1RA00'], {...OPERATING, startTime}))).toEqual([]);
+  });
+
+  it('drops only the unusable row, not the whole build', async () => {
+    const schedules = await stubbedPark([{
+      id: 'P1RA00',
+      name: 'Big Thunder Mountain',
+      schedules: [OPERATING, {...OPERATING, startTime: 'abc'}],
+    }]).getSchedules();
+
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].schedule).toHaveLength(60);
   });
 
   it('survives a schedule fetch that rejects', async () => {

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -29,6 +29,16 @@ function stubbedPark(): DisneylandParis {
         location: {id: 'P1'},
         hideFunctionality: 'Hide from Web List + Mobile App',
       },
+      {
+        // "Hide from the Mobile App" marks content pages, not venues, so it is
+        // not a hide rule. Correcting it into one would drop this show.
+        id: 'P1G108',
+        name: 'The Lion King: Rhythms of the Pride Lands',
+        type: 'Entertainment',
+        subType: 'Stage Show',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from the Mobile App',
+      },
     ],
   });
   return park;
@@ -48,5 +58,10 @@ describe('DLP visibility exceptions', () => {
   it('still drops other hidden shows not in the exception set', async () => {
     const entities = await stubbedPark().getEntities();
     expect(entities.find((e) => e.id === 'P1G107')).toBeUndefined();
+  });
+
+  it('publishes a show flagged "Hide from the Mobile App"', async () => {
+    const entities = await stubbedPark().getEntities();
+    expect(entities.find((e) => e.id === 'P1G108')?.entityType).toBe('SHOW');
   });
 });

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
@@ -69,7 +69,7 @@ function stubbedPark(): DisneylandParis {
 }
 
 describe('DLP visibility exceptions', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   it('surfaces railroad stations flagged Hide from Web List + Mobile App', async () => {
     const entities = await stubbedPark().getEntities();

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -677,6 +677,27 @@ export class DisneylandParis extends Destination {
   }
 
   /**
+   * Ids the entity list publishes, or null when POI is unavailable — a
+   * GraphQL 200-with-errors body reaches getPOIData as an empty object with
+   * no exception, and 12h of cache would pin it. Callers filtering on the
+   * result must treat null as "do not filter", not "filter everything out".
+   */
+  private async getPublishedEntityIds(): Promise<Set<string> | null> {
+    try {
+      const pois = await this.getEmittablePOIEntities();
+      if (pois.length === 0) return null;
+      const ids = new Set<string>(pois.map((poi) => poi.id));
+      // The parks and the destination are published but are not POI records.
+      ids.add('P1');
+      ids.add('P2');
+      ids.add('dlp');
+      return ids;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Map DLP wait time status to our status
    */
   private mapStatus(status: string | null): string {
@@ -1085,7 +1106,8 @@ export class DisneylandParis extends Destination {
     // Disney Village restaurants, character meets, records the visibility
     // filter drops. Hours for an entity we never emit can't be attached to
     // anything, so the published list is the authority on what to keep.
-    const publishedIds = new Set((await this.buildEntityList()).map((entity) => entity.id));
+    // When POI is unavailable, schedules publish unfiltered rather than empty.
+    const publishedIds = await this.getPublishedEntityIds();
 
     // Fetch 60 days of schedule data
     for (let i = 0; i < 60; i++) {
@@ -1105,7 +1127,7 @@ export class DisneylandParis extends Destination {
 
       for (const entity of dateData) {
         if (!Array.isArray(entity?.schedules)) continue;
-        if (!publishedIds.has(entity.id)) continue;
+        if (publishedIds && !publishedIds.has(entity.id)) continue;
 
         for (const hours of entity.schedules) {
           if (hours?.status === 'REFURBISHMENT' || hours?.status === 'CLOSED') continue;
@@ -1118,8 +1140,10 @@ export class DisneylandParis extends Destination {
           const openTime = constructDateTime(dateString, hours.startTime, this.timezone);
           let closeTime = constructDateTime(dateString, hours.endTime, this.timezone);
 
-          // Handle midnight crossing: if close < open, add 1 day to close
-          if (hours.endTime < hours.startTime) {
+          // Handle midnight crossing: if close < open, add 1 day to close.
+          // Compared on HH:MM so a mixed HH:MM / HH:MM:SS pair can't
+          // fabricate a rollover.
+          if (hours.endTime.slice(0, 5) < hours.startTime.slice(0, 5)) {
             const nextDay = addDays(new Date(`${dateString}T00:00:00`), 1);
             const nextDayStr = formatInTimezone(nextDay, this.timezone, 'date');
             const [nmm, ndd, nyyyy] = nextDayStr.split('/');

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -52,6 +52,9 @@ const SHOW_SUBTYPES = new Set([
   'Parade',
 ]);
 
+/** Wall-clock time the schedule feed publishes, e.g. `21:30:00` */
+const TIME_OF_DAY = /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/;
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -1091,11 +1094,16 @@ export class DisneylandParis extends Destination {
       if (!dateData) continue;
 
       for (const entity of dateData) {
-        if (!entity.schedules) continue;
+        if (!Array.isArray(entity?.schedules)) continue;
         if (!publishedIds.has(entity.id)) continue;
 
         for (const hours of entity.schedules) {
-          if (hours.status === 'REFURBISHMENT' || hours.status === 'CLOSED') continue;
+          if (hours?.status === 'REFURBISHMENT' || hours?.status === 'CLOSED') continue;
+
+          // These arrive as plain GraphQL strings, and constructDateTime throws
+          // on anything it can't parse — which costs every entity all 60 days,
+          // not just this row.
+          if (!TIME_OF_DAY.test(hours?.startTime) || !TIME_OF_DAY.test(hours?.endTime)) continue;
 
           const openTime = constructDateTime(dateString, hours.startTime, this.timezone);
           let closeTime = constructDateTime(dateString, hours.endTime, this.timezone);

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -37,11 +37,16 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
 ]);
 
-/** Hide rules that exclude entities from the POI list */
+/**
+ * Hide rules that exclude entities from the POI list.
+ *
+ * `Hide from the Mobile App` is deliberately not one of them. Every record
+ * carrying it is an off-site or guest-information page, not a venue in
+ * either park.
+ */
 const HIDE_RULES = new Set([
   'Hide from Web List + Mobile App',
   'Hide from the Service',
-  'Hide from Mobile App',
 ]);
 
 /** Entertainment subtypes that map to SHOW entity type */

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1068,6 +1068,12 @@ export class DisneylandParis extends Destination {
     const now = new Date();
     const scheduleMap = new Map<string, any[]>();
 
+    // The schedule feed reaches well past the POI set we publish — hotel and
+    // Disney Village restaurants, character meets, records the visibility
+    // filter drops. Hours for an entity we never emit can't be attached to
+    // anything, so the published list is the authority on what to keep.
+    const publishedIds = new Set((await this.buildEntityList()).map((entity) => entity.id));
+
     // Fetch 60 days of schedule data
     for (let i = 0; i < 60; i++) {
       const date = addDays(now, i);
@@ -1086,7 +1092,7 @@ export class DisneylandParis extends Destination {
 
       for (const entity of dateData) {
         if (!entity.schedules) continue;
-        if (IGNORE_ENTITIES.has(entity.id)) continue;
+        if (!publishedIds.has(entity.id)) continue;
 
         for (const hours of entity.schedules) {
           if (hours.status === 'REFURBISHMENT' || hours.status === 'CLOSED') continue;


### PR DESCRIPTION
## Summary

Three fixes in the DLP schedule and filter code, none of which changes an entity or a live-data row.

| | before | after |
|---|---|---|
| Schedule rows | 133 | **95** |
| Schedule days | 14,707 | **8,494** |
| Rows pointing at a non-existent entity | 38 | **0** |
| Entities | 129 | 129 |
| Live rows | 68 | 68 |
| DLP tests | 2 | **39** |

(Counts as measured at the time; the absolute day totals roll with the 60-day window and are not reproducible to the digit.)

## Schedules for entities that do not exist

`buildSchedules` emitted a row for everything the schedule feed returned. That feed covers far more than the POI set this destination publishes, so 38 of 133 rows — **6,213 of 14,707 days, 42% of the output** — pointed at ids no consumer can look up:

- 21 hotel and Disney Village restaurants (`H01R01` … `H07R01`, `D01R*`), which sit outside P1/P2 and are correctly not entities
- 14 character meets, whose `subType` is not in `SHOW_SUBTYPES`
- 2 railroad stations and `P1DA13` *Mickey's PhilharMagic*, dropped by the visibility filter
- the rest, records the ignore list covers

`buildEntityList` is now the authority on what may carry a schedule, rather than a second filter that can drift from it. Both parks keep all 120 days each, including every one of the 120 `EXTRA_HOURS` entries.

Worth saying plainly: most of today's excess is other work in flight, not a separate defect. Once #292's railroad stations and #293's character meets become entities, the same filter leaves **22 rows and 1,258 days**, almost all of it hotel dining. The headline number shrinks accordingly depending on merge order.

## One unusable row no longer costs every schedule

The feed's times were parsed with no validation, and `constructDateTime` throws on anything it cannot read — out of `buildSchedules` entirely, so all 95 entities lose all 60 days over one bad row. Fuzzing the public path, **14 of 19 shapes threw**, including the realistic case of one good row next to one broken one:

```
one good + one broken     THROW  Invalid time value      →  OK  rows=1 days=60
startTime = "9:30:00"     THROW  Invalid time value      →  OK  row skipped
schedules = [null]        THROW  reading 'status'        →  OK  row skipped
schedules = 42            THROW  not iterable            →  OK  entity skipped
activities = [null]       THROW  reading 'schedules'     →  OK  entity skipped
```

The time pattern is deliberately strict — two-digit hour, real minute and second ranges — because `9:30:00` reaches `constructDateTime` and throws exactly like `abc` does. Across **15,681 rows** in the live 60-day window it rejects none: every published time is `HH:MM:SS` with seconds of either `00` or `59`. The `:59` values are the 23:59 refurbishment placeholders, which is why the string is passed through untouched rather than truncated to `HH:MM`.

## A hide rule that has never matched anything

`HIDE_RULES` carried `Hide from Mobile App`. That string appears on **0 of 584** POI records — the value Disney emits is `Hide from the Mobile App`, as you noted reviewing #292.

Correcting the spelling is the obvious move and I think it is the wrong one. The 44 records wearing the real flag are guest-service articles (*Free WiFi*, *Parking Fees*, *Pets*, *Tax refunds*, *Expectant mothers*), day trips to Fontainebleau, Versailles and Provins, two off-site attractions, a third-party hotel and the Disney Village web radio. Content pages, not venues. None of them sits in a category and park this destination publishes, so the correction is measurably a no-op — 126 entities either way, nothing lost, nothing gained — while quietly turning "hidden in the app" into a reason to drop a ride. That is the opposite of where #292 landed for the two railroad stations.

So the dead rule is removed rather than repaired, and `visibility.test.ts` now pins a show wearing the flag as published, so a future spelling fix has to argue with a red test first.

## Merge notes

Touches `buildSchedules`, the `HIDE_RULES` constant and one new constant after `SHOW_SUBTYPES`. #293 and #295 both add a constant in that same spot, so expect a one-hunk conflict with whichever lands first; there is no conflict in `buildSchedules` itself. If #294 lands first, its `TIME_OF_DAY` is the looser `/^\d{2}:\d{2}/` — keep this stricter one, which satisfies both call sites.

Happy to split this into separate PRs if you would rather review them apart.

## Test plan

- [x] `npm test src/parks/dlp` — 39 tests across 2 files
- [x] `npx tsc --noEmit`; test files typechecked separately, since `tsconfig.json` excludes `**/__tests__`
- [x] `npm run dev -- disneylandparis --clear-cache` — 4/4, 129 entities and 68 live rows unchanged, 95 schedules
- [x] Full suite: 1,723 passing; the two failures in `cache.test.ts` / `cachePragmas.test.ts` are pre-existing on `main` (SQLite WAL pragmas on Windows)
- [x] 19 malformed schedule payloads driven through the public `getSchedules()` path, none throwing
