### PR TITLE
fix(phantasialand): attach wait times to the entities that exist

### DIFF
--- a/src/parks/phantasialand/__tests__/liveIdAliases.test.ts
+++ b/src/parks/phantasialand/__tests__/liveIdAliases.test.ts
@@ -1,0 +1,190 @@
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {Phantasialand} from '../phantasialand.js';
+
+/**
+ * Phantasialand's POI feed carries several records per venue: one with
+ * seasons, which becomes the entity, and retired or placeholder copies with
+ * `seasons: []`, which do not. The signage feed reports live state against
+ * whichever copy it likes.
+ *
+ * Live: Black Mamba's 40-minute wait arrived under unpublished id 225 while
+ * published entity 52 got a bare CLOSED, and across the whole park not one
+ * published entity carried a queue. The live rows are aliased onto the
+ * published id so the wait reaches something a consumer can look up.
+ */
+const SEASON = [{from: '2026-01-01', to: '2026-12-31'}];
+
+function poi(over: Record<string, unknown>) {
+  return {
+    id: 1,
+    title: 'Ride',
+    category: 'ATTRACTIONS',
+    seasons: SEASON,
+    tags: [],
+    entrance: {world: {lat: 50.79, lng: 6.87}},
+    ...over,
+  };
+}
+
+function stubbedPark(pois: any[], signage: any[]): Phantasialand {
+  const park = new Phantasialand();
+  vi.spyOn(park as any, 'getPOI').mockResolvedValue(pois);
+  vi.spyOn(park as any, 'getSignage').mockResolvedValue(signage);
+  return park;
+}
+
+/** The published live row for an id, if one was emitted. */
+async function rowFor(park: Phantasialand, id: string) {
+  const live = await park.getLiveData();
+  return live.find((l) => l.id === id);
+}
+
+describe('Phantasialand live-id aliasing', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lands a wait time reported against an unpublished copy on the published entity', async () => {
+    const park = stubbedPark(
+      [
+        poi({id: 52, title: 'Black Mamba'}),
+        poi({id: 225, title: 'Black Mamba', seasons: []}),
+      ],
+      [{poiId: 225, waitTime: 40, open: true}],
+    );
+
+    expect(await rowFor(park, '52')).toMatchObject({
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 40}},
+    });
+    expect(await rowFor(park, '225')).toBeUndefined();
+  });
+
+  it('keeps the real state when the published copy also reports a bare closed', async () => {
+    // Both orders, because the merge must not depend on signage ordering.
+    const pois = [
+      poi({id: 52, title: 'Black Mamba'}),
+      poi({id: 225, title: 'Black Mamba', seasons: []}),
+    ];
+
+    const closedFirst = stubbedPark(pois, [
+      {poiId: 52, open: false},
+      {poiId: 225, waitTime: 40, open: true},
+    ]);
+    expect(await rowFor(closedFirst, '52')).toMatchObject({
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 40}},
+    });
+
+    const closedLast = stubbedPark(pois, [
+      {poiId: 225, waitTime: 40, open: true},
+      {poiId: 52, open: false},
+    ]);
+    expect(await rowFor(closedLast, '52')).toMatchObject({
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 40}},
+    });
+  });
+
+  it('emits one row per entity, never a duplicate', async () => {
+    const park = stubbedPark(
+      [
+        poi({id: 52, title: 'Black Mamba'}),
+        poi({id: 225, title: 'Black Mamba', seasons: []}),
+      ],
+      [
+        {poiId: 52, open: false},
+        {poiId: 225, waitTime: 40, open: true},
+      ],
+    );
+    const live = await park.getLiveData();
+    const ids = live.map((l) => l.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it('aliases showtimes too, not just wait times', async () => {
+    const park = stubbedPark(
+      [
+        poi({id: 194, title: 'Fantissima', category: 'SHOWS'}),
+        poi({id: 112, title: 'Fantissima', category: 'SHOWS', seasons: []}),
+      ],
+      [{poiId: 112, showTimes: ['2026-08-13 19:30:00']}],
+    );
+    const row = await rowFor(park, '194');
+    expect(row?.status).toBe('OPERATING');
+    expect(row?.showtimes).toHaveLength(1);
+  });
+
+  it('drops a venue with no published copy at all', async () => {
+    // Nobis: three records, none published, so there is nothing to alias onto.
+    const park = stubbedPark(
+      [
+        poi({id: 7, title: 'Nobis', category: 'PHOTO_POINT', seasons: []}),
+        poi({id: 13, title: 'Nobis', category: 'SHOWS', seasons: []}),
+        poi({id: 90, title: 'Nobis', category: 'SHOWS', seasons: []}),
+      ],
+      [{poiId: 13, open: true}],
+    );
+    const live = await park.getLiveData();
+    expect(live.find((l) => ['7', '13', '90'].includes(l.id))).toBeUndefined();
+  });
+
+  it('does not alias when a copy is unpublished only because of its category', async () => {
+    // Face painter: the twin has seasons but SERVICE is never an entity type,
+    // so there is still no published entity to attach to.
+    const park = stubbedPark(
+      [
+        poi({id: 189, title: 'Face painter', category: 'SERVICE', seasons: []}),
+        poi({id: 231, title: 'Face painter', category: 'SERVICE'}),
+      ],
+      [{poiId: 189, open: true}],
+    );
+    const live = await park.getLiveData();
+    expect(live).toHaveLength(0);
+  });
+
+  it('refuses to guess when a title has two published records', async () => {
+    // Focaccia Mexico genuinely has two published records. Picking one would
+    // put a wait on the wrong venue, so the unpublished copy stays dropped.
+    const park = stubbedPark(
+      [
+        poi({id: 35, title: 'Focaccia Mexico', category: 'RESTAURANTS_AND_SNACKS'}),
+        poi({id: 37, title: 'Focaccia Mexico', category: 'RESTAURANTS_AND_SNACKS'}),
+        poi({id: 999, title: 'Focaccia Mexico', category: 'RESTAURANTS_AND_SNACKS', seasons: []}),
+      ],
+      [{poiId: 999, open: true}],
+    );
+    expect(await rowFor(park, '999')).toBeUndefined();
+    expect(await rowFor(park, '35')).toBeUndefined();
+    expect(await rowFor(park, '37')).toBeUndefined();
+  });
+
+  it('leaves an unambiguous published id alone', async () => {
+    const park = stubbedPark(
+      [poi({id: 60, title: 'Taron'})],
+      [{poiId: 60, waitTime: 25, open: true}],
+    );
+    expect(await rowFor(park, '60')).toMatchObject({
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 25}},
+    });
+  });
+
+  it('never emits a row for an id the entity list does not publish', async () => {
+    // The invariant the whole change exists to restore.
+    const park = stubbedPark(
+      [
+        poi({id: 52, title: 'Black Mamba'}),
+        poi({id: 225, title: 'Black Mamba', seasons: []}),
+        poi({id: 189, title: 'Face painter', category: 'SERVICE', seasons: []}),
+        poi({id: 162, title: 'ATM', category: 'SERVICE'}),
+      ],
+      [
+        {poiId: 225, waitTime: 40, open: true},
+        {poiId: 189, open: true},
+        {poiId: 162, open: true},
+      ],
+    );
+    const entityIds = new Set((await park.getEntities()).map((e) => e.id));
+    const live = await park.getLiveData();
+    expect(live.filter((l) => !entityIds.has(l.id))).toEqual([]);
+  });
+});

--- a/src/parks/phantasialand/phantasialand.ts
+++ b/src/parks/phantasialand/phantasialand.ts
@@ -45,6 +45,37 @@ const categoryToEntityType: Record<string, Entity['entityType'] | undefined> = {
   'PHANTASIALAND_HOTELS_RESTAURANTS': 'RESTAURANT',
 };
 
+/**
+ * The entity type this POI would be published as, or undefined if it is not
+ * published at all.
+ *
+ * The single source of truth for "does this record become an entity". The live
+ * path needs the same answer as the entity path: the POI feed carries several
+ * records per venue and the signage feed reports against whichever one it
+ * likes, so a second copy of this rule that drifted would silently strand
+ * wait times on ids no consumer can resolve.
+ */
+function publishedEntityType(poi: any): Entity['entityType'] | undefined {
+  if (poi?.adminOnly) return undefined;
+
+  // A record with no seasons is a retired or placeholder copy of a venue.
+  if (!Array.isArray(poi?.seasons) || poi.seasons.length === 0) return undefined;
+
+  // Hotel restaurants are only published when actually tagged as one.
+  if (poi.category === 'PHANTASIALAND_HOTELS_RESTAURANTS') {
+    if (!Array.isArray(poi.tags) || !poi.tags.includes('RESTAURANT')) return undefined;
+  }
+
+  return categoryToEntityType[poi.category];
+}
+
+/** How much a live-data row actually tells us, for picking between duplicates. */
+function livenessScore(ld: LiveData): number {
+  return (ld.queue ? 2 : 0)
+    + ((ld.showtimes?.length ?? 0) > 0 ? 2 : 0)
+    + (ld.status === 'OPERATING' ? 1 : 0);
+}
+
 @destinationController({category: 'Phantasialand'})
 export class Phantasialand extends Destination {
   @config
@@ -378,20 +409,7 @@ export class Phantasialand extends Destination {
     }> = [];
 
     for (const poi of pois) {
-      // Skip admin-only entries
-      if (poi.adminOnly) continue;
-
-      // Skip entries without seasons
-      if (!poi.seasons || !Array.isArray(poi.seasons) || poi.seasons.length === 0) continue;
-
-      const category = poi.category;
-      let entityType = categoryToEntityType[category];
-
-      // For hotel restaurant category, only include if tagged as RESTAURANT
-      if (category === 'PHANTASIALAND_HOTELS_RESTAURANTS') {
-        if (!Array.isArray(poi.tags) || !poi.tags.includes('RESTAURANT')) continue;
-      }
-
+      const entityType = publishedEntityType(poi);
       if (!entityType) continue;
 
       // Build multi-language name. The API ships two shapes:
@@ -455,14 +473,71 @@ export class Phantasialand extends Destination {
     return [parkEntity, ...entities];
   }
 
+  /**
+   * Unpublished POI id -> the published id for the same venue.
+   *
+   * The POI feed carries several records per venue: one with seasons, which
+   * becomes the entity, and retired or placeholder copies with `seasons: []`
+   * which do not. The signage feed reports live state against whichever copy
+   * it likes, so Black Mamba's wait time arrives under the unpublished id
+   * while the published entity gets a bare CLOSED — the park ends up with no
+   * wait times at all downstream.
+   *
+   * Records are linked by title, which matches exactly across the copies.
+   * A title is only aliased when exactly one of its records is published;
+   * groups with none (Lockers, Toilets, Nobis) or with several stay unmapped
+   * and their rows keep being dropped.
+   */
+  private async getLiveIdMapping(): Promise<{aliases: Map<string, string>; publishedIds: Set<string>}> {
+    const pois = await this.getPOI();
+
+    const publishedIds = new Set<string>();
+    const byTitle = new Map<string, {published: string[]; unpublished: string[]}>();
+    for (const poi of pois) {
+      const {en, de} = pickLocalisedName(poi?.title ?? poi?._title ?? poi?.name);
+      const title = en || de;
+      if (!title) continue;
+
+      const isPublished = !!publishedEntityType(poi);
+      if (isPublished) publishedIds.add(String(poi.id));
+
+      let group = byTitle.get(title);
+      if (!group) {
+        group = {published: [], unpublished: []};
+        byTitle.set(title, group);
+      }
+      (isPublished ? group.published : group.unpublished).push(String(poi.id));
+    }
+
+    const aliases = new Map<string, string>();
+    for (const {published, unpublished} of byTitle.values()) {
+      if (published.length !== 1) continue;
+      for (const id of unpublished) aliases.set(id, published[0]);
+    }
+    return {aliases, publishedIds};
+  }
+
   protected async buildLiveData(): Promise<LiveData[]> {
-    const signage = await this.getSignage();
-    const liveData: LiveData[] = [];
+    const [signage, {aliases, publishedIds}] = await Promise.all([
+      this.getSignage(),
+      this.getLiveIdMapping(),
+    ]);
+    // Keyed by published id: once aliased, two signage entries can land on the
+    // same entity (a bare CLOSED for the published copy, the real state for
+    // the other), so the more informative row wins.
+    const rows = new Map<string, LiveData>();
 
     for (const entry of signage) {
       if (!entry.poiId) continue;
 
-      const entityId = String(entry.poiId);
+      const rawId = String(entry.poiId);
+      const entityId = aliases.get(rawId) ?? rawId;
+
+      // Venues the entity list doesn't publish (services, photo points,
+      // records with no live copy at all) can't be looked up by a consumer,
+      // so their rows are dropped rather than emitted against a dead id.
+      if (!publishedIds.has(entityId)) continue;
+
       const ld: LiveData = {id: entityId, status: 'CLOSED'} as LiveData;
 
       if (entry.showTimes !== null && entry.showTimes !== undefined) {
@@ -493,10 +568,13 @@ export class Phantasialand extends Destination {
         ld.status = (entry.open ? 'OPERATING' : 'CLOSED') as any;
       }
 
-      liveData.push(ld);
+      const existing = rows.get(entityId);
+      if (!existing || livenessScore(ld) > livenessScore(existing)) {
+        rows.set(entityId, ld);
+      }
     }
 
-    return liveData;
+    return [...rows.values()];
   }
 
   /**


### PR DESCRIPTION
## Summary

Phantasialand publishes **no wait times at all**, and its two headline coasters read closed while they are running. The data is fetched correctly on every poll and then filed under ids no consumer can resolve.

| measured against the live feed | before | after |
|---|---|---|
| entities | 110 | 110 |
| live rows | 58 | 51 |
| rows keyed to an unpublished id | **7** | **0** |
| **entities carrying a queue** | **0** | **2** |
| entities carrying showtimes | 13 | 13 |

## What was happening

The POI feed carries several records per venue: one with `seasons`, which `buildEntityList` publishes, and retired or placeholder copies with `seasons: []`, which it skips at `phantasialand.ts:385`. `buildLiveData` at `:458` emitted a row for every signage `poiId` and never consulted the entity list.

The signage feed reports against whichever copy it likes:

| venue | published entity | its live row | unpublished twin | its live row |
|---|---|---|---|---|
| Black Mamba | `52` (seasons=2) | `{"status":"CLOSED"}` | `225` (seasons=0) | `{"status":"OPERATING","queue":{"STANDBY":{"waitTime":40}}}` |
| Colorado Adventure | `224` (seasons=2) | `{"status":"CLOSED"}` | `25` (seasons=0) | `{"status":"OPERATING","queue":{"STANDBY":{"waitTime":5}}}` |

So an inverted coaster and the mine train both showed CLOSED while queueing at 40 and 5 minutes, and every other wait the park produced was discarded downstream.

## The fix

Live rows are aliased onto the published id, matching on `title`, which is exact across the copies. Guardrails:

- **A title is only aliased when exactly one of its records is published.** `Focaccia Mexico` genuinely has two published records and `Nobis` has three, none published; both stay unmapped rather than guessed at. Picking one would put a wait time on the wrong venue.
- **Rows that still resolve to nothing are dropped**, rather than published against a dead id. That covers services and photo points (`ATM`, `Face painter`, `Lockers`) which are not entities in any copy.
- **Where two signage entries land on the same entity** — a bare CLOSED for the published copy and the real state for the other — the more informative row wins, scored on queue, showtimes and status. Order-independent, and tested both ways round.

The publish rule moves into a single `publishedEntityType()` that both paths call. Two copies of that rule drifting apart is the actual root cause, so leaving them separate would invite the same bug back.

## How it surfaced

The orphan check in #299. Nobody was looking at Phantasialand; it passed the harness 4/4 before and after, because a row keyed to a non-existent entity was not something anything checked.

## Test plan

- [x] `npm test` — 75 files, 1702 tests, all passing
- [x] `npx tsc --noEmit` — clean
- [x] New `liveIdAliases.test.ts`, 9 tests, **7 fail against pre-fix source**
- [x] Covered: a wait landing on the published entity, the bare-CLOSED merge in both orderings, no duplicate ids in the output, showtimes aliasing as well as waits, a venue with no published copy, a copy unpublished only by category, a title with two published records left unguessed, an unambiguous id untouched, and the overall invariant that no row is emitted for an unpublished id
- [x] `npm run dev -- phantasialand` — 4/4, 110 entities, 51 live rows
- [x] Live feed: Black Mamba and Colorado Adventure now carry `OPERATING` with their real waits on entities `52` and `224`
