### PR TITLE
feat(harness): report live data and schedules keyed to unpublished entities

### DIFF
--- a/src/__tests__/orphanEntityCheck.test.ts
+++ b/src/__tests__/orphanEntityCheck.test.ts
@@ -1,0 +1,50 @@
+import {describe, it, expect} from 'vitest';
+import {findOrphanIds} from '../testRunner.js';
+
+/**
+ * Live data and schedules are keyed by entity id. A row keyed to an id that
+ * getEntities() never emits cannot be looked up by any consumer, so the
+ * harness reports it. Disneyland Paris was publishing 36 such schedule ids,
+ * 42% of its schedule days, because buildSchedules read a wider upstream feed
+ * than buildEntityList did.
+ */
+describe('findOrphanIds', () => {
+  const published = new Set(['P1', 'P2', 'P1RA00']);
+
+  it('returns nothing when every row is published', () => {
+    expect(findOrphanIds([{id: 'P1'}, {id: 'P1RA00'}], published)).toEqual([]);
+  });
+
+  it('finds a row keyed to an unpublished id', () => {
+    expect(findOrphanIds([{id: 'P1'}, {id: 'H03R00'}], published)).toEqual(['H03R00']);
+  });
+
+  it('reports each orphan id once however many rows carry it', () => {
+    const rows = [{id: 'H03R00'}, {id: 'H03R00'}, {id: 'H03R00'}, {id: 'D01R02'}];
+    expect(findOrphanIds(rows, published)).toEqual(['H03R00', 'D01R02']);
+  });
+
+  it('stays quiet when the entity list is empty', () => {
+    // getEntities() failed or was skipped. Reporting every row as an orphan
+    // would bury the real failure under noise.
+    expect(findOrphanIds([{id: 'H03R00'}, {id: 'D01R02'}], new Set())).toEqual([]);
+  });
+
+  it('ignores rows with no id', () => {
+    expect(findOrphanIds([{}, {id: undefined}, {id: ''}], published)).toEqual([]);
+  });
+
+  it('survives null and undefined rows', () => {
+    const rows = [null, undefined, {id: 'H03R00'}] as unknown as Array<{id?: string}>;
+    expect(findOrphanIds(rows, published)).toEqual(['H03R00']);
+  });
+
+  it('returns an empty list for an empty input', () => {
+    expect(findOrphanIds([], published)).toEqual([]);
+  });
+
+  it('is exact about ids rather than matching loosely', () => {
+    // 'P1' is published; 'P10' and 'p1' are not.
+    expect(findOrphanIds([{id: 'P10'}, {id: 'p1'}], published)).toEqual(['P10', 'p1']);
+  });
+});

--- a/src/__tests__/orphanEntityCheck.test.ts
+++ b/src/__tests__/orphanEntityCheck.test.ts
@@ -1,27 +1,30 @@
 import {describe, it, expect} from 'vitest';
-import {findOrphanIds} from '../testRunner.js';
+import {findOrphanIds} from '../orphanCheck.js';
 
 /**
  * Live data and schedules are keyed by entity id. A row keyed to an id that
  * getEntities() never emits cannot be looked up by any consumer, so the
  * harness reports it. Disneyland Paris was publishing 36 such schedule ids,
- * 42% of its schedule days, because buildSchedules read a wider upstream feed
- * than buildEntityList did.
+ * covering most of its schedule days, because buildSchedules read a wider
+ * upstream feed than buildEntityList did.
  */
 describe('findOrphanIds', () => {
-  const published = new Set(['P1', 'P2', 'P1RA00']);
+  // Built per test. Shared across tests it silently masked whether the
+  // implementation mutates the caller's set: a mutating version "failed" only
+  // because it poisoned later tests, which would evaporate on a reorder.
+  const mkPublished = () => new Set(['P1', 'P2', 'P1RA00']);
 
   it('returns nothing when every row is published', () => {
-    expect(findOrphanIds([{id: 'P1'}, {id: 'P1RA00'}], published)).toEqual([]);
+    expect(findOrphanIds([{id: 'P1'}, {id: 'P1RA00'}], mkPublished())).toEqual([]);
   });
 
   it('finds a row keyed to an unpublished id', () => {
-    expect(findOrphanIds([{id: 'P1'}, {id: 'H03R00'}], published)).toEqual(['H03R00']);
+    expect(findOrphanIds([{id: 'P1'}, {id: 'H03R00'}], mkPublished())).toEqual(['H03R00']);
   });
 
   it('reports each orphan id once however many rows carry it', () => {
     const rows = [{id: 'H03R00'}, {id: 'H03R00'}, {id: 'H03R00'}, {id: 'D01R02'}];
-    expect(findOrphanIds(rows, published).sort()).toEqual(['D01R02', 'H03R00']);
+    expect(findOrphanIds(rows, mkPublished()).sort()).toEqual(['D01R02', 'H03R00']);
   });
 
   it('stays quiet when the entity list is empty', () => {
@@ -31,16 +34,28 @@ describe('findOrphanIds', () => {
   });
 
   it('ignores rows with no id', () => {
-    expect(findOrphanIds([{}, {id: undefined}, {id: ''}], published)).toEqual([]);
+    expect(findOrphanIds([{}, {id: undefined}, {id: ''}], mkPublished())).toEqual([]);
   });
 
   it('survives null and undefined rows', () => {
     const rows = [null, undefined, {id: 'H03R00'}] as unknown as Array<{id?: string}>;
-    expect(findOrphanIds(rows, published)).toEqual(['H03R00']);
+    expect(findOrphanIds(rows, mkPublished())).toEqual(['H03R00']);
+  });
+
+  it('treats a single published id as a real entity list', () => {
+    // The empty-set guard means "the entity list is missing". One entity is a
+    // list of one, and its feed still gets checked.
+    expect(findOrphanIds([{id: 'ONLY'}, {id: 'GHOST'}], new Set(['ONLY']))).toEqual(['GHOST']);
+  });
+
+  it('does not modify the caller\'s published set', () => {
+    const published = new Set(['P1']);
+    findOrphanIds([{id: 'GHOST'}, {id: 'P1'}], published);
+    expect([...published]).toEqual(['P1']);
   });
 
   it('is exact about ids rather than matching loosely', () => {
     // 'P1' is published; 'P10' and 'p1' are not.
-    expect(findOrphanIds([{id: 'P10'}, {id: 'p1'}], published).sort()).toEqual(['P10', 'p1']);
+    expect(findOrphanIds([{id: 'P10'}, {id: 'p1'}], mkPublished()).sort()).toEqual(['P10', 'p1']);
   });
 });

--- a/src/__tests__/orphanEntityCheck.test.ts
+++ b/src/__tests__/orphanEntityCheck.test.ts
@@ -21,7 +21,7 @@ describe('findOrphanIds', () => {
 
   it('reports each orphan id once however many rows carry it', () => {
     const rows = [{id: 'H03R00'}, {id: 'H03R00'}, {id: 'H03R00'}, {id: 'D01R02'}];
-    expect(findOrphanIds(rows, published)).toEqual(['H03R00', 'D01R02']);
+    expect(findOrphanIds(rows, published).sort()).toEqual(['D01R02', 'H03R00']);
   });
 
   it('stays quiet when the entity list is empty', () => {
@@ -39,12 +39,8 @@ describe('findOrphanIds', () => {
     expect(findOrphanIds(rows, published)).toEqual(['H03R00']);
   });
 
-  it('returns an empty list for an empty input', () => {
-    expect(findOrphanIds([], published)).toEqual([]);
-  });
-
   it('is exact about ids rather than matching loosely', () => {
     // 'P1' is published; 'P10' and 'p1' are not.
-    expect(findOrphanIds([{id: 'P10'}, {id: 'p1'}], published)).toEqual(['P10', 'p1']);
+    expect(findOrphanIds([{id: 'P10'}, {id: 'p1'}], published).sort()).toEqual(['P10', 'p1']);
   });
 });

--- a/src/__tests__/orphanReporting.test.ts
+++ b/src/__tests__/orphanReporting.test.ts
@@ -1,0 +1,106 @@
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {testPark} from '../testRunner.js';
+import {Destination} from '../destination.js';
+
+/**
+ * The orphan warning itself: truncation to five ids, the "+N more" tail, and
+ * the affected-day sum. Driven through the real `testPark` rather than a
+ * replica, so the shipped strings are what gets asserted.
+ */
+function stubPark(opts: {
+  entities?: string[];
+  liveIds?: string[];
+  schedules?: Array<{id: string; days: number}>;
+}): Destination {
+  const park = new (class extends Destination {})({} as any);
+
+  vi.spyOn(park, 'getDestinations').mockResolvedValue([
+    {id: 'dest', name: 'Dest', entityType: 'DESTINATION', location: {latitude: 1, longitude: 1}} as any,
+  ]);
+  vi.spyOn(park, 'getEntities').mockResolvedValue([
+    {id: 'dest', name: 'Dest', entityType: 'DESTINATION', location: {latitude: 1, longitude: 1}},
+    ...(opts.entities ?? []).map((id) => ({id, name: id, entityType: 'ATTRACTION'})),
+  ] as any);
+  vi.spyOn(park, 'getLiveData').mockResolvedValue(
+    (opts.liveIds ?? []).map((id) => ({id, status: 'OPERATING'})) as any,
+  );
+  vi.spyOn(park, 'getSchedules').mockResolvedValue(
+    (opts.schedules ?? []).map((s) => ({
+      id: s.id,
+      schedule: Array.from({length: s.days}, () => ({
+        date: '2026-08-14', type: 'OPERATING', openingTime: '', closingTime: '',
+      })),
+    })) as any,
+  );
+
+  return park;
+}
+
+async function warnings(park: Destination): Promise<string[]> {
+  const lines: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((...args) => {
+    lines.push(args.join(' '));
+  });
+  await testPark('stub', 'Stub Park', park, {verbose: true});
+  log.mockRestore();
+  return lines.filter((l) => l.includes('unpublished entities') || l.includes('days affected'));
+}
+
+describe('orphan reporting', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('says nothing when every row resolves', async () => {
+    const park = stubPark({entities: ['A', 'B'], liveIds: ['A', 'B']});
+    expect(await warnings(park)).toEqual([]);
+  });
+
+  it('lists every orphan up to five without a tail', async () => {
+    const park = stubPark({entities: ['A'], liveIds: ['O1', 'O2', 'O3', 'O4', 'O5']});
+    const [line] = await warnings(park);
+    expect(line).toContain('Live data for unpublished entities: 5');
+    expect(line).toContain('O1, O2, O3, O4, O5');
+    expect(line).not.toContain('more');
+  });
+
+  it('truncates at five and counts the rest', async () => {
+    const park = stubPark({entities: ['A'], liveIds: ['O1', 'O2', 'O3', 'O4', 'O5', 'O6']});
+    const [line] = await warnings(park);
+    expect(line).toContain('unpublished entities: 6');
+    expect(line).toContain('+1 more');
+    expect(line).not.toContain('O6');
+  });
+
+  it('keeps shown plus remainder equal to the total', async () => {
+    const ids = Array.from({length: 12}, (_, i) => `O${i + 1}`);
+    const park = stubPark({entities: ['A'], liveIds: ids});
+    const [line] = await warnings(park);
+    expect(line).toContain('unpublished entities: 12');
+    expect(line).toContain('+7 more');
+    // 5 shown + 7 more = 12
+    expect(line.match(/O\d+/g)?.length).toBe(5);
+  });
+
+  it('reports one orphan without a tail', async () => {
+    const park = stubPark({entities: ['A'], liveIds: ['A', 'GHOST']});
+    const [line] = await warnings(park);
+    expect(line).toContain('unpublished entities: 1 (GHOST)');
+    expect(line).not.toContain('more');
+  });
+
+  it('sums the days of every orphaned schedule row, not the ids', async () => {
+    // Two rows can carry the same orphan id; the day count follows rows.
+    const park = stubPark({
+      entities: ['A'],
+      schedules: [{id: 'A', days: 10}, {id: 'GHOST', days: 3}, {id: 'GHOST', days: 2}],
+    });
+    const lines = await warnings(park);
+    expect(lines.join('\n')).toContain('Schedules for unpublished entities: 1');
+    expect(lines.join('\n')).toContain('(5 of 15 days affected)');
+  });
+
+  it('stays silent when the entity list could not be built', async () => {
+    const park = stubPark({liveIds: ['GHOST']});
+    vi.spyOn(park, 'getEntities').mockRejectedValue(new Error('upstream down'));
+    expect(await warnings(park)).toEqual([]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from './datetime.js';
 export * from './htmlUtils.js';
 export * from './statusMap.js';
 export * from './promiseReuse.js';
+export * from './orphanCheck.js';
 
 // Export default as named export for config decorator
 export { default as config } from './config.js';

--- a/src/orphanCheck.ts
+++ b/src/orphanCheck.ts
@@ -1,0 +1,36 @@
+/**
+ * Cross-check that emitted rows are keyed to entities that actually exist.
+ *
+ * Deliberately dependency-free. It lives outside testRunner so the collector
+ * can assert the same invariant on the push path, where orphan rows reach
+ * consumers continuously, rather than only when someone runs the harness by
+ * hand — and so its unit tests don't drag in the HTTP queue's interval timer
+ * and the SQLite cache to exercise a pure function.
+ */
+
+/**
+ * Distinct ids in `rows` that no published entity claims.
+ *
+ * Live data or schedules keyed to an id `getEntities()` never emits cannot be
+ * looked up by a consumer, so they are dead weight in the output. Usually it
+ * means a build path is reading a wider upstream feed than the entity list.
+ *
+ * Returns nothing when `publishedIds` is empty — that means the entity list
+ * is unavailable, not that everything is an orphan, and reporting every row
+ * would bury whatever real failure emptied it. One published id is a real
+ * entity list and is checked normally.
+ *
+ * Does not modify `publishedIds`.
+ */
+export function findOrphanIds(
+  rows: Array<{id?: string}>,
+  publishedIds: ReadonlySet<string>,
+): string[] {
+  if (publishedIds.size === 0) return [];
+
+  const orphans = new Set<string>();
+  for (const row of rows) {
+    if (row?.id && !publishedIds.has(row.id)) orphans.add(row.id);
+  }
+  return [...orphans];
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -182,8 +182,8 @@ function printSummary(summaries: ParkTestSummary[]): void {
       const counts = summary.results.reduce(
         (acc, result) => {
           const orphans = (result.details?.orphanIds ?? []) as string[];
-          if (result.testName === 'getLiveData') acc.live = orphans.length;
-          if (result.testName === 'getSchedules') acc.schedules = orphans.length;
+          if (result.testName === 'getLiveData') acc.live += orphans.length;
+          if (result.testName === 'getSchedules') acc.schedules += orphans.length;
           return acc;
         },
         {live: 0, schedules: 0},
@@ -196,8 +196,8 @@ function printSummary(summaries: ParkTestSummary[]): void {
     console.log(`Rows keyed to unpublished entities (${withOrphans.length} park(s)):`);
     withOrphans.forEach(({parkName, live, schedules}) => {
       const parts = [
-        live > 0 ? `${live} live` : null,
-        schedules > 0 ? `${schedules} schedule` : null,
+        live > 0 ? `${live} live row${live === 1 ? '' : 's'}` : null,
+        schedules > 0 ? `${schedules} schedule row${schedules === 1 ? '' : 's'}` : null,
       ].filter(Boolean).join(', ');
       console.log(`  ⚠ ${parkName.padEnd(40)} ${parts}`);
     });

--- a/src/test.ts
+++ b/src/test.ts
@@ -174,6 +174,36 @@ function printSummary(summaries: ParkTestSummary[]): void {
     console.log('');
   }
 
+  // Orphan roll-up. These don't fail a park, so without a summary line they'd
+  // only ever be seen by someone running a single park verbosely — while the
+  // rows themselves keep reaching consumers.
+  const withOrphans = summaries
+    .map((summary) => {
+      const counts = summary.results.reduce(
+        (acc, result) => {
+          const orphans = (result.details?.orphanIds ?? []) as string[];
+          if (result.testName === 'getLiveData') acc.live = orphans.length;
+          if (result.testName === 'getSchedules') acc.schedules = orphans.length;
+          return acc;
+        },
+        {live: 0, schedules: 0},
+      );
+      return {parkName: summary.parkName, ...counts};
+    })
+    .filter((s) => s.live > 0 || s.schedules > 0);
+
+  if (withOrphans.length > 0) {
+    console.log(`Rows keyed to unpublished entities (${withOrphans.length} park(s)):`);
+    withOrphans.forEach(({parkName, live, schedules}) => {
+      const parts = [
+        live > 0 ? `${live} live` : null,
+        schedules > 0 ? `${schedules} schedule` : null,
+      ].filter(Boolean).join(', ');
+      console.log(`  ⚠ ${parkName.padEnd(40)} ${parts}`);
+    });
+    console.log('');
+  }
+
   // Failed test details
   if (failed.length > 0) {
     console.log('Failed Tests:');

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -308,8 +308,9 @@ export async function testPark(
       const totalDays = schedules.reduce((sum, s) => sum + s.schedule.length, 0);
 
       const orphanIds = findOrphans(schedules);
+      const orphanIdSet = new Set(orphanIds);
       const orphanDays = schedules
-        .filter((s) => orphanIds.includes(s.id))
+        .filter((s) => orphanIdSet.has(s.id))
         .reduce((sum, s) => sum + s.schedule.length, 0);
 
       return { count: schedules.length, totalDays, schedules, orphanIds, orphanDays };
@@ -321,7 +322,7 @@ export async function testPark(
         const orphanIds = (schedulesResult.details.orphanIds ?? []) as string[];
         reportOrphans(orphanIds, 'Schedules');
         if (orphanIds.length > 0) {
-          console.log(`       (${schedulesResult.details.orphanDays} of ${schedulesResult.details.totalDays} days)`);
+          console.log(`       (${schedulesResult.details.orphanDays} of ${schedulesResult.details.totalDays} days affected)`);
         }
       } else {
         console.log(`   ✗ Failed: ${schedulesResult.error}`);

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -8,28 +8,7 @@ import {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
 import {getQueueLength} from './http.js';
 import {tracing} from './tracing.js';
 import {typeDetector} from './typeDetector.js';
-
-/**
- * Distinct ids in `rows` that no published entity claims.
- *
- * Live data or schedules keyed to an id `getEntities()` never emits cannot be
- * looked up by a consumer, so they are dead weight in the output. Usually it
- * means a build path is reading a wider upstream feed than the entity list.
- *
- * Returns nothing when `publishedIds` is empty, so a failed or skipped
- * getEntities() reports no orphans rather than every row.
- */
-export function findOrphanIds(
-  rows: Array<{id?: string}>,
-  publishedIds: ReadonlySet<string>,
-): string[] {
-  if (publishedIds.size === 0) return [];
-  const orphans = new Set<string>();
-  for (const row of rows) {
-    if (row?.id && !publishedIds.has(row.id)) orphans.add(row.id);
-  }
-  return [...orphans];
-}
+import {findOrphanIds} from './orphanCheck.js';
 
 export type TestResult = {
   testName: string;

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -9,6 +9,28 @@ import {getQueueLength} from './http.js';
 import {tracing} from './tracing.js';
 import {typeDetector} from './typeDetector.js';
 
+/**
+ * Distinct ids in `rows` that no published entity claims.
+ *
+ * Live data or schedules keyed to an id `getEntities()` never emits cannot be
+ * looked up by a consumer, so they are dead weight in the output. Usually it
+ * means a build path is reading a wider upstream feed than the entity list.
+ *
+ * Returns nothing when `publishedIds` is empty, so a failed or skipped
+ * getEntities() reports no orphans rather than every row.
+ */
+export function findOrphanIds(
+  rows: Array<{id?: string}>,
+  publishedIds: ReadonlySet<string>,
+): string[] {
+  if (publishedIds.size === 0) return [];
+  const orphans = new Set<string>();
+  for (const row of rows) {
+    if (row?.id && !publishedIds.has(row.id)) orphans.add(row.id);
+  }
+  return [...orphans];
+}
+
 export type TestResult = {
   testName: string;
   passed: boolean;
@@ -205,6 +227,25 @@ export async function testPark(
     }
   }
 
+  // IDs the destination actually publishes. Live data and schedules keyed to
+  // anything outside this set can't be looked up by a consumer, so they are
+  // dead weight in the output. Empty when getEntities() failed, in which case
+  // the orphan checks below stay quiet rather than reporting every row.
+  const publishedIds = new Set<string>(
+    entitiesResult.passed
+      ? ((entitiesResult.details?.entities ?? []) as Array<{id: string}>).map((e) => e.id)
+      : [],
+  );
+
+  const findOrphans = (rows: Array<{id?: string}>): string[] => findOrphanIds(rows, publishedIds);
+
+  const reportOrphans = (orphans: string[], label: string): void => {
+    if (orphans.length === 0) return;
+    const sample = orphans.slice(0, 5).join(', ');
+    const more = orphans.length > 5 ? `, +${orphans.length - 5} more` : '';
+    console.log(`     ⚠ ${label} for unpublished entities: ${orphans.length} (${sample}${more})`);
+  };
+
   // Test 3: getLiveData()
   if (!skipLiveData) {
     if (verbose) console.log('\n3. Testing getLiveData()...');
@@ -225,7 +266,9 @@ export async function testPark(
       // Count entries with wait times
       const withWaitTimes = liveData.filter(l => l.queue?.STANDBY?.waitTime !== undefined).length;
 
-      return { count: liveData.length, statuses, withWaitTimes, liveData };
+      const orphanIds = findOrphans(liveData);
+
+      return { count: liveData.length, statuses, withWaitTimes, liveData, orphanIds };
     });
     results.push(liveDataResult);
     if (verbose) {
@@ -235,6 +278,7 @@ export async function testPark(
         Object.entries(liveDataResult.details.statuses).forEach(([status, count]) => {
           console.log(`     - ${status}: ${count}`);
         });
+        reportOrphans(liveDataResult.details.orphanIds ?? [], 'Live data');
       } else {
         console.log(`   ✗ Failed: ${liveDataResult.error}`);
       }
@@ -263,12 +307,22 @@ export async function testPark(
 
       const totalDays = schedules.reduce((sum, s) => sum + s.schedule.length, 0);
 
-      return { count: schedules.length, totalDays, schedules };
+      const orphanIds = findOrphans(schedules);
+      const orphanDays = schedules
+        .filter((s) => orphanIds.includes(s.id))
+        .reduce((sum, s) => sum + s.schedule.length, 0);
+
+      return { count: schedules.length, totalDays, schedules, orphanIds, orphanDays };
     });
     results.push(schedulesResult);
     if (verbose) {
       if (schedulesResult.passed) {
         console.log(`   ✓ Found ${schedulesResult.details.count} schedule(s) with ${schedulesResult.details.totalDays} total days (${schedulesResult.duration}ms)`);
+        const orphanIds = (schedulesResult.details.orphanIds ?? []) as string[];
+        reportOrphans(orphanIds, 'Schedules');
+        if (orphanIds.length > 0) {
+          console.log(`       (${schedulesResult.details.orphanDays} of ${schedulesResult.details.totalDays} days)`);
+        }
       } else {
         console.log(`   ✗ Failed: ${schedulesResult.error}`);
       }


### PR DESCRIPTION
## Summary

Live data and schedules are keyed by entity id. A row keyed to an id that `getEntities()` never emits cannot be looked up by any consumer. It usually means a `build*` path is reading a wider upstream feed than `buildEntityList` does. The harness validated schedule *structure* but never checked that the ids resolve, so this class of defect was invisible.

This adds the cross-check for both `getLiveData()` and `getSchedules()`, printed per park and rolled up in the run summary.

```
   ✓ Found 133 schedule(s) with 14139 total days (36435ms)
     ⚠ Schedules for unpublished entities: 36 (P1MG86, H03R00, H02R05, D01R02, H07R00, +31 more)
       (5849 of 14139 days affected)
```

```
Rows keyed to unpublished entities (2 park(s)):
  ⚠ Busch Gardens Tampa                      12 live rows
  ⚠ Busch Gardens Williamsburg               7 live rows
```

## What it found: 10 of 80 parks

All 80 park ids run through `testPark()`. **10 carry orphans**, measured in a single sweep on 2026-08-14 at 10:49Z:

| park | live orphans | schedule orphans |
|---|---|---|
| sixflags | 42 of 1457 rows | 0 |
| disneylandparis | 0 | 36 of 133 rows (5,849 of 14,139 days) |
| seaworldsandiego | 15 of 87 | 0 |
| buschgardenstampa | 12 of 71 | 0 |
| universalstudios | 11 of 48 | 0 |
| seaworldorlando | 10 of 76 | 0 |
| seaworldsanantonio | 9 of 43 | 0 |
| buschgardenswilliamsburg | 7 of 65 | 0 |
| phantasialand | 7 of 58 | 0 |
| sesameplacephiladelphia | 3 of 117 | 0 |

Orphaned **live data** is the common case, 9 parks to 1. Counts drift with the upstream feeds — sixflags moved 1447 → 1457 rows between two runs the same week, and USH moved 11 → 10 within four hours of the same day. Ten is also a *lower bound*: a park whose `getEntities()` fails reports no orphans by design, so any park failing that run is silent here.

## What those orphans actually are

Each park below was re-sampled during its own operating hours, because a park sampled overnight tells you nothing about whether its orphans carry data.

- **Six Flags** (42) — the union of `/venue-status` and `/wait-times` is deliberate, and the comment at `sixflags.ts:956-984` explains why: the vendor sometimes publishes a live wait for a ride it has dropped from that roster, and enumerating the roster alone discards it. The incident recorded there is the *pre-union* behaviour — at Canada's Wonderland on 2026-07-23 The Daredeviler's 60 minute wait was thrown away and the wiki kept serving a CLOSED record frozen since April. The union is what stops that, and its side effect is that a ride absent from `/poi` too now surfaces here as an orphan **carrying a real wait**. So this park is structurally capable of orphans-with-data, by design.
  Sampled 2026-08-14 14:35Z with the parks open: none of the 42 carried data. 41 are shows publishing a bare `OPERATING`, and the 42nd (`RIDE-001-00181`) is `CLOSED` with an empty `queue.STANDBY: {}`. Scanning the operating-hours show lists forward through September, those 41 show ids carry times on **no** date, and no ride id is currently absent from both feeds. The right fix here is publishing the missing entities, not suppressing the rows.
- **SeaWorld family** (15 / 12 / 10 / 9 / 7 / 3) — cosmetic. Every orphan is a ShowTimes row with zero times, publishing a bare `CLOSED`; there are no orphaned wait-time rows anywhere in the family. Sampled during operating hours (Orlando and Busch Gardens Tampa at 14:45Z, 10:45 local): zero orphans carrying data. Querying the availability feed forward, the orphan show ids carry times on no date at any of the six parks, while the resolved shows do.
- **Phantasialand** (7) — cosmetic, but only with #301 applied, which matters because this branch was cut before it. Sampled 14:40Z with #301 in the tree and the park open (16:40 local): all 7 bare `CLOSED`, none carrying a queue or showtimes. Without #301 the same 7 were the frozen relics it retires — two carried standby waits (Black Mamba 40 min, Colorado Adventure 5 min) and two carried showtimes. #301 is already on `main`, so the merged result is the sampled one.
- **Universal Studios Hollywood** (10-11) — **the one with real loss.** Sampled 14:47Z: 2 of the 10 carry live showtimes. `ush.mms.minion.dance.party` (6 showtimes) sits in a namespace with **no** entries in the places feed at all — an id-namespace mismatch, a straight coverage gap. `ush.upper_lot.shows.studio_tour_spanish` (6 showtimes) is different: it *is* in the places feed and is dropped on purpose by `isEventVariantAlias` as a language variant of the canonical Studio Tour. Whether losing its separate departure times is correct dedup or real loss is a judgement call, not a bug. The remaining orphans split the same way — some absent from `/places`, some deliberately excluded (CityWalk via `NON_SURFACED_VENUE_PARENT`, other Studio Tour variants).
- **Disneyland Paris** (36 schedule rows, 41% of its days) — dead weight: 14 character meet & greets, 21 hotel and Disney Village restaurants and bars, and Mickey's PhilharMagic, whose published SHOW entity already carries its own schedule. Addressed in #296.

So the honest summary: Universal Studios Hollywood is losing showtimes today; Six Flags produces orphans-with-data by design whenever the vendor drops a still-operating ride, though none of its current 42 carry any; DLP's are dead weight; the SeaWorld family's and Phantasialand's are cosmetic, verified with the parks open.

## Why a warning, not a failure

An orphan row is always wrong, so failing is defensible, and now that the count is known (10) it would not be an unbounded change. Two reasons to keep it a warning:

- **The harness is not in CI.** `.github/workflows/unit_test.js.yml` runs `npm ci`, `npm run build`, `npm test`; `docs.yml` runs `npm run docs`. Neither invokes `npm run dev`, so a hard failure buys no automated signal.
- **Most of the ten are cosmetic**, per the breakdown above, and the two that matter need per-park investigation rather than a mechanical fix.

Worth promoting to a failure once those ten are cleared. One caveat for whoever does that: entity data is cached far longer than live data in several parks (`seaworld.ts:188` 12h vs `:197` 60s), so on a warm cache an upstream addition can appear in live data before the entity list learns about it, producing a transient orphan that is not a code defect. Pair the promotion with a cache clear, or accept the flake.

This follows the precedent already in the file: structural violations throw, things that are legitimately variable are counted and printed with `⚠`.

## What this check does not catch

Worth stating plainly, because I overestimated it at first. A park that filters its live rows against the entity list passes this check regardless of whether the data landed on the *right* entity. It measures resolvability, not correctness. It would have gone green on a change that rewrote ids onto plausible-looking but wrong entities.

That caveat is not hypothetical: **20 of the 80 destinations can never report an orphan**, because their shared base classes intersect live rows with the entity id set before emitting (`te2.ts:775-783`, 4 destinations; `attractionsiov1.ts:1154-1164`, 16). They pass by construction.

Its value is narrower than "finds bugs": it surfaces parks whose two build paths disagree about what exists. That is worth a look, and at Phantasialand it paid off directly — all 7 of its orphans turned out to be stale signage rows the feed never prunes, published as current, fixed in #301.

## Implementation

`findOrphanIds(rows, publishedIds)` is exported as a pure function so it can be unit tested. It returns nothing when the published set is empty, so a failed `getEntities()` reports no orphans rather than flagging every row and burying the real failure.

Cost is not measurable: 2.45 ms total across all 80 parks, max 0.33 ms on sixflags (1457 rows against 2558 entities, in a 152 s park run). An isolated benchmark on the same shape puts it at 0.068 ms warm, 0.474 ms cold.

## Test plan

- [x] `npm test` — 75 files, 1700 tests, all passing
- [x] `npx tsc --noEmit` — clean
- [x] `src/__tests__/orphanEntityCheck.test.ts` — mutation-tested: 10 mutants of `findOrphanIds` (dropped guard, `row.id` for `row?.id`, array for Set, case-insensitive compare, prefix match, counting `''`, report-everything, inverted membership, always-empty, first-only) — all 10 killed
- [x] `src/__tests__/orphanReporting.test.ts` — drives the real `testPark()` against a stub Destination; 7 reporting mutants killed
- [x] `npm run dev -- disneylandparis` — reports 36 ids and the day count, matching an independent count
- [x] `npm run dev -- --category "Busch Gardens"` non-verbose — roll-up appears in the summary, which is the mode the first revision missed
- [x] Verified silent when `getEntities()` fails: walibibelgium fails on an id-charset error and reports no orphans despite 15 live rows
- [x] Severity of every entry above re-sampled during that park's operating hours, not overnight
