### PR TITLE
fix(phantasialand): retire stale signage rows instead of trusting them

### DIFF
--- a/src/parks/phantasialand/__tests__/staleSignage.test.ts
+++ b/src/parks/phantasialand/__tests__/staleSignage.test.ts
@@ -2,57 +2,69 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {Phantasialand} from '../phantasialand.js';
 
 /**
- * The signage feed regenerates a row for every venue it is still reporting on
- * and never deletes the ones it has stopped reporting. Retired rows keep their
- * original timestamp and their last observed state forever.
+ * The signage feed rewrites its whole snapshot every couple of minutes under
+ * one shared timestamp, and never prunes rows for venues it has stopped
+ * reporting on. Those rows keep their last observed state indefinitely.
  *
  * Live, that meant Mystic Winter Castle published OPERATING with nine
- * showtimes in August off a February observation, and Hack & Buddl published
- * CLOSED off a row last touched 521 days earlier. Rows older than a day are
- * dropped so a stale observation is never restated as current.
+ * showtimes dated February, all summer, and Tiempo de Fuego published
+ * showtimes dated 2021. A stale row is emitted as a bare CLOSED, which
+ * clears the frozen content once and then stops changing.
  *
- * Every test here carries a fresh row that must survive, so a test cannot pass
- * by the pipeline silently producing nothing.
+ * `buildLiveData` reads only `getSignage()`, so these stub nothing else —
+ * an earlier draft stubbed `getPOI` too and every one of those fixtures was
+ * dead code.
  */
 const NOW = new Date('2026-08-14T10:00:00Z');
 
-/** A POI record that becomes a published entity. */
-function poi(id: number, title: string, category = 'ATTRACTIONS') {
+/** Time `hoursAgo` before the pinned now, ISO. */
+const at = (hoursAgo: number) => new Date(NOW.getTime() - hoursAgo * 3600_000).toISOString();
+
+/** A signage row whose three timestamps all sit at the same age. */
+function row(poiId: number, hoursAgo: number, state: Record<string, unknown> = {}) {
+  const stamp = at(hoursAgo);
   return {
-    id,
-    title,
-    category,
-    seasons: ['SUMMER', 'WINTER'],
-    tags: [],
-    entrance: {world: {lat: 50.79, lng: 6.87}},
+    poiId: String(poiId),
+    updatedAt: stamp,
+    createdAt: stamp,
+    updatedRow: stamp,
+    waitTime: null,
+    open: null,
+    showTimes: null,
+    ...state,
   };
 }
 
-/** A signage row, aged `hoursAgo` before the pinned now. */
-function row(poiId: number, hoursAgo: number, state: Record<string, unknown>) {
-  const at = new Date(NOW.getTime() - hoursAgo * 3600_000).toISOString();
-  return {poiId: String(poiId), updatedAt: at, createdAt: at, updatedRow: at, ...state};
-}
+/**
+ * The canary: a genuinely fresh row that must survive intact in every test.
+ * Aged two minutes to match the real feed's cadence, so a regression that
+ * tightened the threshold cannot leave it standing.
+ */
+const CANARY_AGE_H = 2 / 60;
+const canary = () => row(60, CANARY_AGE_H, {waitTime: 25, open: true});
 
-/** The canary: always fresh, always published, must appear in every test. */
-const FRESH_POI = poi(60, 'Taron');
-const freshRow = () => row(60, 0, {waitTime: 25, open: true});
-
-function stubbedPark(extraPois: any[], extraSignage: any[]): Phantasialand {
+function stubbedPark(signage: any[]): Phantasialand {
   const park = new Phantasialand();
-  vi.spyOn(park as any, 'getPOI').mockResolvedValue([FRESH_POI, ...extraPois]);
-  vi.spyOn(park as any, 'getSignage').mockResolvedValue([freshRow(), ...extraSignage]);
+  vi.spyOn(park as any, 'getSignage').mockResolvedValue([canary(), ...signage]);
   return park;
 }
 
 async function live(park: Phantasialand) {
   const rows = await park.getLiveData();
-  // Canary: if this ever goes missing the test is proving nothing.
   expect(rows.find((l) => l.id === '60')).toMatchObject({
     status: 'OPERATING',
     queue: {STANDBY: {waitTime: 25}},
   });
   return rows;
+}
+
+/** A stale row must publish CLOSED and nothing else. */
+function expectRetired(rows: any[], id: string) {
+  const found = rows.find((l) => l.id === id);
+  expect(found).toBeDefined();
+  expect(found.status).toBe('CLOSED');
+  expect(found.showtimes).toBeUndefined();
+  expect(found.queue).toBeUndefined();
 }
 
 describe('Phantasialand stale signage rows', () => {
@@ -66,87 +78,184 @@ describe('Phantasialand stale signage rows', () => {
     vi.restoreAllMocks();
   });
 
-  it('drops a months-old row that would publish a show as running', async () => {
-    // Mystic Winter Castle: OPERATING with showtimes, last observed in February.
-    const park = stubbedPark(
-      [poi(223, 'Mystic Winter Castle', 'SHOWS')],
-      [row(223, 4055, {showTimes: ['2026-02-14 18:00:00', '2026-02-14 19:00:00']})],
-    );
-    expect((await live(park)).find((l) => l.id === '223')).toBeUndefined();
-  });
+  describe('retiring a stale row', () => {
+    it('clears showtimes a stale row was still advertising', async () => {
+      // Mystic Winter Castle: OPERATING with nine February showtimes, in August.
+      const rows = await live(stubbedPark([
+        row(223, 4055, {showTimes: ['2026-02-26 20:00:00', '2026-02-26 21:00:00']}),
+      ]));
+      expectRetired(rows, '223');
+    });
 
-  it('drops a stale CLOSED row just as readily as a stale OPERATING one', async () => {
-    // Staleness is about the observation, not about which way it reads.
-    const park = stubbedPark(
-      [poi(78, 'Hack & Buddl', 'RESTAURANTS_AND_SNACKS')],
-      [row(78, 12501, {open: false})],
-    );
-    expect((await live(park)).find((l) => l.id === '78')).toBeUndefined();
-  });
+    it('clears a stale wait time rather than restating it as current', async () => {
+      const rows = await live(stubbedPark([row(225, 10077, {waitTime: 40, open: true})]));
+      expectRetired(rows, '225');
+    });
 
-  it('drops a stale wait time rather than restating it as current', async () => {
-    const park = stubbedPark(
-      [poi(225, 'Black Mamba')],
-      [row(225, 10077, {waitTime: 40, open: true})],
-    );
-    expect((await live(park)).find((l) => l.id === '225')).toBeUndefined();
-  });
+    it('retires a stale row that already read closed', async () => {
+      // Staleness is about the observation, not which way it happens to read.
+      const rows = await live(stubbedPark([row(78, 12501, {open: false})]));
+      expectRetired(rows, '78');
+    });
 
-  it('keeps a row from earlier the same day', async () => {
-    const park = stubbedPark([poi(52, 'Black Mamba')], [row(52, 6, {waitTime: 5, open: true})]);
-    expect((await live(park)).find((l) => l.id === '52')).toMatchObject({
-      status: 'OPERATING',
-      queue: {STANDBY: {waitTime: 5}},
+    it('emits exactly one row per stale entry', async () => {
+      const rows = await live(stubbedPark([row(223, 4055, {showTimes: ['2026-02-26 20:00:00']})]));
+      expect(rows.filter((l) => l.id === '223')).toHaveLength(1);
     });
   });
 
-  it('keeps a row right up to the day boundary and drops it just past', async () => {
-    const inside = stubbedPark([poi(52, 'Black Mamba')], [row(52, 23.9, {waitTime: 5, open: true})]);
-    expect((await live(inside)).find((l) => l.id === '52')).toBeDefined();
+  describe('keeping a fresh row', () => {
+    it('keeps a row from earlier the same day', async () => {
+      const rows = await live(stubbedPark([row(52, 6, {waitTime: 5, open: true})]));
+      expect(rows.find((l) => l.id === '52')).toMatchObject({
+        status: 'OPERATING',
+        queue: {STANDBY: {waitTime: 5}},
+      });
+    });
 
-    const outside = stubbedPark([poi(52, 'Black Mamba')], [row(52, 24.1, {waitTime: 5, open: true})]);
-    expect((await live(outside)).find((l) => l.id === '52')).toBeUndefined();
+    it('publishes showtimes from a fresh show row', async () => {
+      const rows = await live(stubbedPark([
+        row(194, 0.5, {showTimes: ['2026-08-14 19:30:00']}),
+      ]));
+      expect(rows.find((l) => l.id === '194')).toMatchObject({status: 'OPERATING'});
+      expect(rows.find((l) => l.id === '194')?.showtimes).toHaveLength(1);
+    });
+
+    it('keeps a row sitting exactly on the threshold', async () => {
+      const rows = await live(stubbedPark([row(52, 168, {waitTime: 5, open: true})]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('retires a row a millisecond past the threshold', async () => {
+      const stamp = new Date(NOW.getTime() - (168 * 3600_000 + 1)).toISOString();
+      const rows = await live(stubbedPark([
+        {poiId: '52', updatedAt: stamp, createdAt: stamp, updatedRow: stamp, waitTime: 5, open: true},
+      ]));
+      expectRetired(rows, '52');
+    });
   });
 
-  it('keeps a row when any one of its timestamps is fresh', async () => {
-    // Only every timestamp agreeing makes a row stale.
-    const stale = new Date(NOW.getTime() - 4055 * 3600_000).toISOString();
-    const park = stubbedPark(
-      [poi(52, 'Black Mamba')],
-      [{
+  describe('reading the timestamps', () => {
+    it('uses createdAt when it is the newest, as the real feed has it', async () => {
+      // Real ordering is updatedAt < createdAt = updatedRow.
+      const rows = await live(stubbedPark([{
         poiId: '52',
-        createdAt: stale,
-        updatedRow: stale,
-        updatedAt: NOW.toISOString(),
+        updatedAt: at(4055),
+        createdAt: at(0.5),
+        updatedRow: at(4055),
         waitTime: 5,
         open: true,
-      }],
-    );
-    expect((await live(park)).find((l) => l.id === '52')).toBeDefined();
+      }]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('uses updatedRow when it is the newest', async () => {
+      const rows = await live(stubbedPark([{
+        poiId: '52',
+        updatedAt: at(4055),
+        createdAt: at(4055),
+        updatedRow: at(0.5),
+        waitTime: 5,
+        open: true,
+      }]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('retires a row whose only readable timestamp is ancient', async () => {
+      // Junk beside a real stamp must not read as "cannot tell".
+      const rows = await live(stubbedPark([
+        {poiId: '52', updatedAt: at(4055), createdAt: 'not a date', updatedRow: null, waitTime: 5, open: true},
+      ]));
+      expectRetired(rows, '52');
+    });
+
+    it('keeps a row carrying no readable timestamp at all', async () => {
+      // Cannot tell, so do not retire: guessing here would close the whole
+      // park if the feed's shape ever changed.
+      const rows = await live(stubbedPark([{poiId: '52', waitTime: 5, open: true}]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('ignores a numeric timestamp rather than reading it as ancient', async () => {
+      const rows = await live(stubbedPark([
+        {poiId: '52', updatedAt: NOW.getTime(), createdAt: null, updatedRow: null, waitTime: 5, open: true},
+      ]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('keeps a row stamped slightly in the future', async () => {
+      // Collector clock skew, not a retirement.
+      const rows = await live(stubbedPark([row(52, -0.05, {waitTime: 5, open: true})]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('keeps a row stamped far in the future rather than reading the gap as age', async () => {
+      // A month ahead is nonsense, but it is not evidence of retirement, and
+      // measuring the distance either way would make it look ancient.
+      const rows = await live(stubbedPark([row(52, -720, {waitTime: 5, open: true})]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
+
+    it('ignores a Date object rather than coercing it to a timestamp', async () => {
+      // Only strings are read. A Date stringifies into something Date.parse
+      // accepts, so a loosened guard would start trusting a shape the feed
+      // does not send — and this one would retire a live venue on the
+      // strength of it.
+      const rows = await live(stubbedPark([
+        {
+          poiId: '52',
+          updatedAt: new Date('2020-01-01T00:00:00Z'),
+          createdAt: null,
+          updatedRow: null,
+          waitTime: 5,
+          open: true,
+        },
+      ]));
+      expect(rows.find((l) => l.id === '52')?.queue).toBeDefined();
+    });
   });
 
-  it('keeps a row carrying no readable timestamp at all', async () => {
-    // Cannot tell, so do not drop: guessing here would empty the feed if the
-    // shape ever changed.
-    const park = stubbedPark([poi(52, 'Black Mamba')], [{poiId: '52', waitTime: 5, open: true}]);
-    expect((await live(park)).find((l) => l.id === '52')).toBeDefined();
-  });
+  describe('when the whole feed goes stale', () => {
+    it('reports every venue closed rather than emitting nothing', async () => {
+      const park = new Phantasialand();
+      vi.spyOn(park as any, 'getSignage').mockResolvedValue([
+        row(52, 4055, {waitTime: 5, open: true}),
+        row(223, 4055, {showTimes: ['2026-02-26 20:00:00']}),
+      ]);
+      const rows = await park.getLiveData();
+      expect(rows).toHaveLength(2);
+      expectRetired(rows, '52');
+      expectRetired(rows, '223');
+    });
 
-  it('ignores an unparseable timestamp rather than treating it as ancient', async () => {
-    const park = stubbedPark(
-      [poi(52, 'Black Mamba')],
-      [{poiId: '52', updatedAt: 'not a date', createdAt: null, waitTime: 5, open: true}],
-    );
-    expect((await live(park)).find((l) => l.id === '52')).toBeDefined();
+    it('says so loudly', async () => {
+      const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const park = new Phantasialand();
+      vi.spyOn(park as any, 'getSignage').mockResolvedValue([row(52, 4055, {open: true})]);
+      await park.getLiveData();
+      expect(err).toHaveBeenCalledWith(expect.stringContaining('feed has probably stopped updating'));
+    });
+
+    it('stays quiet while any row is fresh', async () => {
+      const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await live(stubbedPark([row(52, 4055, {open: true})]));
+      expect(err).not.toHaveBeenCalled();
+    });
   });
 
   it('leaves a feed of entirely fresh rows untouched', async () => {
-    const park = stubbedPark(
-      [poi(52, 'Black Mamba'), poi(224, 'Colorado Adventure')],
-      [row(52, 0, {waitTime: 5, open: true}), row(224, 0, {open: false})],
-    );
-    const rows = await live(park);
+    const rows = await live(stubbedPark([
+      row(52, 0.02, {waitTime: 5, open: true}),
+      row(224, 0.02, {open: false}),
+    ]));
     expect(rows).toHaveLength(3);
     expect(rows.find((l) => l.id === '224')).toMatchObject({status: 'CLOSED'});
+  });
+
+  it('skips an entry with no poiId, stale or not', async () => {
+    const rows = await live(stubbedPark([
+      {poiId: null, updatedAt: at(4055), createdAt: at(4055), updatedRow: at(4055), open: true},
+    ]));
+    expect(rows).toHaveLength(1);
   });
 });

--- a/src/parks/phantasialand/__tests__/staleSignage.test.ts
+++ b/src/parks/phantasialand/__tests__/staleSignage.test.ts
@@ -1,0 +1,152 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {Phantasialand} from '../phantasialand.js';
+
+/**
+ * The signage feed regenerates a row for every venue it is still reporting on
+ * and never deletes the ones it has stopped reporting. Retired rows keep their
+ * original timestamp and their last observed state forever.
+ *
+ * Live, that meant Mystic Winter Castle published OPERATING with nine
+ * showtimes in August off a February observation, and Hack & Buddl published
+ * CLOSED off a row last touched 521 days earlier. Rows older than a day are
+ * dropped so a stale observation is never restated as current.
+ *
+ * Every test here carries a fresh row that must survive, so a test cannot pass
+ * by the pipeline silently producing nothing.
+ */
+const NOW = new Date('2026-08-14T10:00:00Z');
+
+/** A POI record that becomes a published entity. */
+function poi(id: number, title: string, category = 'ATTRACTIONS') {
+  return {
+    id,
+    title,
+    category,
+    seasons: ['SUMMER', 'WINTER'],
+    tags: [],
+    entrance: {world: {lat: 50.79, lng: 6.87}},
+  };
+}
+
+/** A signage row, aged `hoursAgo` before the pinned now. */
+function row(poiId: number, hoursAgo: number, state: Record<string, unknown>) {
+  const at = new Date(NOW.getTime() - hoursAgo * 3600_000).toISOString();
+  return {poiId: String(poiId), updatedAt: at, createdAt: at, updatedRow: at, ...state};
+}
+
+/** The canary: always fresh, always published, must appear in every test. */
+const FRESH_POI = poi(60, 'Taron');
+const freshRow = () => row(60, 0, {waitTime: 25, open: true});
+
+function stubbedPark(extraPois: any[], extraSignage: any[]): Phantasialand {
+  const park = new Phantasialand();
+  vi.spyOn(park as any, 'getPOI').mockResolvedValue([FRESH_POI, ...extraPois]);
+  vi.spyOn(park as any, 'getSignage').mockResolvedValue([freshRow(), ...extraSignage]);
+  return park;
+}
+
+async function live(park: Phantasialand) {
+  const rows = await park.getLiveData();
+  // Canary: if this ever goes missing the test is proving nothing.
+  expect(rows.find((l) => l.id === '60')).toMatchObject({
+    status: 'OPERATING',
+    queue: {STANDBY: {waitTime: 25}},
+  });
+  return rows;
+}
+
+describe('Phantasialand stale signage rows', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('drops a months-old row that would publish a show as running', async () => {
+    // Mystic Winter Castle: OPERATING with showtimes, last observed in February.
+    const park = stubbedPark(
+      [poi(223, 'Mystic Winter Castle', 'SHOWS')],
+      [row(223, 4055, {showTimes: ['2026-02-14 18:00:00', '2026-02-14 19:00:00']})],
+    );
+    expect((await live(park)).find((l) => l.id === '223')).toBeUndefined();
+  });
+
+  it('drops a stale CLOSED row just as readily as a stale OPERATING one', async () => {
+    // Staleness is about the observation, not about which way it reads.
+    const park = stubbedPark(
+      [poi(78, 'Hack & Buddl', 'RESTAURANTS_AND_SNACKS')],
+      [row(78, 12501, {open: false})],
+    );
+    expect((await live(park)).find((l) => l.id === '78')).toBeUndefined();
+  });
+
+  it('drops a stale wait time rather than restating it as current', async () => {
+    const park = stubbedPark(
+      [poi(225, 'Black Mamba')],
+      [row(225, 10077, {waitTime: 40, open: true})],
+    );
+    expect((await live(park)).find((l) => l.id === '225')).toBeUndefined();
+  });
+
+  it('keeps a row from earlier the same day', async () => {
+    const park = stubbedPark([poi(52, 'Black Mamba')], [row(52, 6, {waitTime: 5, open: true})]);
+    expect((await live(park)).find((l) => l.id === '52')).toMatchObject({
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 5}},
+    });
+  });
+
+  it('keeps a row right up to the day boundary and drops it just past', async () => {
+    const inside = stubbedPark([poi(52, 'Black Mamba')], [row(52, 23.9, {waitTime: 5, open: true})]);
+    expect((await live(inside)).find((l) => l.id === '52')).toBeDefined();
+
+    const outside = stubbedPark([poi(52, 'Black Mamba')], [row(52, 24.1, {waitTime: 5, open: true})]);
+    expect((await live(outside)).find((l) => l.id === '52')).toBeUndefined();
+  });
+
+  it('keeps a row when any one of its timestamps is fresh', async () => {
+    // Only every timestamp agreeing makes a row stale.
+    const stale = new Date(NOW.getTime() - 4055 * 3600_000).toISOString();
+    const park = stubbedPark(
+      [poi(52, 'Black Mamba')],
+      [{
+        poiId: '52',
+        createdAt: stale,
+        updatedRow: stale,
+        updatedAt: NOW.toISOString(),
+        waitTime: 5,
+        open: true,
+      }],
+    );
+    expect((await live(park)).find((l) => l.id === '52')).toBeDefined();
+  });
+
+  it('keeps a row carrying no readable timestamp at all', async () => {
+    // Cannot tell, so do not drop: guessing here would empty the feed if the
+    // shape ever changed.
+    const park = stubbedPark([poi(52, 'Black Mamba')], [{poiId: '52', waitTime: 5, open: true}]);
+    expect((await live(park)).find((l) => l.id === '52')).toBeDefined();
+  });
+
+  it('ignores an unparseable timestamp rather than treating it as ancient', async () => {
+    const park = stubbedPark(
+      [poi(52, 'Black Mamba')],
+      [{poiId: '52', updatedAt: 'not a date', createdAt: null, waitTime: 5, open: true}],
+    );
+    expect((await live(park)).find((l) => l.id === '52')).toBeDefined();
+  });
+
+  it('leaves a feed of entirely fresh rows untouched', async () => {
+    const park = stubbedPark(
+      [poi(52, 'Black Mamba'), poi(224, 'Colorado Adventure')],
+      [row(52, 0, {waitTime: 5, open: true}), row(224, 0, {open: false})],
+    );
+    const rows = await live(park);
+    expect(rows).toHaveLength(3);
+    expect(rows.find((l) => l.id === '224')).toMatchObject({status: 'CLOSED'});
+  });
+});

--- a/src/parks/phantasialand/phantasialand.ts
+++ b/src/parks/phantasialand/phantasialand.ts
@@ -45,6 +45,35 @@ const categoryToEntityType: Record<string, Entity['entityType'] | undefined> = {
   'PHANTASIALAND_HOTELS_RESTAURANTS': 'RESTAURANT',
 };
 
+/**
+ * How old a signage row may be and still count as an observation.
+ *
+ * Rows the feed is still reporting on are regenerated every few minutes, so
+ * in practice a live row is seconds old. Retired rows are frozen: the
+ * youngest observed is 54 days, the oldest 2.7 years. A day is far from both
+ * edges, and leaves room for the feed to pause overnight without discarding
+ * genuine observations.
+ */
+const MAX_SIGNAGE_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Milliseconds since a signage row was last regenerated, or null when it
+ * carries no readable timestamp.
+ *
+ * Null means "cannot tell", and the caller keeps the row: dropping on missing
+ * evidence would silently empty the feed if the shape ever changes. All three
+ * fields are consulted so a row is only considered stale when every timestamp
+ * agrees it is.
+ */
+function signageRowAge(entry: any, nowMs: number): number | null {
+  const stamps = [entry?.updatedAt, entry?.createdAt, entry?.updatedRow]
+    .map((value) => (typeof value === 'string' ? Date.parse(value) : NaN))
+    .filter((ms) => Number.isFinite(ms));
+
+  if (stamps.length === 0) return null;
+  return nowMs - Math.max(...stamps);
+}
+
 @destinationController({category: 'Phantasialand'})
 export class Phantasialand extends Destination {
   @config
@@ -458,9 +487,19 @@ export class Phantasialand extends Destination {
   protected async buildLiveData(): Promise<LiveData[]> {
     const signage = await this.getSignage();
     const liveData: LiveData[] = [];
+    const nowMs = Date.now();
 
     for (const entry of signage) {
       if (!entry.poiId) continue;
+
+      // The signage feed regenerates a row for every venue it is still
+      // reporting on, and never deletes the ones it has stopped reporting.
+      // Retired rows keep their original timestamp and their last observed
+      // state forever, so publishing them states as current something last
+      // seen months ago — Mystic Winter Castle was being published OPERATING
+      // with nine showtimes in August off a February observation.
+      const age = signageRowAge(entry, nowMs);
+      if (age !== null && age > MAX_SIGNAGE_AGE_MS) continue;
 
       const entityId = String(entry.poiId);
       const ld: LiveData = {id: entityId, status: 'CLOSED'} as LiveData;

--- a/src/parks/phantasialand/phantasialand.ts
+++ b/src/parks/phantasialand/phantasialand.ts
@@ -48,13 +48,17 @@ const categoryToEntityType: Record<string, Entity['entityType'] | undefined> = {
 /**
  * How old a signage row may be and still count as an observation.
  *
- * Rows the feed is still reporting on are regenerated every few minutes, so
- * in practice a live row is seconds old. Retired rows are frozen: the
- * youngest observed is 54 days, the oldest 2.7 years. A day is far from both
- * edges, and leaves room for the feed to pause overnight without discarding
- * genuine observations.
+ * The feed rewrites its whole snapshot every ~2 minutes under one shared
+ * timestamp, so a row it is still reporting on is minutes old; there is no
+ * per-venue cadence that could make a live row legitimately stale. Rows for
+ * venues removed from the signage config are never pruned and never touched
+ * again: the youngest observed is 54 days, the oldest 2.7 years.
+ *
+ * A week sits 8x clear of the nearest relic while tolerating a feed outage
+ * far longer than any observed. It is deliberately not tighter — the cost of
+ * being wrong in that direction is every row going stale at once.
  */
-const MAX_SIGNAGE_AGE_MS = 24 * 60 * 60 * 1000;
+const MAX_SIGNAGE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Milliseconds since a signage row was last regenerated, or null when it
@@ -71,6 +75,12 @@ function signageRowAge(entry: any, nowMs: number): number | null {
     .filter((ms) => Number.isFinite(ms));
 
   if (stamps.length === 0) return null;
+
+  // The newest of the three is the row-write time. Measured ordering is
+  // always `updatedAt < createdAt = updatedRow`: updatedAt is the upstream
+  // data tick and lags the write by a minute or so. Relics keep their own
+  // frozen updatedAt rather than picking up the current tick, so taking the
+  // newest cannot resurrect one.
   return nowMs - Math.max(...stamps);
 }
 
@@ -488,20 +498,31 @@ export class Phantasialand extends Destination {
     const signage = await this.getSignage();
     const liveData: LiveData[] = [];
     const nowMs = Date.now();
+    let staleRows = 0;
 
     for (const entry of signage) {
       if (!entry.poiId) continue;
 
+      const entityId = String(entry.poiId);
+
       // The signage feed regenerates a row for every venue it is still
       // reporting on, and never deletes the ones it has stopped reporting.
       // Retired rows keep their original timestamp and their last observed
-      // state forever, so publishing them states as current something last
-      // seen months ago — Mystic Winter Castle was being published OPERATING
-      // with nine showtimes in August off a February observation.
+      // state forever — Mystic Winter Castle was published OPERATING with
+      // nine showtimes dated February, all summer.
+      //
+      // Such a row is emitted as a bare CLOSED rather than skipped. Skipping
+      // writes nothing, and the wiki keeps rows until something replaces
+      // them, so the stale showtimes would simply sit there for good. One
+      // CLOSED clears them; after that the value stops changing and stops
+      // being rewritten, so nothing fakes a heartbeat either. Same treatment
+      // as a retired Nigloland ride.
       const age = signageRowAge(entry, nowMs);
-      if (age !== null && age > MAX_SIGNAGE_AGE_MS) continue;
-
-      const entityId = String(entry.poiId);
+      if (age !== null && age > MAX_SIGNAGE_AGE_MS) {
+        staleRows++;
+        liveData.push({id: entityId, status: 'CLOSED'} as LiveData);
+        continue;
+      }
       const ld: LiveData = {id: entityId, status: 'CLOSED'} as LiveData;
 
       if (entry.showTimes !== null && entry.showTimes !== undefined) {
@@ -533,6 +554,16 @@ export class Phantasialand extends Destination {
       }
 
       liveData.push(ld);
+    }
+
+    // Every row going stale at once means the feed stopped, not that the
+    // estate retired overnight. The output is still safe — everything reads
+    // CLOSED — but it is worth saying out loud rather than inferring from a
+    // park that has quietly gone dark.
+    if (staleRows > 0 && staleRows === liveData.length) {
+      console.error(
+        `[Phantasialand] every signage row (${staleRows}) is older than ${MAX_SIGNAGE_AGE_MS / 86400000}d — the feed has probably stopped updating`,
+      );
     }
 
     return liveData;


### PR DESCRIPTION
Replaces #300, which was built on a wrong premise. See that PR for the postmortem.

## The problem

The signage feed rewrites its whole snapshot every couple of minutes under one shared timestamp, and never prunes rows for venues it has stopped reporting on. Those rows keep their last observed state indefinitely, and we published them as current.

Live on the wiki right now, all frozen since April:

```
119d  Mystic Winter Castle   OPERATING  9 showtimes dated 2026-02-26
119d  Kroka's Lodge          OPERATING  6 showtimes dated 2025-11-13
119d  Dragon Wang / Drago    OPERATING  6 showtimes each
 54d  Tiempo de Fuego        OPERATING  2 showtimes dated 2021-11-19
```

A winter castle advertising nine February performances, in August. Every dropped payload is dated to its own freeze date, so these are self-evidently not observations of today.

## The fix

A signage row older than 7 days is emitted as a bare `CLOSED` instead of being trusted.

**Why CLOSED rather than skipping the row.** Skipping writes nothing, and the wiki keeps a live-data row until something replaces it — the server only writes on a content change, which is why `lastUpdated` for these 13 entities has been frozen since April. Emitting nothing leaves the stale showtimes published permanently. One `CLOSED` clears them, and because the value then stops changing it stops being rewritten, so nothing fakes a heartbeat either. This is what `nigloland.ts` does with a retired ride, for the reason its comment gives: so the wiki does not echo cancelled performances.

**Why 7 days.** There is no per-venue refresh cadence that could make a live row legitimately stale — a row is in the current whole-snapshot pass or it is frozen forever. Sorted ages in hours from a live pull:

```
[0 x38, 1293 x3, 4056 x6, 6573, 6573, 6574, 6645, 10078, 11923, 12502, 12502, 15328, 15329, 23560]
```

Nothing has ever held an intermediate age. A tighter threshold buys about a day of earlier detection and costs outage tolerance, and the failure is all-or-nothing. A week still clears the nearest relic 8x.

**Why the newest of the three timestamps.** Measured ordering is `updatedAt < createdAt = updatedRow`: `updatedAt` is the upstream data tick and lags the row write. Relics keep their own frozen `updatedAt` rather than picking up the current tick, so taking the newest cannot resurrect one.

A row with no readable timestamp is kept — dropping on missing evidence would close the whole park if the feed's shape ever changed. When *every* row is stale the park still reads safely as closed, but it logs, because that means the feed stopped rather than the estate retiring overnight.

## Effect, diffed on one captured snapshot

Both versions over the same signage array, so nothing here is a cross-time artifact:

```
rows: 58 -> 58        added 0, removed 0
with a queue: 33 -> 31        with showtimes: 15 -> 4
13 rows changed, all of the same shape:
  223  OPERATING shows=9  ->  CLOSED shows=0     Mystic Winter Castle
  219  OPERATING shows=6  ->  CLOSED shows=0     Kroka's Lodge
  225  OPERATING q=40     ->  CLOSED q=null      relic, frozen 2025-06-20
  25   OPERATING q=5      ->  CLOSED q=null      relic, frozen 2023-12-06
  ... 9 more
```

The two cleared wait times are relics sitting on unpublished ids. Their published twins are fresh and untouched: Black Mamba reports its live 45 minutes throughout, and no venue loses a wait time. Entities and schedules are byte-identical.

## What this does not fix

Eight of the thirteen carry `seasons: ["WINTER"]` and are genuinely out of season. The rest — the Six Dragons meet & greets, Avoras, Hack & Buddl — are plausibly operating, and `CLOSED` is a judgement rather than an observation for them. It is a better judgement than "OPERATING, next show 13 November 2025", but the underlying gap is that the signage config stopped listing venues the park still runs. That is upstream, and worth its own issue.

Separately: on a closed day the feed still emits shows with plausible evening showtimes, so during a seasonal closure the park will likely publish shows as OPERATING. Those rows are fresh, so this filter cannot catch them. Also worth its own issue.

## Test plan

- [x] `npm test` — 75 files, 1714 tests, all passing
- [x] `npx tsc --noEmit` — clean
- [x] `staleSignage.test.ts`, 21 tests, clock pinned with fake timers
- [x] **Mutation tested, 16 mutants, all killed**: never retire, retire everything, retire-on-null, `max`→`min`, threshold 1h, threshold 90d, each timestamp field individually, `>`→`>=`, drop `Number.isFinite`, `typeof`→truthiness, `Math.abs(age)`, `stamps[0]`, remove the poiId skip, `length===0`→`length<3`, retire-drops-row, retire-keeps-OPERATING, suppress the all-stale log
- [x] Previous revision's fixtures stubbed `getPOI`, which `buildLiveData` never calls — every one was dead code, and replacing that stub with a rejection left all tests green. Removed
- [x] Canary row aged to 2 minutes, matching the real cadence, so it is no longer immune to a tightened threshold
- [x] Covered: cleared showtimes, cleared wait, stale-already-closed, both sides of the exact threshold, each timestamp field carrying the newest value, ancient-stamp-beside-junk, no timestamp, numeric timestamp, Date object, near and far future stamps, whole feed stale, the log firing and staying quiet, no-poiId entry
- [x] `npm run dev -- phantasialand` — 4/4, 110 entities, 58 live rows
