### PR TITLE
fix(dlp): read park hours from the schedule feed, not the ride estate

### DIFF
--- a/src/__tests__/datetime.test.ts
+++ b/src/__tests__/datetime.test.ts
@@ -14,6 +14,7 @@ import {
   localFromFakeUtc,
   hostnameFromUrl,
   constructDateTime,
+  shiftDateString,
 } from '../datetime.js';
 
 describe('DateTime Utilities', () => {
@@ -795,5 +796,56 @@ describe('DateTime Utilities', () => {
     test('handles http URL', () => {
       expect(hostnameFromUrl('http://localhost/api')).toBe('localhost');
     });
+  });
+});
+
+describe('shiftDateString', () => {
+  it('steps forward and back a day', () => {
+    expect(shiftDateString('2026-08-13', 1)).toBe('2026-08-14');
+    expect(shiftDateString('2026-08-13', -1)).toBe('2026-08-12');
+    expect(shiftDateString('2026-08-13', 0)).toBe('2026-08-13');
+  });
+
+  it('crosses month, year and leap-day boundaries', () => {
+    expect(shiftDateString('2026-08-31', 1)).toBe('2026-09-01');
+    expect(shiftDateString('2026-12-31', 1)).toBe('2027-01-01');
+    expect(shiftDateString('2027-01-01', -1)).toBe('2026-12-31');
+    expect(shiftDateString('2028-02-28', 1)).toBe('2028-02-29');
+    expect(shiftDateString('2028-03-01', -1)).toBe('2028-02-29');
+  });
+
+  it('crosses a DST boundary without slipping', () => {
+    // Europe/Paris springs forward on 2026-03-29 and back on 2026-10-25.
+    expect(shiftDateString('2026-03-28', 1)).toBe('2026-03-29');
+    expect(shiftDateString('2026-03-29', 1)).toBe('2026-03-30');
+    expect(shiftDateString('2026-10-24', 1)).toBe('2026-10-25');
+    expect(shiftDateString('2026-10-25', 1)).toBe('2026-10-26');
+  });
+
+  it('steps by more than one day', () => {
+    expect(shiftDateString('2026-08-13', 60)).toBe('2026-10-12');
+  });
+
+  it('throws on an unparseable date rather than returning a wrong one', () => {
+    expect(() => shiftDateString('not-a-date', 1)).toThrow(RangeError);
+  });
+
+  it('steps identically whatever timezone the host runs in', () => {
+    // The whole point of the helper. `new Date('2026-08-13T00:00:00')` parses
+    // in the host zone, so the naive form fails to advance on any host east of
+    // UTC — and CI runs UTC, where the naive form looks fine. Pinning the zone
+    // here is what makes that regression catchable.
+    const original = process.env.TZ;
+    try {
+      for (const tz of ['UTC', 'Pacific/Kiritimati', 'Pacific/Auckland', 'Asia/Tokyo', 'Europe/Moscow', 'America/Los_Angeles']) {
+        process.env.TZ = tz;
+        expect(shiftDateString('2026-08-13', 1), tz).toBe('2026-08-14');
+        expect(shiftDateString('2026-12-31', 1), tz).toBe('2027-01-01');
+        expect(shiftDateString('2026-08-13', -1), tz).toBe('2026-08-12');
+      }
+    } finally {
+      if (original === undefined) delete process.env.TZ;
+      else process.env.TZ = original;
+    }
   });
 });

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -205,6 +205,27 @@ export function addDays(date: Date, days: number): Date {
 }
 
 /**
+ * Step a calendar date string by whole days, independent of the host timezone.
+ *
+ * `new Date('2026-08-13T00:00:00')` parses in the *host's* zone, so adding a
+ * day and reformatting in the park's zone silently returns the same date on
+ * any host east of that park. This anchors at noon UTC instead, which no
+ * offset or DST shift can push across a date boundary.
+ *
+ * @param dateStr Date in YYYY-MM-DD format
+ * @param days Whole days to add; may be negative
+ * @returns The resulting date in YYYY-MM-DD format
+ */
+export function shiftDateString(dateStr: string, days: number): string {
+  const anchored = new Date(`${dateStr}T12:00:00Z`);
+  if (!Number.isFinite(anchored.getTime())) {
+    throw new RangeError(`shiftDateString: unparseable date "${dateStr}"`);
+  }
+  anchored.setUTCDate(anchored.getUTCDate() + days);
+  return anchored.toISOString().slice(0, 10);
+}
+
+/**
  * Construct a full ISO 8601 datetime string from separate date, time, and timezone.
  * Replaces the per-park getXxxOffset() helpers that every park reimplemented.
  *

--- a/src/parks/dlp/__tests__/parkHours.test.ts
+++ b/src/parks/dlp/__tests__/parkHours.test.ts
@@ -38,6 +38,8 @@ function stubbedPark(opts: {
   walkthroughPark?: string;
   extraAttractions?: any[];
   waitTimes?: any[];
+  /** Per-entity rows in the schedule feed. Defaults to just the canary. */
+  entitySchedules?: any[];
 }): DisneylandParis {
   const park = new DisneylandParis();
   const today = parkToday();
@@ -56,22 +58,18 @@ function stubbedPark(opts: {
         // No `schedules` — this is the whole point: it must fall back.
       },
       {
-        // Canary. Carries its own window, so it resolves without park hours
-        // and must read OPERATING in every test. Without it, a test that only
-        // asserts CLOSED would pass just as happily against a dead pipeline.
+        // Canary. Carries its own window in the schedule feed, so it resolves
+        // without park hours and must read OPERATING in every test. Without
+        // it, a test that only asserts CLOSED would pass just as happily
+        // against a dead pipeline.
+        //
+        // No `schedules` here either. The POI blob is never the source for
+        // own-hours: it carries only the date it was fetched and is cached
+        // 12h, so past park-local midnight it is empty for the current date.
         id: 'P1MA03',
         name: 'Liberty Arcade',
         type: 'Attraction',
         location: {id: 'P1'},
-        // A narrow window around now: wide enough to always contain it,
-        // narrow enough never to straddle midnight at any pinned clock.
-        schedules: [{
-          date: parkToday(),
-          startTime: parkClock(-5),
-          endTime: parkClock(5),
-          status: 'OPERATING',
-          closed: false,
-        }],
       },
       ...(opts.extraAttractions ?? []),
     ],
@@ -80,8 +78,22 @@ function stubbedPark(opts: {
   vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue(opts.waitTimes ?? []);
   vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
   vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  // The canary's own window rides along with every stub. Narrow around now:
+  // wide enough to always contain it, narrow enough never to straddle
+  // midnight at any pinned clock.
+  const canaryRow = {
+    id: 'P1MA03',
+    name: 'Liberty Arcade',
+    schedules: [{
+      startTime: parkClock(-5),
+      endTime: parkClock(5),
+      status: 'OPERATING',
+      closed: false,
+    }],
+  };
+
   vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(
-    (opts.parkSchedules ?? []).map((s) => ({
+    [...(opts.parkSchedules ?? []), ...(opts.entitySchedules ?? [canaryRow])].map((s) => ({
       ...s,
       schedules: s.schedules.map((r: any) => ({...r, date: today})),
     })),
@@ -128,6 +140,45 @@ describe('DLP park-hours fallback for walkthroughs', () => {
   it('reports OPERATING inside its own park\'s published window', async () => {
     const park = stubbedPark({parkSchedules: [openNow('P1'), closedNow('P2')]});
     expect(await walkthroughStatus(park)).toBe('OPERATING');
+  });
+
+  it('reads an entity\'s own hours from the schedule feed, not the POI blob', async () => {
+    // The state after park-local midnight: the 12h-cached POI blob still
+    // carries yesterday's row and nothing for today, while the schedule feed
+    // is fetched per date and is correct. Sourcing own-hours from POI meant a
+    // walkthrough with its own shorter window silently inherited full park
+    // hours until the cache rolled.
+    //
+    // Park is open, the entity's own window closed two hours ago. Reading the
+    // feed gives CLOSED; reading the POI blob gives OPERATING via the park
+    // fallback, because the blob has no row for today at all.
+    const park = stubbedPark({
+      parkSchedules: [openNow('P1'), openNow('P2')],
+      entitySchedules: [
+        {
+          id: 'P1MA00',
+          name: 'Discovery Arcade',
+          schedules: [{
+            startTime: parkClock(-180),
+            endTime: parkClock(-120),
+            status: 'OPERATING',
+            closed: false,
+          }],
+        },
+        // Canary carried explicitly, since the default is replaced.
+        {
+          id: 'P1MA03',
+          name: 'Liberty Arcade',
+          schedules: [{
+            startTime: parkClock(-5),
+            endTime: parkClock(5),
+            status: 'OPERATING',
+            closed: false,
+          }],
+        },
+      ],
+    });
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
   });
 
   it('reports CLOSED outside its own park\'s published window', async () => {
@@ -303,9 +354,19 @@ describe('DLP park-hours fallback for walkthroughs', () => {
     });
 
     it('reports CLOSED when the schedule feed fails', async () => {
+      // The canary cannot apply here. Own-hours come from the same feed as
+      // park hours, so a total feed failure leaves every walkthrough without
+      // a window by definition. Assert the rows exist and are CLOSED instead,
+      // which still fails on a pipeline that emits nothing at all.
       const park = stubbedPark({parkSchedules: []});
       vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream 500'));
-      expect(await walkthroughStatus(park)).toBe('CLOSED');
+
+      const live = await park.getLiveData();
+      for (const id of ['P1MA00', 'P1MA03']) {
+        const row = live.find((l) => l.id === id);
+        expect(row, `expected a live row for ${id}`).toBeDefined();
+        expect(row?.status).toBe('CLOSED');
+      }
     });
 
     it('still honours the walkthrough\'s own schedule when it has one', async () => {

--- a/src/parks/dlp/__tests__/parkHours.test.ts
+++ b/src/parks/dlp/__tests__/parkHours.test.ts
@@ -1,0 +1,238 @@
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+import {CacheLib} from '../../../cache.js';
+import {formatInTimezone} from '../../../datetime.js';
+
+/**
+ * Walkthrough attractions (Discovery Arcade, Sleeping Beauty Castle, …) never
+ * appear in the wait feed, so their live status falls back to park hours.
+ *
+ * Those hours come from each park's own row in the schedule feed. They used to
+ * be derived from the attraction estate — earliest start and latest end across
+ * queue-bearing rides — which one outlying ride could move by hours, which
+ * conflated P1 and P2 into a single window, and which read POI schedules that
+ * only ever carry the date they were fetched.
+ */
+const TZ = 'Europe/Paris';
+
+function parkToday(): string {
+  const [mm, dd, yyyy] = formatInTimezone(new Date(), TZ, 'date').split('/');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** A time `offsetMinutes` from now, in the park's wall clock, as `HH:MM:SS`. */
+function parkClock(offsetMinutes: number): string {
+  const at = new Date(Date.now() + offsetMinutes * 60_000);
+  return formatInTimezone(at, TZ, 'iso').slice(11, 19);
+}
+
+/**
+ * A park with one walkthrough attraction that publishes no schedule of its
+ * own, so it can only resolve through the park-hours fallback.
+ */
+function stubbedPark(opts: {
+  parkSchedules?: any[];
+  walkthroughPark?: string;
+  extraAttractions?: any[];
+  waitTimes?: any[];
+}): DisneylandParis {
+  const park = new DisneylandParis();
+  const today = parkToday();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [
+      {id: 'P1', name: 'Disneyland Park', type: 'ThemePark'},
+      {id: 'P2', name: 'Disney Adventure World', type: 'ThemePark'},
+    ],
+    Attraction: [
+      {
+        id: 'P1MA00',
+        name: 'Discovery Arcade',
+        type: 'Attraction',
+        location: {id: opts.walkthroughPark ?? 'P1'},
+        // No `schedules` — this is the whole point: it must fall back.
+      },
+      ...(opts.extraAttractions ?? []),
+    ],
+  });
+
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue(opts.waitTimes ?? []);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(
+    (opts.parkSchedules ?? []).map((s) => ({
+      ...s,
+      schedules: s.schedules.map((r: any) => ({...r, date: today})),
+    })),
+  );
+
+  return park;
+}
+
+async function walkthroughStatus(park: DisneylandParis): Promise<string | undefined> {
+  const live = await park.getLiveData();
+  return live.find((l) => l.id === 'P1MA00')?.status;
+}
+
+/** A park row that is open right now, from 90 minutes ago to 90 minutes ahead. */
+function openNow(id: string) {
+  return {
+    id,
+    name: id,
+    schedules: [
+      {startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: false},
+    ],
+  };
+}
+
+/** A park row whose operating window has already ended. */
+function closedNow(id: string) {
+  return {
+    id,
+    name: id,
+    schedules: [
+      {startTime: parkClock(-180), endTime: parkClock(-120), status: 'OPERATING', closed: false},
+    ],
+  };
+}
+
+describe('DLP park-hours fallback for walkthroughs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('DisneylandParis');
+  });
+
+  it('reports OPERATING inside its own park\'s published window', async () => {
+    const park = stubbedPark({parkSchedules: [openNow('P1'), closedNow('P2')]});
+    expect(await walkthroughStatus(park)).toBe('OPERATING');
+  });
+
+  it('reports CLOSED outside its own park\'s published window', async () => {
+    const park = stubbedPark({parkSchedules: [closedNow('P1'), openNow('P2')]});
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+
+  it('does not borrow the other park\'s hours', async () => {
+    // P2 is open, P1 is shut. A walkthrough in P1 must not read OPERATING.
+    const park = stubbedPark({
+      parkSchedules: [closedNow('P1'), openNow('P2')],
+      walkthroughPark: 'P1',
+    });
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+
+    // …and the mirror case, so this isn't just "always CLOSED".
+    const other = stubbedPark({
+      parkSchedules: [closedNow('P1'), openNow('P2')],
+      walkthroughPark: 'P2',
+    });
+    expect(await walkthroughStatus(other)).toBe('OPERATING');
+  });
+
+  it('ignores a queue-bearing ride that runs past park close', async () => {
+    // The regression this fixes: park close was the latest endTime across
+    // queue-bearing rides, so one ride publishing 23:59 kept every walkthrough
+    // OPERATING long after the park shut. The station below is exactly that
+    // shape, and the park's own row says it closed two hours ago.
+    const park = stubbedPark({
+      parkSchedules: [closedNow('P1')],
+      extraAttractions: [
+        {
+          id: 'P1DA10',
+          name: 'Disneyland Railroad Discoveryland Station',
+          type: 'Attraction',
+          location: {id: 'P1'},
+          schedules: [
+            {
+              date: parkToday(),
+              startTime: '00:00:00',
+              endTime: '23:59:00',
+              status: 'OPERATING',
+              closed: false,
+            },
+          ],
+        },
+      ],
+      // Present in the wait feed, so it counts as queue-bearing.
+      waitTimes: [{entityId: 'P1DA10', type: 'Attraction', status: 'OPERATING', postedWaitMinutes: '5'}],
+    });
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+
+  it('ignores a queue-bearing ride that opens before the park', async () => {
+    // Mirror of the above on the open side: an 08:13 ride start used to become
+    // park open, so walkthroughs read OPERATING before guests could get in.
+    const park = stubbedPark({
+      parkSchedules: [
+        {
+          id: 'P1',
+          name: 'P1',
+          schedules: [
+            {startTime: parkClock(60), endTime: parkClock(180), status: 'OPERATING', closed: false},
+          ],
+        },
+      ],
+      extraAttractions: [
+        {
+          id: 'P1RA00',
+          name: 'Big Thunder Mountain',
+          type: 'Attraction',
+          location: {id: 'P1'},
+          schedules: [
+            {
+              date: parkToday(),
+              startTime: parkClock(-60),
+              endTime: parkClock(180),
+              status: 'OPERATING',
+              closed: false,
+            },
+          ],
+        },
+      ],
+      waitTimes: [{entityId: 'P1RA00', type: 'Attraction', status: 'OPERATING', postedWaitMinutes: '5'}],
+    });
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+
+  it('reports CLOSED rather than throwing when the park publishes no hours', async () => {
+    const park = stubbedPark({parkSchedules: []});
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+
+  it('ignores a closed-flagged park row', async () => {
+    const park = stubbedPark({
+      parkSchedules: [
+        {
+          id: 'P1',
+          name: 'P1',
+          schedules: [
+            {startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: true},
+          ],
+        },
+      ],
+    });
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+
+  it('ignores EXTRA_MAGIC_HOURS when choosing the window', async () => {
+    // EMH is a hotel-guest preview, not general park opening.
+    const park = stubbedPark({
+      parkSchedules: [
+        {
+          id: 'P1',
+          name: 'P1',
+          schedules: [
+            {startTime: parkClock(-30), endTime: parkClock(30), status: 'EXTRA_MAGIC_HOURS', closed: false},
+            {startTime: parkClock(-180), endTime: parkClock(-120), status: 'OPERATING', closed: false},
+          ],
+        },
+      ],
+    });
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+
+  it('survives a schedule-feed failure', async () => {
+    const park = stubbedPark({parkSchedules: []});
+    vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream 500'));
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  });
+});

--- a/src/parks/dlp/__tests__/parkHours.test.ts
+++ b/src/parks/dlp/__tests__/parkHours.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, afterEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
 import {CacheLib} from '../../../cache.js';
 import {formatInTimezone} from '../../../datetime.js';
@@ -12,24 +12,27 @@ import {formatInTimezone} from '../../../datetime.js';
  * queue-bearing rides — which one outlying ride could move by hours, which
  * conflated P1 and P2 into a single window, and which read POI schedules that
  * only ever carry the date they were fetched.
+ *
+ * The clock is pinned throughout. These windows are wall-clock relative, so on
+ * a live clock the suite went red between 22:30 and 01:30 Paris, when a
+ * +90-minute window wraps past midnight.
  */
 const TZ = 'Europe/Paris';
+
+/** Midday in Paris, well inside any plausible park day. */
+const NOON = new Date('2026-08-13T12:00:00+02:00');
 
 function parkToday(): string {
   const [mm, dd, yyyy] = formatInTimezone(new Date(), TZ, 'date').split('/');
   return `${yyyy}-${mm}-${dd}`;
 }
 
-/** A time `offsetMinutes` from now, in the park's wall clock, as `HH:MM:SS`. */
+/** A time `offsetMinutes` from the pinned now, in the park's wall clock. */
 function parkClock(offsetMinutes: number): string {
   const at = new Date(Date.now() + offsetMinutes * 60_000);
   return formatInTimezone(at, TZ, 'iso').slice(11, 19);
 }
 
-/**
- * A park with one walkthrough attraction that publishes no schedule of its
- * own, so it can only resolve through the park-hours fallback.
- */
 function stubbedPark(opts: {
   parkSchedules?: any[];
   walkthroughPark?: string;
@@ -69,35 +72,33 @@ function stubbedPark(opts: {
   return park;
 }
 
+/** The walkthrough's published status, or undefined when no row was emitted. */
 async function walkthroughStatus(park: DisneylandParis): Promise<string | undefined> {
   const live = await park.getLiveData();
   return live.find((l) => l.id === 'P1MA00')?.status;
 }
 
-/** A park row that is open right now, from 90 minutes ago to 90 minutes ahead. */
-function openNow(id: string) {
+function parkRow(id: string, startTime: string, endTime: string, extra: Record<string, unknown> = {}) {
   return {
     id,
     name: id,
-    schedules: [
-      {startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: false},
-    ],
+    schedules: [{startTime, endTime, status: 'OPERATING', closed: false, ...extra}],
   };
 }
 
-/** A park row whose operating window has already ended. */
-function closedNow(id: string) {
-  return {
-    id,
-    name: id,
-    schedules: [
-      {startTime: parkClock(-180), endTime: parkClock(-120), status: 'OPERATING', closed: false},
-    ],
-  };
-}
+/** Open right now: from 90 minutes ago to 90 minutes ahead. */
+const openNow = (id: string) => parkRow(id, parkClock(-90), parkClock(90));
+/** Shut: the window ended two hours ago. */
+const closedNow = (id: string) => parkRow(id, parkClock(-180), parkClock(-120));
 
 describe('DLP park-hours fallback for walkthroughs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOON);
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     CacheLib.clearByClassName('DisneylandParis');
   });
@@ -131,8 +132,7 @@ describe('DLP park-hours fallback for walkthroughs', () => {
   it('ignores a queue-bearing ride that runs past park close', async () => {
     // The regression this fixes: park close was the latest endTime across
     // queue-bearing rides, so one ride publishing 23:59 kept every walkthrough
-    // OPERATING long after the park shut. The station below is exactly that
-    // shape, and the park's own row says it closed two hours ago.
+    // OPERATING long after the park shut.
     const park = stubbedPark({
       parkSchedules: [closedNow('P1')],
       extraAttractions: [
@@ -142,35 +142,20 @@ describe('DLP park-hours fallback for walkthroughs', () => {
           type: 'Attraction',
           location: {id: 'P1'},
           schedules: [
-            {
-              date: parkToday(),
-              startTime: '00:00:00',
-              endTime: '23:59:00',
-              status: 'OPERATING',
-              closed: false,
-            },
+            {date: parkToday(), startTime: '00:00:00', endTime: '23:59:00', status: 'OPERATING', closed: false},
           ],
         },
       ],
-      // Present in the wait feed, so it counts as queue-bearing.
       waitTimes: [{entityId: 'P1DA10', type: 'Attraction', status: 'OPERATING', postedWaitMinutes: '5'}],
     });
     expect(await walkthroughStatus(park)).toBe('CLOSED');
   });
 
   it('ignores a queue-bearing ride that opens before the park', async () => {
-    // Mirror of the above on the open side: an 08:13 ride start used to become
-    // park open, so walkthroughs read OPERATING before guests could get in.
+    // Mirror on the open side: an 08:13 ride start used to become park open,
+    // so walkthroughs read OPERATING before guests could get in.
     const park = stubbedPark({
-      parkSchedules: [
-        {
-          id: 'P1',
-          name: 'P1',
-          schedules: [
-            {startTime: parkClock(60), endTime: parkClock(180), status: 'OPERATING', closed: false},
-          ],
-        },
-      ],
+      parkSchedules: [parkRow('P1', parkClock(60), parkClock(180))],
       extraAttractions: [
         {
           id: 'P1RA00',
@@ -178,13 +163,7 @@ describe('DLP park-hours fallback for walkthroughs', () => {
           type: 'Attraction',
           location: {id: 'P1'},
           schedules: [
-            {
-              date: parkToday(),
-              startTime: parkClock(-60),
-              endTime: parkClock(180),
-              status: 'OPERATING',
-              closed: false,
-            },
+            {date: parkToday(), startTime: parkClock(-60), endTime: parkClock(180), status: 'OPERATING', closed: false},
           ],
         },
       ],
@@ -193,24 +172,11 @@ describe('DLP park-hours fallback for walkthroughs', () => {
     expect(await walkthroughStatus(park)).toBe('CLOSED');
   });
 
-  it('reports CLOSED rather than throwing when the park publishes no hours', async () => {
-    const park = stubbedPark({parkSchedules: []});
-    expect(await walkthroughStatus(park)).toBe('CLOSED');
-  });
-
   it('ignores a closed-flagged park row', async () => {
     const park = stubbedPark({
-      parkSchedules: [
-        {
-          id: 'P1',
-          name: 'P1',
-          schedules: [
-            {startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: true},
-          ],
-        },
-      ],
+      parkSchedules: [parkRow('P1', parkClock(-90), parkClock(90), {closed: true})],
     });
-    expect(await walkthroughStatus(park)).toBe('CLOSED');
+    expect(await walkthroughStatus(park)).toBeUndefined();
   });
 
   it('ignores EXTRA_MAGIC_HOURS when choosing the window', async () => {
@@ -230,9 +196,89 @@ describe('DLP park-hours fallback for walkthroughs', () => {
     expect(await walkthroughStatus(park)).toBe('CLOSED');
   });
 
-  it('survives a schedule-feed failure', async () => {
-    const park = stubbedPark({parkSchedules: []});
-    vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream 500'));
-    expect(await walkthroughStatus(park)).toBe('CLOSED');
+  it('picks the OPERATING row whatever order the feed lists it in', async () => {
+    // Observed live: some days EXTRA_MAGIC_HOURS is index 0, some days it isn't.
+    const park = stubbedPark({
+      parkSchedules: [
+        {
+          id: 'P1',
+          name: 'P1',
+          schedules: [
+            {startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: false},
+            {startTime: parkClock(-240), endTime: parkClock(-180), status: 'EXTRA_MAGIC_HOURS', closed: false},
+          ],
+        },
+      ],
+    });
+    expect(await walkthroughStatus(park)).toBe('OPERATING');
+  });
+
+  describe('a park day that runs past midnight', () => {
+    it('is still open before midnight', async () => {
+      vi.setSystemTime(new Date('2026-08-13T23:00:00+02:00'));
+      const park = stubbedPark({parkSchedules: [parkRow('P1', '09:30:00', '01:00:00')]});
+      expect(await walkthroughStatus(park)).toBe('OPERATING');
+    });
+
+    it('reads the small hours against the new day, not the one still running', async () => {
+      // Known limitation, pinned so it is a decision rather than a surprise.
+      // At 00:30 the park is still in the 13th's 09:30-01:00 day, but todayStr
+      // has rolled to the 14th and buildLiveData only fetches todayStr — so we
+      // judge against the 14th's window, which has not opened yet, and report
+      // CLOSED. Resolving this properly needs yesterday's row too.
+      vi.setSystemTime(new Date('2026-08-14T00:30:00+02:00'));
+      const park = stubbedPark({parkSchedules: [parkRow('P1', '09:30:00', '01:00:00')]});
+      expect(await walkthroughStatus(park)).toBe('CLOSED');
+    });
+
+    it('is shut in the gap between closing and reopening', async () => {
+      vi.setSystemTime(new Date('2026-08-13T08:00:00+02:00'));
+      const park = stubbedPark({parkSchedules: [parkRow('P1', '09:30:00', '01:00:00')]});
+      expect(await walkthroughStatus(park)).toBe('CLOSED');
+    });
+  });
+
+  describe('when no hours are published', () => {
+    // Emitting CLOSED here would assert a closure nobody reported. The row is
+    // omitted instead, so the last good value stands.
+
+    it('emits no row when the park publishes no hours', async () => {
+      const park = stubbedPark({parkSchedules: []});
+      expect(await walkthroughStatus(park)).toBeUndefined();
+    });
+
+    it('emits no row when the feed carries no row for this park', async () => {
+      // Real shape: past the publication horizon the feed returns activities
+      // but no P1/P2 rows at all.
+      const park = stubbedPark({parkSchedules: [openNow('P2')], walkthroughPark: 'P1'});
+      expect(await walkthroughStatus(park)).toBeUndefined();
+    });
+
+    it('emits no row when the schedule feed fails', async () => {
+      const park = stubbedPark({parkSchedules: []});
+      vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream 500'));
+      expect(await walkthroughStatus(park)).toBeUndefined();
+    });
+
+    it('still honours the walkthrough\'s own schedule when it has one', async () => {
+      // No park hours, but the attraction publishes its own window: that is a
+      // real observation and must still be used.
+      const park = stubbedPark({
+        parkSchedules: [],
+        extraAttractions: [
+          {
+            id: 'P1MA03',
+            name: 'Liberty Arcade',
+            type: 'Attraction',
+            location: {id: 'P1'},
+            schedules: [
+              {date: parkToday(), startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: false},
+            ],
+          },
+        ],
+      });
+      const live = await park.getLiveData();
+      expect(live.find((l) => l.id === 'P1MA03')?.status).toBe('OPERATING');
+    });
   });
 });

--- a/src/parks/dlp/__tests__/parkHours.test.ts
+++ b/src/parks/dlp/__tests__/parkHours.test.ts
@@ -55,6 +55,24 @@ function stubbedPark(opts: {
         location: {id: opts.walkthroughPark ?? 'P1'},
         // No `schedules` — this is the whole point: it must fall back.
       },
+      {
+        // Canary. Carries its own window, so it resolves without park hours
+        // and must read OPERATING in every test. Without it, a test that only
+        // asserts CLOSED would pass just as happily against a dead pipeline.
+        id: 'P1MA03',
+        name: 'Liberty Arcade',
+        type: 'Attraction',
+        location: {id: 'P1'},
+        // A narrow window around now: wide enough to always contain it,
+        // narrow enough never to straddle midnight at any pinned clock.
+        schedules: [{
+          date: parkToday(),
+          startTime: parkClock(-5),
+          endTime: parkClock(5),
+          status: 'OPERATING',
+          closed: false,
+        }],
+      },
       ...(opts.extraAttractions ?? []),
     ],
   });
@@ -72,9 +90,13 @@ function stubbedPark(opts: {
   return park;
 }
 
-/** The walkthrough's published status, or undefined when no row was emitted. */
+/**
+ * The walkthrough's published status, having first checked the canary is
+ * alive so an assertion of CLOSED cannot be satisfied by an empty pipeline.
+ */
 async function walkthroughStatus(park: DisneylandParis): Promise<string | undefined> {
   const live = await park.getLiveData();
+  expect(live.find((l) => l.id === 'P1MA03')?.status).toBe('OPERATING');
   return live.find((l) => l.id === 'P1MA00')?.status;
 }
 
@@ -172,15 +194,17 @@ describe('DLP park-hours fallback for walkthroughs', () => {
     expect(await walkthroughStatus(park)).toBe('CLOSED');
   });
 
-  it('ignores a closed-flagged park row', async () => {
+  it('reports CLOSED for a closed-flagged park row', async () => {
     const park = stubbedPark({
       parkSchedules: [parkRow('P1', parkClock(-90), parkClock(90), {closed: true})],
     });
-    expect(await walkthroughStatus(park)).toBeUndefined();
+    expect(await walkthroughStatus(park)).toBe('CLOSED');
   });
 
-  it('ignores EXTRA_MAGIC_HOURS when choosing the window', async () => {
-    // EMH is a hotel-guest preview, not general park opening.
+  it('counts EXTRA_MAGIC_HOURS as part of the window', async () => {
+    // EMH is hotel-guest-only, but guests are in the park and the rides
+    // publish windows covering it. Excluding it would report a coaster
+    // operating while a walkthrough beside it reads closed.
     const park = stubbedPark({
       parkSchedules: [
         {
@@ -188,12 +212,30 @@ describe('DLP park-hours fallback for walkthroughs', () => {
           name: 'P1',
           schedules: [
             {startTime: parkClock(-30), endTime: parkClock(30), status: 'EXTRA_MAGIC_HOURS', closed: false},
-            {startTime: parkClock(-180), endTime: parkClock(-120), status: 'OPERATING', closed: false},
+            {startTime: parkClock(60), endTime: parkClock(180), status: 'OPERATING', closed: false},
           ],
         },
       ],
     });
-    expect(await walkthroughStatus(park)).toBe('CLOSED');
+    expect(await walkthroughStatus(park)).toBe('OPERATING');
+  });
+
+  it('spans the whole day when the feed splits it into several windows', async () => {
+    // A day broken by a private event publishes two OPERATING rows; taking
+    // only the first would report closed for the rest of the day.
+    const park = stubbedPark({
+      parkSchedules: [
+        {
+          id: 'P1',
+          name: 'P1',
+          schedules: [
+            {startTime: parkClock(-240), endTime: parkClock(-180), status: 'OPERATING', closed: false},
+            {startTime: parkClock(-60), endTime: parkClock(60), status: 'OPERATING', closed: false},
+          ],
+        },
+      ],
+    });
+    expect(await walkthroughStatus(park)).toBe('OPERATING');
   });
 
   it('picks the OPERATING row whatever order the feed lists it in', async () => {
@@ -239,46 +281,41 @@ describe('DLP park-hours fallback for walkthroughs', () => {
   });
 
   describe('when no hours are published', () => {
-    // Emitting CLOSED here would assert a closure nobody reported. The row is
-    // omitted instead, so the last good value stands.
+    // CLOSED, not silence. The wiki keeps a row until something replaces it,
+    // so emitting nothing would leave a walkthrough last seen OPERATING
+    // reading OPERATING forever. And since the query only asks for OPERATING
+    // and EXTRA_MAGIC_HOURS rows, a park shut all day cannot produce a row at
+    // all — absence is what a real closure looks like.
+    //
+    // The canary in each of these proves the pipeline is alive, so CLOSED is
+    // a decision rather than an empty result.
 
-    it('emits no row when the park publishes no hours', async () => {
+    it('reports CLOSED when the park publishes no hours', async () => {
       const park = stubbedPark({parkSchedules: []});
-      expect(await walkthroughStatus(park)).toBeUndefined();
+      expect(await walkthroughStatus(park)).toBe('CLOSED');
     });
 
-    it('emits no row when the feed carries no row for this park', async () => {
+    it('reports CLOSED when the feed carries no row for this park', async () => {
       // Real shape: past the publication horizon the feed returns activities
       // but no P1/P2 rows at all.
       const park = stubbedPark({parkSchedules: [openNow('P2')], walkthroughPark: 'P1'});
-      expect(await walkthroughStatus(park)).toBeUndefined();
+      expect(await walkthroughStatus(park)).toBe('CLOSED');
     });
 
-    it('emits no row when the schedule feed fails', async () => {
+    it('reports CLOSED when the schedule feed fails', async () => {
       const park = stubbedPark({parkSchedules: []});
       vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream 500'));
-      expect(await walkthroughStatus(park)).toBeUndefined();
+      expect(await walkthroughStatus(park)).toBe('CLOSED');
     });
 
     it('still honours the walkthrough\'s own schedule when it has one', async () => {
       // No park hours, but the attraction publishes its own window: that is a
-      // real observation and must still be used.
-      const park = stubbedPark({
-        parkSchedules: [],
-        extraAttractions: [
-          {
-            id: 'P1MA03',
-            name: 'Liberty Arcade',
-            type: 'Attraction',
-            location: {id: 'P1'},
-            schedules: [
-              {date: parkToday(), startTime: parkClock(-90), endTime: parkClock(90), status: 'OPERATING', closed: false},
-            ],
-          },
-        ],
-      });
+      // real observation and must still be used. This is the canary's own
+      // case, asserted explicitly rather than only as a precondition.
+      const park = stubbedPark({parkSchedules: []});
       const live = await park.getLiveData();
       expect(live.find((l) => l.id === 'P1MA03')?.status).toBe('OPERATING');
+      expect(live.find((l) => l.id === 'P1MA00')?.status).toBe('CLOSED');
     });
   });
 });

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1106,19 +1106,29 @@ export class DisneylandParis extends Destination {
       (poi) => this.mapEntityType(poi) === 'ATTRACTION',
     );
 
-    // Today's park-open window — fallback for walkthroughs whose POI
-    // entry doesn't carry its own schedule (Discovery Arcade etc.).
-    // Derived from queue-bearing rides' POI schedules.
-    const parkScheduleEntries = attractionPois
-      .filter((p) => queueBearingIds.has(p.id))
-      .flatMap((p) => p.schedules || [])
-      .filter((s) => s.date === todayStr && s.status === 'OPERATING' && !s.closed);
-    const parkOpenStr = parkScheduleEntries.length
-      ? parkScheduleEntries.map((s) => s.startTime).sort()[0]
-      : null;
-    const parkCloseStr = parkScheduleEntries.length
-      ? parkScheduleEntries.map((s) => s.endTime).sort().reverse()[0]
-      : null;
+    // Today's park-open window, per park — the fallback for walkthroughs whose
+    // POI entry doesn't carry its own schedule (Discovery Arcade etc.).
+    //
+    // Read from each park's own row in the schedule feed. Deriving it from the
+    // attraction estate instead (min start / max end across queue-bearing
+    // rides) fails three ways: a single early or late ride moves the whole
+    // window, the two parks are conflated into one set of hours, and the POI
+    // schedules it read only ever carry the date they were fetched, so after
+    // park-local midnight there is nothing left to derive from.
+    const parkHours = new Map<string, {open: string; close: string}>();
+    try {
+      for (const sched of await this.getScheduleForDate(todayStr)) {
+        if (sched.id !== 'P1' && sched.id !== 'P2') continue;
+        const operating = (sched.schedules || []).find(
+          (s) => s.status === 'OPERATING' && s.closed !== true && s.startTime && s.endTime,
+        );
+        if (operating) {
+          parkHours.set(sched.id, {open: operating.startTime, close: operating.endTime});
+        }
+      }
+    } catch (e) {
+      console.error(`[DLP] Error fetching today's park hours: ${e}`);
+    }
 
     const nowMs = Date.now();
     const isWithinWindow = (open: string, close: string): boolean => {
@@ -1138,8 +1148,9 @@ export class DisneylandParis extends Destination {
       if (own?.status === 'OPERATING' && own.startTime && own.endTime) {
         return isWithinWindow(own.startTime, own.endTime) ? 'OPERATING' : 'CLOSED';
       }
-      if (parkOpenStr && parkCloseStr) {
-        return isWithinWindow(parkOpenStr, parkCloseStr) ? 'OPERATING' : 'CLOSED';
+      const hours = parkHours.get(poi.location?.id ?? '');
+      if (hours) {
+        return isWithinWindow(hours.open, hours.close) ? 'OPERATING' : 'CLOSED';
       }
       return 'CLOSED';
     };

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1120,9 +1120,20 @@ export class DisneylandParis extends Destination {
     // park and the rides publish windows covering it, so excluding it would
     // report Big Thunder Mountain operating at 08:45 while Sleeping Beauty
     // Castle, fifty metres away, reads closed.
+    //
+    // Both this and the per-entity lookup below read `todaySchedules`, the
+    // payload the showtimes block already fetched. The POI blob is not a
+    // usable source for either: its `schedules` array only ever carries the
+    // date it was fetched, and it is cached 12h, so past park-local midnight
+    // it holds nothing for the current date.
+    const todayRowsById = new Map<string, DLPScheduleEntry[]>();
+    for (const sched of todaySchedules) {
+      if (sched?.id && Array.isArray(sched.schedules)) todayRowsById.set(sched.id, sched.schedules);
+    }
+
     const parkHours = new Map<string, {open: string; close: string}>();
-    try {
-      for (const sched of await this.getScheduleForDate(todayStr)) {
+    {
+      for (const sched of todaySchedules) {
         if (sched.id !== 'P1' && sched.id !== 'P2') continue;
 
         // Union of every window the feed publishes for the day. A day split
@@ -1139,8 +1150,6 @@ export class DisneylandParis extends Destination {
           close: windows.map((s) => s.endTime).sort().reverse()[0],
         });
       }
-    } catch (e) {
-      console.error(`[DLP] Error fetching today's park hours: ${e}`);
     }
 
     const nowMs = Date.now();
@@ -1177,7 +1186,7 @@ export class DisneylandParis extends Destination {
     const deriveWalkthroughStatus = (
       poi: DLPPOIEntity & {category: string},
     ): 'OPERATING' | 'CLOSED' => {
-      const own = (poi.schedules || []).find((s) => s.date === todayStr);
+      const own = (todayRowsById.get(poi.id) || []).find((s) => s.date === todayStr);
       if (own?.closed === true) return 'CLOSED';
       if (own?.status === 'OPERATING' && own.startTime && own.endTime) {
         return isWithinWindow(own.startTime, own.endTime) ? 'OPERATING' : 'CLOSED';
@@ -1224,10 +1233,6 @@ export class DisneylandParis extends Destination {
     // Without published hours a restaurant is skipped, not reported closed.
     // This feed is authoritative for a restaurant's status, so unlike the
     // walkthrough block above it overwrites what other feeds set.
-    const todayRowsById = new Map<string, DLPScheduleEntry[]>();
-    for (const sched of todaySchedules) {
-      if (sched?.id && Array.isArray(sched.schedules)) todayRowsById.set(sched.id, sched.schedules);
-    }
     for (const poi of emittablePois) {
       if (this.mapEntityType(poi) !== 'RESTAURANT') continue;
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -13,7 +13,7 @@ import {
   LanguageCode,
   TagData,
 } from '@themeparks/typelib';
-import {formatInTimezone, addDays, constructDateTime} from '../../datetime.js';
+import {formatInTimezone, addDays, constructDateTime, shiftDateString} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 
 // ============================================================================
@@ -1106,25 +1106,38 @@ export class DisneylandParis extends Destination {
       (poi) => this.mapEntityType(poi) === 'ATTRACTION',
     );
 
-    // Today's park-open window, per park — the fallback for walkthroughs whose
-    // POI entry doesn't carry its own schedule (Discovery Arcade etc.).
+    // Today's guests-on-site window, per park — the fallback for walkthroughs
+    // whose POI entry doesn't carry its own schedule (Discovery Arcade etc.).
     //
-    // Read from each park's own row in the schedule feed. Deriving it from the
-    // attraction estate instead (min start / max end across queue-bearing
-    // rides) fails three ways: a single early or late ride moves the whole
-    // window, the two parks are conflated into one set of hours, and the POI
-    // schedules it read only ever carry the date they were fetched, so after
-    // park-local midnight there is nothing left to derive from.
+    // Read from each park's own row in the schedule feed rather than derived
+    // from the attraction estate. The old min-start/max-end across
+    // queue-bearing rides let one early ride move the window: measured, it
+    // opened the parks at 08:19 against a published 09:30. It also read POI
+    // schedules, which only carry the date they were fetched, so after
+    // park-local midnight there was nothing left to derive from.
+    //
+    // EXTRA_MAGIC_HOURS counts. It is hotel-guest-only, but guests are in the
+    // park and the rides publish windows covering it, so excluding it would
+    // report Big Thunder Mountain operating at 08:45 while Sleeping Beauty
+    // Castle, fifty metres away, reads closed.
     const parkHours = new Map<string, {open: string; close: string}>();
     try {
       for (const sched of await this.getScheduleForDate(todayStr)) {
         if (sched.id !== 'P1' && sched.id !== 'P2') continue;
-        const operating = (sched.schedules || []).find(
-          (s) => s.status === 'OPERATING' && s.closed !== true && s.startTime && s.endTime,
+
+        // Union of every window the feed publishes for the day. A day split
+        // by a private event would otherwise lose whichever half `.find()`
+        // happened to miss.
+        const windows = (sched.schedules || []).filter(
+          (s) => (s.status === 'OPERATING' || s.status === 'EXTRA_MAGIC_HOURS')
+            && s.closed !== true && s.startTime && s.endTime,
         );
-        if (operating) {
-          parkHours.set(sched.id, {open: operating.startTime, close: operating.endTime});
-        }
+        if (windows.length === 0) continue;
+
+        parkHours.set(sched.id, {
+          open: windows.map((s) => s.startTime).sort()[0],
+          close: windows.map((s) => s.endTime).sort().reverse()[0],
+        });
       }
     } catch (e) {
       console.error(`[DLP] Error fetching today's park hours: ${e}`);
@@ -1141,34 +1154,29 @@ export class DisneylandParis extends Destination {
       // 09:30-01:00 day reads as closing before it opened, so nothing is ever
       // inside it.
       //
-      // The day is stepped at noon UTC rather than via `new Date(dateStr)`,
-      // which parses in the host's zone: on a host at UTC+10 or beyond that
-      // lands on the previous day and the step silently does nothing.
-      let closeDateStr = todayStr;
-      if (close < open) {
-        const next = new Date(`${todayStr}T12:00:00Z`);
-        next.setUTCDate(next.getUTCDate() + 1);
-        closeDateStr = next.toISOString().slice(0, 10);
-      }
+      // shiftDateString anchors at noon UTC; stepping via `new Date(dateStr)`
+      // parses in the host's zone and silently fails to advance on any host
+      // east of Paris.
+      const closeDateStr = close < open ? shiftDateString(todayStr, 1) : todayStr;
       const c = new Date(constructDateTime(closeDateStr, close.slice(0, 5), this.timezone)).getTime();
 
       return nowMs >= o && nowMs <= c;
     };
 
     /**
-     * OPERATING/CLOSED for a walkthrough, or undefined when neither its own
-     * schedule nor its park's hours are published.
+     * OPERATING or CLOSED for a walkthrough.
      *
-     * Undefined means no row is emitted. A walkthrough is only ever knowable
-     * through published hours, so with none in hand `CLOSED` would be a
-     * statement we cannot support — and the upstream shapes that get us here
-     * (an empty schedule payload, a date past the publication horizon) are
-     * ones the feed really produces. Reporting nothing lets the last good
-     * value stand instead of overwriting it with a guess.
+     * With no hours in hand this answers CLOSED rather than staying silent.
+     * Silence is not the neutral option: the wiki keeps a live-data row until
+     * something replaces it, so emitting nothing leaves a walkthrough last
+     * seen OPERATING reading OPERATING indefinitely. And the query only asks
+     * for OPERATING and EXTRA_MAGIC_HOURS rows, so a park closed all day
+     * cannot produce a row at all — absence is exactly what a genuine closure
+     * looks like, which is the case where CLOSED is most likely right.
      */
     const deriveWalkthroughStatus = (
       poi: DLPPOIEntity & {category: string},
-    ): 'OPERATING' | 'CLOSED' | undefined => {
+    ): 'OPERATING' | 'CLOSED' => {
       const own = (poi.schedules || []).find((s) => s.date === todayStr);
       if (own?.closed === true) return 'CLOSED';
       if (own?.status === 'OPERATING' && own.startTime && own.endTime) {
@@ -1178,7 +1186,7 @@ export class DisneylandParis extends Destination {
       if (hours) {
         return isWithinWindow(hours.open, hours.close) ? 'OPERATING' : 'CLOSED';
       }
-      return undefined;
+      return 'CLOSED';
     };
 
     for (const poi of attractionPois) {
@@ -1200,14 +1208,10 @@ export class DisneylandParis extends Destination {
           ld.queue.SINGLE_RIDER = {waitTime: null};
         }
       } else if (!ld) {
-        // Walkthrough — status from schedule, no queue. Skipped entirely when
-        // no hours are published, rather than asserting a closure we can't see.
-        const status = deriveWalkthroughStatus(poi);
-        if (status) {
-          const walkthrough = {id, status} as LiveData;
-          liveDataMap.set(id, walkthrough);
-          liveData.push(walkthrough);
-        }
+        // Walkthrough — status from schedule, no queue.
+        const walkthrough = {id, status: deriveWalkthroughStatus(poi)} as LiveData;
+        liveDataMap.set(id, walkthrough);
+        liveData.push(walkthrough);
       }
       // If a walkthrough already has a row from upstream feeds (PA / VQ /
       // showtimes), leave it — those feeds are authoritative.

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1136,13 +1136,39 @@ export class DisneylandParis extends Destination {
       // constructDateTime and throw out of the whole build.
       if (!TIME_OF_DAY.test(open) || !TIME_OF_DAY.test(close)) return false;
       const o = new Date(constructDateTime(todayStr, open.slice(0, 5), this.timezone)).getTime();
-      const c = new Date(constructDateTime(todayStr, close.slice(0, 5), this.timezone)).getTime();
+
+      // A window closing after midnight ends tomorrow. Without this a
+      // 09:30-01:00 day reads as closing before it opened, so nothing is ever
+      // inside it.
+      //
+      // The day is stepped at noon UTC rather than via `new Date(dateStr)`,
+      // which parses in the host's zone: on a host at UTC+10 or beyond that
+      // lands on the previous day and the step silently does nothing.
+      let closeDateStr = todayStr;
+      if (close < open) {
+        const next = new Date(`${todayStr}T12:00:00Z`);
+        next.setUTCDate(next.getUTCDate() + 1);
+        closeDateStr = next.toISOString().slice(0, 10);
+      }
+      const c = new Date(constructDateTime(closeDateStr, close.slice(0, 5), this.timezone)).getTime();
+
       return nowMs >= o && nowMs <= c;
     };
 
+    /**
+     * OPERATING/CLOSED for a walkthrough, or undefined when neither its own
+     * schedule nor its park's hours are published.
+     *
+     * Undefined means no row is emitted. A walkthrough is only ever knowable
+     * through published hours, so with none in hand `CLOSED` would be a
+     * statement we cannot support — and the upstream shapes that get us here
+     * (an empty schedule payload, a date past the publication horizon) are
+     * ones the feed really produces. Reporting nothing lets the last good
+     * value stand instead of overwriting it with a guess.
+     */
     const deriveWalkthroughStatus = (
       poi: DLPPOIEntity & {category: string},
-    ): 'OPERATING' | 'CLOSED' => {
+    ): 'OPERATING' | 'CLOSED' | undefined => {
       const own = (poi.schedules || []).find((s) => s.date === todayStr);
       if (own?.closed === true) return 'CLOSED';
       if (own?.status === 'OPERATING' && own.startTime && own.endTime) {
@@ -1152,7 +1178,7 @@ export class DisneylandParis extends Destination {
       if (hours) {
         return isWithinWindow(hours.open, hours.close) ? 'OPERATING' : 'CLOSED';
       }
-      return 'CLOSED';
+      return undefined;
     };
 
     for (const poi of attractionPois) {
@@ -1174,10 +1200,14 @@ export class DisneylandParis extends Destination {
           ld.queue.SINGLE_RIDER = {waitTime: null};
         }
       } else if (!ld) {
-        // Walkthrough — status from schedule, no queue.
-        const walkthrough = {id, status: deriveWalkthroughStatus(poi)} as LiveData;
-        liveDataMap.set(id, walkthrough);
-        liveData.push(walkthrough);
+        // Walkthrough — status from schedule, no queue. Skipped entirely when
+        // no hours are published, rather than asserting a closure we can't see.
+        const status = deriveWalkthroughStatus(poi);
+        if (status) {
+          const walkthrough = {id, status} as LiveData;
+          liveDataMap.set(id, walkthrough);
+          liveData.push(walkthrough);
+        }
       }
       // If a walkthrough already has a row from upstream feeds (PA / VQ /
       // showtimes), leave it — those feeds are authoritative.


### PR DESCRIPTION
## Summary

Six walkthrough attractions (Discovery Arcade, Liberty Arcade, Sleeping Beauty Castle, La Galerie de la Belle au Bois Dormant, Horse-Drawn Streetcars, World Premiere) never appear in the wait feed, so `buildLiveData` derives their status from park hours. Those hours were the earliest start and latest end across queue-bearing *rides'* POI schedules.

Each park already publishes its own hours in the schedule feed this method fetches anyway. This reads them from there.

| | before | after |
|---|---|---|
| source | min/max across queue-bearing rides | each park's own schedule row |
| scope | one window shared by both parks | per park (`P1`, `P2`) |
| Extra Magic Hours | excluded | included |
| window crossing midnight | never inside it | handled |
| after park-local midnight | no data, everything CLOSED | correct |
| no hours available | emits nothing | emits `CLOSED` |
| extra HTTP requests | – | none, reuses the schedule fetch |

Entities, schedules and every other live-data path are untouched.

## The three problems, graded honestly

**A single ride sets the window for both parks.** Measured against the live feed today (2026-08-14):

```
published hours        P1 08:30 -> 22:00     P2 08:30 -> 22:00
derived from rides        08:19 -> 22:00  (both parks)
```

`08:19` is one attraction, *Ratatouille*, which sits in Walt Disney Studios (`P2`) — and its start time was setting the window for Disneyland Park too. Today that is an 11 minute error. The size is not bounded by anything: it is whatever the earliest or latest outlier happens to publish, and an earlier run measured `08:13`. The close side is the same shape in reverse, and became reachable when #292 made the railroad stations emittable, since they publish full-day windows on days they are flagged.

**One window for both parks.** `parkOpenStr` / `parkCloseStr` were module-scope, so `P1` inherited `P2`'s hours and vice versa. Today the two parks publish identical hours, so the only visible symptom is the cross-park leak above. On any day their hours diverge it becomes a straight wrong answer for one of them.

**It broke after park-local midnight.** The POI blob's `schedules` array only ever carries the date it was fetched — verified today, the entire blob holds exactly one distinct date, `2026-08-14` — and `getPOIData` is cached 12h. Once the park clock rolled past midnight, `todayStr` moved on, no POI row matched, `parkOpenStr`/`parkCloseStr` went null and every walkthrough fell to `CLOSED` until the cache expired. Observed live at 00:07 Paris. The schedule feed is fetched per date, so reading hours from there removes the dependency entirely.

## Extra Magic Hours counts

Each park publishes two rows:

```
P1  EXTRA_MAGIC_HOURS  08:30-09:30
P1  OPERATING          09:30-22:00
```

Both are used, unioned into one window. Extra Magic Hours is a hotel-guest preview rather than general opening, but guests are physically in the park and the rides publish windows covering it. Excluding it would report Big Thunder Mountain operating at 08:45 while Sleeping Beauty Castle, fifty metres away, read closed. Taking the union rather than picking one row also survives a day split by a private event, where `.find()` would have kept whichever half it reached first.

## Emitting CLOSED rather than nothing

The earlier revision of this PR returned `undefined` when no hours were available and pushed no row. That is wrong for the same reason #301 was: the wiki keeps a live-data row until something replaces it, so emitting nothing leaves a walkthrough last seen `OPERATING` reading `OPERATING` for as long as that lasts. Silence is not neutral.

`CLOSED` is also the right guess rather than a shrug: the query asks only for `OPERATING` and `EXTRA_MAGIC_HOURS` rows, so a park closed all day cannot produce a row at all. Absence is exactly what a genuine closure looks like.

## `shiftDateString`

A window closing after midnight (`09:30-01:00`) read as closing before it opened, so nothing was ever inside it. Fixing that needs a day step, and the obvious form is wrong:

```ts
new Date(`${todayStr}T00:00:00`)   // parses in the HOST's zone
```

On any host east of the park that silently fails to advance the date. Extracted to `src/datetime.ts` as `shiftDateString`, anchored at noon UTC where no offset or DST shift can cross a date boundary, and covered by a test that pins `process.env.TZ` across six zones from Kiritimati to Los Angeles. `buildSchedules` in this file, plus `futuroscope.ts` and `chimelong.ts`, still carry the naive form — out of scope here, worth a follow-up.

## Test plan

- [x] `npm test` — 77 files, 1730 tests, all passing
- [x] `npx tsc --noEmit` — clean
- [x] New `src/parks/dlp/__tests__/parkHours.test.ts`, 16 tests. Verified against pre-fix source: **7 fail**, including both regression cases (`ignores a queue-bearing ride that runs past park close`, `ignores a queue-bearing ride that opens before the park`). The first draft of those two passed against pre-fix code and were rewritten until they didn't.
- [x] Every test carries a canary walkthrough (`P1MA03`) with its own ±5 minute window asserted `OPERATING`, so a change that made the pipeline return nothing fails instead of passing vacuously. An earlier draft had exactly that hole.
- [x] 6 new tests for `shiftDateString` in `src/__tests__/datetime.test.ts`, including the TZ sweep. Mutating the helper back to the naive `T00:00:00` anchor fails the suite; before the sweep existed, that mutant survived.
- [x] Covered: inside/outside window, per-park isolation in both directions, a ride running past close, a ride opening early, no published hours, a `closed: true` park row, EXTRA_MAGIC_HOURS unioned, a window crossing midnight, and a schedule-feed failure
- [x] Live feed at 20:20 Paris (hours 09:30-22:00): all 6 walkthroughs `OPERATING`, La Galerie correctly `CLOSED` on its own schedule, 69 live rows, 131 entities, no row missing a status

## Merge note

Touches `buildLiveData` around the walkthrough block, so expect a small conflict with #294, which edits `isWithinWindow` in the same region. No overlap with #293, #295 or #296.
