### PR TITLE
feat(dlp): surface Mickey's PhilharMagic

### DIFF
--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -1,11 +1,12 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 
 /**
- * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES). Entities
- * listed in VISIBILITY_EXCEPTIONS bypass that. P1GS93 ("Live Your Story") is a
- * real Castle Stage show Disney flags "Hide from the Service", so it must be
- * force-surfaced while other hidden shows stay filtered.
+ * A hidden POI is normally dropped by filterPOIEntities (HIDE_RULES); entities
+ * in VISIBILITY_EXCEPTIONS bypass that. Mickey's PhilharMagic exists twice in
+ * POI — published Entertainment record P1G103 and hidden Attraction twin
+ * P1DA13 — and must surface exactly once, as P1G103, with the twin's live
+ * and schedule data folded onto it.
  */
 function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
@@ -35,6 +36,7 @@ function stubbedPark(): DisneylandParis {
         hideFunctionality: 'Hide from Web List + Mobile App',
       },
       {
+        // The hidden PhilharMagic twin: stays filtered, its data is aliased.
         id: 'P1DA13',
         name: 'Mickey’s PhilharMagic',
         type: 'Attraction',
@@ -69,13 +71,27 @@ function stubbedPark(): DisneylandParis {
         location: {id: 'P1'},
         hideFunctionality: 'Hide from Web List + Mobile App',
       },
+      {
+        // The published PhilharMagic record.
+        id: 'P1G103',
+        name: 'Mickey’s PhilharMagic',
+        type: 'Entertainment',
+        subType: 'Stage Show',
+        location: {id: 'P1'},
+      },
     ],
   });
   return park;
 }
 
+function stubLiveFeeds(park: DisneylandParis, waitTimes: unknown[] = []): void {
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue(waitTimes);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+}
+
 describe('DLP visibility exceptions', () => {
-  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   it('surfaces railroad stations flagged Hide from Web List + Mobile App', async () => {
     const entities = await stubbedPark().getEntities();
@@ -97,12 +113,45 @@ describe('DLP visibility exceptions', () => {
     expect((lys as any)?.parkId).toBe('P1');
   });
 
-  it('surfaces P1DA13 (Mickey’s PhilharMagic) despite its "Hide from the Service" flag', async () => {
+  it('publishes exactly one PhilharMagic: P1G103 as a show-type attraction', async () => {
     const entities = await stubbedPark().getEntities();
-    const philharMagic = entities.find((e) => e.id === 'P1DA13');
-    expect(philharMagic).toBeDefined();
-    expect(philharMagic?.entityType).toBe('ATTRACTION');
-    expect((philharMagic as any)?.parkId).toBe('P1');
+    const matches = entities.filter((e) => /philharmagic/i.test(String(e.name)));
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe('P1G103');
+    expect(matches[0].entityType).toBe('ATTRACTION');
+    expect((matches[0] as any).attractionType).toBe('SHOW');
+    expect((matches[0] as any).parkId).toBe('P1');
+  });
+
+  it('folds the hidden twin\'s wait time onto P1G103 and keeps its showtimes', async () => {
+    const park = stubbedPark();
+    stubLiveFeeds(park, [
+      {entityId: 'P1DA13', type: 'Attraction', status: 'OPERATING', postedWaitMinutes: 15},
+    ]);
+    vi.spyOn(park as any, 'getScheduleForDate').mockImplementation(async (date) => [
+      {id: 'P1G103', schedules: [
+        {date, startTime: '12:30:00', endTime: '12:30:00', status: 'PERFORMANCE_TIME'},
+      ]},
+    ]);
+
+    const live = await park.getLiveData();
+    expect(live.find((l) => l.id === 'P1DA13')).toBeUndefined();
+    const row = live.find((l) => l.id === 'P1G103');
+    expect(row?.queue?.STANDBY).toEqual({waitTime: 15});
+    expect(row?.showtimes).toHaveLength(1);
+  });
+
+  it('attaches the twin\'s schedule rows to P1G103 instead of orphaning them', async () => {
+    const park = stubbedPark();
+    vi.spyOn(park as any, 'getScheduleForDate').mockImplementation(async (date) => [
+      {id: 'P1DA13', schedules: [
+        {date, startTime: '12:30:00', endTime: '17:30:00', status: 'OPERATING'},
+      ]},
+    ]);
+
+    const schedules = await park.getSchedules();
+    expect(schedules.find((s) => s.id === 'P1DA13')).toBeUndefined();
+    expect(schedules.find((s) => s.id === 'P1G103')?.schedule).toHaveLength(60);
   });
 
   it('still drops other retirement-flagged POIs not in the exception set', async () => {

--- a/src/parks/dlp/__tests__/visibility.test.ts
+++ b/src/parks/dlp/__tests__/visibility.test.ts
@@ -34,6 +34,22 @@ function stubbedPark(): DisneylandParis {
         location: {id: 'P1'},
         hideFunctionality: 'Hide from Web List + Mobile App',
       },
+      {
+        id: 'P1DA13',
+        name: 'Mickey’s PhilharMagic',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from the Service',
+      },
+      {
+        // Control: the only other attraction carrying "Hide from the Service",
+        // and it appears in no live feed — must stay dropped.
+        id: 'P1JF00',
+        name: 'Gardens of Wonder',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        hideFunctionality: 'Hide from the Service',
+      },
     ],
     Entertainment: [
       {
@@ -81,9 +97,18 @@ describe('DLP visibility exceptions', () => {
     expect((lys as any)?.parkId).toBe('P1');
   });
 
+  it('surfaces P1DA13 (Mickey’s PhilharMagic) despite its "Hide from the Service" flag', async () => {
+    const entities = await stubbedPark().getEntities();
+    const philharMagic = entities.find((e) => e.id === 'P1DA13');
+    expect(philharMagic).toBeDefined();
+    expect(philharMagic?.entityType).toBe('ATTRACTION');
+    expect((philharMagic as any)?.parkId).toBe('P1');
+  });
+
   it('still drops other retirement-flagged POIs not in the exception set', async () => {
     const entities = await stubbedPark().getEntities();
     expect(entities.find((e) => e.id === 'P1G107')).toBeUndefined();
     expect(entities.find((e) => e.id === 'P1DA14-OLD')).toBeUndefined();
+    expect(entities.find((e) => e.id === 'P1JF00')).toBeUndefined();
   });
 });

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -35,15 +35,27 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
   'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
-  // Also flagged "Hide from the Service", but a running attraction: it posts
-  // wait times and the schedule feed lists it as operating.
-  'P1DA13', // Mickey's PhilharMagic
   // Disney flags these "Hide from Web List + Mobile App", which it otherwise uses as a
   // retirement marker (every old-/-OLD record carries it). These two are live and still
   // report wait times, so they are the only members of that flag we surface.
   'P1DA10', // Disneyland Railroad Discoveryland Station
   'P1NA16', // Disneyland Railroad Fantasyland Station
 ]);
+
+/**
+ * DLP splits Mickey's PhilharMagic across two records: published
+ * Entertainment record P1G103 carries the showtimes, while hidden Attraction
+ * twin P1DA13 carries the standby wait and a schedule restating those
+ * showtimes. Live and schedule rows for the twin fold onto the published id.
+ */
+const ID_ALIASES: Record<string, string> = {
+  P1DA13: 'P1G103',
+};
+
+/** Entity types keyed by id, checked ahead of the category mapping. */
+const ENTITY_TYPE_OVERRIDES: Record<string, Entity['entityType']> = {
+  P1G103: 'ATTRACTION', // PhilharMagic is an attraction across Disney resorts
+};
 
 /** Hide rules that exclude entities from the POI list */
 const HIDE_RULES = new Set([
@@ -650,6 +662,8 @@ export class DisneylandParis extends Destination {
    * Map DLP entity type to our entity type
    */
   private mapEntityType(entity: DLPPOIEntity & {category: string}): Entity['entityType'] | undefined {
+    const override = ENTITY_TYPE_OVERRIDES[entity.id];
+    if (override) return override;
     if (entity.category === 'Attraction') return 'ATTRACTION';
     if (entity.category === 'Restaurant') return 'RESTAURANT';
     if (entity.category === 'Entertainment') {
@@ -754,6 +768,11 @@ export class DisneylandParis extends Destination {
         entity.location = {latitude: coords.lat, longitude: coords.lng};
       }
 
+      if (poi.id === 'P1G103') {
+        // 4D cinema — destination.ts otherwise defaults ATTRACTION to RIDE.
+        (entity as Entity & {attractionType?: string}).attractionType = 'SHOW';
+      }
+
       // Build tags
       const tags: any[] = [];
 
@@ -837,7 +856,7 @@ export class DisneylandParis extends Destination {
       if (!wt.entityId || wt.type !== 'Attraction') continue;
       if (IGNORE_ENTITIES.has(wt.entityId)) continue;
 
-      const ld = getOrCreate(wt.entityId);
+      const ld = getOrCreate(ID_ALIASES[wt.entityId] ?? wt.entityId);
       if (!ld) continue;
       ld.status = this.mapStatus(wt.status) as any;
 
@@ -999,7 +1018,7 @@ export class DisneylandParis extends Destination {
       Array.isArray(previousHistory) ? previousHistory : [],
     );
     for (const wt of waitTimes) {
-      if (wt.entityId) queueBearingIds.add(wt.entityId);
+      if (wt.entityId) queueBearingIds.add(ID_ALIASES[wt.entityId] ?? wt.entityId);
     }
     CacheLib.set(queueHistoryKey, [...queueBearingIds], 30 * 24 * 60 * 60); // 30 days
 
@@ -1095,6 +1114,7 @@ export class DisneylandParis extends Destination {
       for (const entity of dateData) {
         if (!entity.schedules) continue;
         if (IGNORE_ENTITIES.has(entity.id)) continue;
+        const scheduleId = ID_ALIASES[entity.id] ?? entity.id;
 
         for (const hours of entity.schedules) {
           if (hours.status === 'REFURBISHMENT' || hours.status === 'CLOSED') continue;
@@ -1122,10 +1142,10 @@ export class DisneylandParis extends Destination {
             description = 'Performance Time';
           }
 
-          if (!scheduleMap.has(entity.id)) {
-            scheduleMap.set(entity.id, []);
+          if (!scheduleMap.has(scheduleId)) {
+            scheduleMap.set(scheduleId, []);
           }
-          scheduleMap.get(entity.id)!.push({
+          scheduleMap.get(scheduleId)!.push({
             date: dateString,
             openingTime: openTime,
             closingTime: closeTime,

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -35,6 +35,9 @@ const VISIBILITY_EXCEPTIONS = new Set([
   'P2EA00', // Frozen Ever After
   'P2DA00', // Tangled Spin
   'P1GS93', // Live Your Story – a Disney Princess Celebration (Castle Stage; Disney flags it "Hide from the Service")
+  // Also flagged "Hide from the Service", but a running attraction: it posts
+  // wait times and the schedule feed lists it as operating.
+  'P1DA13', // Mickey's PhilharMagic
   // Disney flags these "Hide from Web List + Mobile App", which it otherwise uses as a
   // retirement marker (every old-/-OLD record carries it). These two are live and still
   // report wait times, so they are the only members of that flag we surface.


### PR DESCRIPTION
Mickey's PhilharMagic ran without a published standby wait: its wait-feed row belongs to `P1DA13`, an Attraction record flagged `Hide from the Service` and filtered out of the POI list. It is not retired — the wait feed carries it alongside the rest of the ride estate, and the activity-schedule feed reports it OPERATING on every day of the window.

Review surfaced why simply excepting `P1DA13` was wrong: POI holds **two records for the same theatre**, and the other one is already published.

```
[Attraction]    P1DA13 | Mickey's PhilharMagic | hide="Hide from the Service" | wait feed, derived OPERATING schedule
[Entertainment] P1G103 | Mickey's PhilharMagic | no flag                      | showtimes (live on the wiki today)
```

`P1DA13`'s 60-day OPERATING window is exactly the first-to-last performance time of `P1G103` and tracks the timetable when it shifts — a derived restatement. Surfacing it would have created a name-level duplicate with the venue's data split in half.

**Approach:** keep the published id and fold the twin onto it.

- `P1G103` is emitted as an `ATTRACTION` via an id-keyed override ahead of the category mapping — the classification Walt Disney World, Disneyland Resort and Hong Kong use — with `attractionType: SHOW` set explicitly so `destination.ts` cannot default a 4D cinema to `RIDE`.
- `ID_ALIASES = {P1DA13: 'P1G103'}` folds the twin's rows onto the published id in the wait-times loop, the queue-bearing history and `buildSchedules`.
- `P1DA13` stays filtered; `VISIBILITY_EXCEPTIONS` and the hide rules are untouched.

**Effect:** entities stay at 131, and the published entity — stable id, stable UUID — now carries both halves. Verified live: `P1G103` reports `OPERATING` with a `STANDBY` wait and 11 showtimes, its schedule holds the performance times plus the twin's 60 OPERATING days, `P1DA13` appears nowhere, and orphaned schedule ids go 36 → 35 (the rest is #296's territory).

`P1JF00` Gardens of Wonder — the only other attraction carrying the flag, absent from every feed — remains the control: it stays filtered, and the test goes red if anyone widens the rule.

## Test plan

- [x] `npm test src/parks/dlp` — cardinality (exactly one PhilharMagic), `ATTRACTION`/`SHOW` type pair, folded wait time next to surviving showtimes, schedule attachment; 3 of 6 fail against the previous approach
- [x] `npx tsc --noEmit`
- [x] Verified against the live API (entities, live data, schedules — numbers above)
