### PR TITLE
Fix/walibi publish untagged attractions

### DIFF
--- a/src/parks/walibi/__tests__/entityIds.test.ts
+++ b/src/parks/walibi/__tests__/entityIds.test.ts
@@ -45,11 +45,9 @@ describe('WalibiBase.buildEntityList — restaurant ids from CMS paths', () => {
 
     const dining = entities.filter(e => e.entityType === 'RESTAURANT');
     expect(dining.map(e => e.name)).toEqual(['Pêche & Mignon', 'Crêpes Corner']);
-    // Only the `&` is replaced, so the hyphens around it survive:
-    // `dining_p-che-&-mignon` becomes `dining_p-che---mignon`. Ugly, but it is
-    // the rename with the smallest blast radius, and it is the id the wiki
-    // record has to be repointed to.
-    expect(dining[0].id).toBe('dining_p-che---mignon');
+    // The `&` and the hyphens glued to it collapse into one: this is the id
+    // the live `dining_p-che-&-mignon` record has to be repointed to.
+    expect(dining[0].id).toBe('dining_p-che-mignon');
 
     for (const entity of entities) {
       expect(entity.id).toMatch(/^[\w.-]+$/);
@@ -83,6 +81,22 @@ describe('WalibiBase.buildEntityList — restaurant ids from CMS paths', () => {
     const ids = entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id);
     expect(ids).toEqual(['dining_cafe--rouge', 'dining_cafe-rouge']);
     expect(new Set(ids).size).toBe(2);
+  });
+
+  test('leaves every slug the charset already accepts byte-identical', async () => {
+    // The guarantee that makes this safe to ship: sanitising touches only runs
+    // containing a rejected character, so a legal slug matches nothing. These
+    // are real slugs from the live feeds, hyphen shapes and all.
+    const legal = [
+      'crepes-corner', 'stardocks-caf-', 'wild-rock-caf-', 'cafe--rouge',
+      'shiva-s-food-truck', 'n-soso', 'javass-coffee-corner', 'fun-o-clock',
+      'cine-chill', 'ice_saloon', 'pizza.solo', '-taco', 'taco-',
+    ];
+
+    const entities = await stubbedPark(legal.map(slug => restaurant(slug, slug))).getEntities();
+
+    expect(entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id))
+      .toEqual(legal.map(slug => `dining_${slug}`));
   });
 
   test('a slug made entirely of rejected characters still publishes, rather than leaving a stale row', async () => {

--- a/src/parks/walibi/__tests__/entityIds.test.ts
+++ b/src/parks/walibi/__tests__/entityIds.test.ts
@@ -1,0 +1,60 @@
+import {describe, test, expect, beforeEach, afterEach} from 'vitest';
+import {WalibiBelgium} from '../walibi.js';
+import {CacheLib} from '../../../cache.js';
+import type {HTTPObj} from '../../../http.js';
+
+/**
+ * Restaurants have no stable id in the API, so their entity id is the last
+ * segment of the CMS path. The CMS builds that segment from the display name
+ * and does not sanitise it: "Pêche & Mignon" becomes `p-che-&-mignon`, and the
+ * `&` fails the harness id charset (`/^[\w.-]+$/`). Because validation runs
+ * over the whole list, that single restaurant made getEntities() throw — every
+ * Walibi Belgium entity, rides included, was rejected with it.
+ */
+const restaurant = (title: string, slug: string) => ({
+  title,
+  path: `/content/dam/wbe/nl/restaurants/${slug}-files/${slug}`,
+});
+
+function stubbedPark(restaurants: any[]): WalibiBelgium {
+  const park = new WalibiBelgium();
+  park.fetchAttractions = (async () => ({json: async () => []} as any as HTTPObj)) as any;
+  park.getRestaurants = async () => restaurants;
+  park.getWaitTimes = async () => [];
+  return park;
+}
+
+describe('WalibiBase.buildEntityList — restaurant ids from CMS paths', () => {
+  beforeEach(() => CacheLib.clear());
+  afterEach(() => CacheLib.clear());
+
+  test('sanitises a CMS slug the id charset rejects, without dropping the entity', async () => {
+    const entities = await stubbedPark([
+      restaurant('Pêche & Mignon', 'p-che-&-mignon'),
+      restaurant('Crêpes Corner', 'crepes-corner'),
+    ]).getEntities();
+
+    const names = entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.name);
+    expect(names).toEqual(['Pêche & Mignon', 'Crêpes Corner']);
+
+    for (const entity of entities) {
+      expect(entity.id).toMatch(/^[\w.-]+$/);
+    }
+  });
+
+  test('leaves already-clean slugs untouched, so existing ids do not shift', async () => {
+    const entities = await stubbedPark([restaurant('Crêpes Corner', 'crepes-corner')]).getEntities();
+
+    expect(entities.find(e => e.entityType === 'RESTAURANT')?.id).toBe('dining_crepes-corner');
+  });
+
+  test('a slug made entirely of rejected characters yields no entity rather than a bare prefix', async () => {
+    const entities = await stubbedPark([
+      restaurant('???', '&&&'),
+      restaurant('Crêpes Corner', 'crepes-corner'),
+    ]).getEntities();
+
+    const dining = entities.filter(e => e.entityType === 'RESTAURANT');
+    expect(dining.map(e => e.id)).toEqual(['dining_crepes-corner']);
+  });
+});

--- a/src/parks/walibi/__tests__/entityIds.test.ts
+++ b/src/parks/walibi/__tests__/entityIds.test.ts
@@ -6,10 +6,19 @@ import type {HTTPObj} from '../../../http.js';
 /**
  * Restaurants have no stable id in the API, so their entity id is the last
  * segment of the CMS path. The CMS builds that segment from the display name
- * and does not sanitise it: "Pêche & Mignon" becomes `p-che-&-mignon`, and the
- * `&` fails the harness id charset (`/^[\w.-]+$/`). Because validation runs
- * over the whole list, that single restaurant made getEntities() throw — every
- * Walibi Belgium entity, rides included, was rejected with it.
+ * and does not sanitise it: "Pêche & Mignon" becomes `p-che-&-mignon`.
+ *
+ * That id publishes fine today — `Destination.getEntities()` does no id
+ * validation, and `dining_p-che-&-mignon` is a live record. What it breaks is
+ * `npm run dev -- walibibelgium`: the charset check at `src/testRunner.ts:151`
+ * runs over the whole entity list, so one bad restaurant rejects every Walibi
+ * Belgium entity, rides included. Sanitising it is therefore a *rename* of a
+ * live record, not a rescue.
+ *
+ * The flip side is that ids the charset already accepts must not move —
+ * including the trailing hyphens the CMS emits (`stardocks-caf-`,
+ * `wild-rock-caf-`, both live on Walibi Rhône-Alpes). Renaming those would
+ * mint new wiki records and orphan their history.
  */
 const restaurant = (title: string, slug: string) => ({
   title,
@@ -34,27 +43,58 @@ describe('WalibiBase.buildEntityList — restaurant ids from CMS paths', () => {
       restaurant('Crêpes Corner', 'crepes-corner'),
     ]).getEntities();
 
-    const names = entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.name);
-    expect(names).toEqual(['Pêche & Mignon', 'Crêpes Corner']);
+    const dining = entities.filter(e => e.entityType === 'RESTAURANT');
+    expect(dining.map(e => e.name)).toEqual(['Pêche & Mignon', 'Crêpes Corner']);
+    // Only the `&` is replaced, so the hyphens around it survive:
+    // `dining_p-che-&-mignon` becomes `dining_p-che---mignon`. Ugly, but it is
+    // the rename with the smallest blast radius, and it is the id the wiki
+    // record has to be repointed to.
+    expect(dining[0].id).toBe('dining_p-che---mignon');
 
     for (const entity of entities) {
       expect(entity.id).toMatch(/^[\w.-]+$/);
     }
   });
 
-  test('leaves already-clean slugs untouched, so existing ids do not shift', async () => {
-    const entities = await stubbedPark([restaurant('Crêpes Corner', 'crepes-corner')]).getEntities();
+  test('leaves a trailing-hyphen slug untouched, so live ids do not shift', async () => {
+    // `stardocks-caf-` and `wild-rock-caf-` are published today. A trailing
+    // hyphen is legal under /^[\w.-]+$/, so trimming it would rename them.
+    const entities = await stubbedPark([
+      restaurant('Stardocks Café', 'stardocks-caf-'),
+      restaurant('Wild Rock Café', 'wild-rock-caf-'),
+      restaurant('Crêpes Corner', 'crepes-corner'),
+    ]).getEntities();
 
-    expect(entities.find(e => e.entityType === 'RESTAURANT')?.id).toBe('dining_crepes-corner');
+    expect(entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id)).toEqual([
+      'dining_stardocks-caf-',
+      'dining_wild-rock-caf-',
+      'dining_crepes-corner',
+    ]);
   });
 
-  test('a slug made entirely of rejected characters yields no entity rather than a bare prefix', async () => {
+  test('keeps slugs distinct when they differ only in hyphens', async () => {
+    // Collapsing or trimming hyphen runs would land these on one id and
+    // silently merge two venues into a single entity.
+    const entities = await stubbedPark([
+      restaurant('Café Rouge', 'cafe--rouge'),
+      restaurant('Cafe Rouge Express', 'cafe-rouge'),
+    ]).getEntities();
+
+    const ids = entities.filter(e => e.entityType === 'RESTAURANT').map(e => e.id);
+    expect(ids).toEqual(['dining_cafe--rouge', 'dining_cafe-rouge']);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  test('a slug made entirely of rejected characters still publishes, rather than leaving a stale row', async () => {
     const entities = await stubbedPark([
       restaurant('???', '&&&'),
       restaurant('Crêpes Corner', 'crepes-corner'),
     ]).getEntities();
 
     const dining = entities.filter(e => e.entityType === 'RESTAURANT');
-    expect(dining.map(e => e.id)).toEqual(['dining_crepes-corner']);
+    expect(dining.map(e => e.id)).toEqual(['dining_-', 'dining_crepes-corner']);
+    for (const entity of entities) {
+      expect(entity.id).toMatch(/^[\w.-]+$/);
+    }
   });
 });

--- a/src/parks/walibi/__tests__/localeMerge.test.ts
+++ b/src/parks/walibi/__tests__/localeMerge.test.ts
@@ -1,15 +1,18 @@
-import {describe, test, expect, beforeEach, afterEach, vi} from 'vitest';
+import {describe, test, expect, beforeEach, afterEach, beforeAll, afterAll, vi} from 'vitest';
+import {createServer, IncomingMessage, ServerResponse} from 'http';
+import {AddressInfo} from 'net';
 import {WalibiBelgium} from '../walibi.js';
 import {CacheLib} from '../../../cache.js';
 import type {HTTPObj} from '../../../http.js';
 
 /**
  * The CMS serves one attractions feed per locale and those locales drift.
- * Walibi Belgium is configured on `nl`, whose feed silently omits VAMPIRE
- * (waitingTimeName 34) — as does `en`. Only `fr` lists it. Because the ride
- * was missing from the configured feed, buildEntityList never emitted an
- * entity for it and buildLiveData dropped its wait time on the floor, even
- * though waitingtimes.v1.json reported it open the whole time.
+ * Walibi Belgium's `nl` feed silently omits VAMPIRE (waitingTimeName 34) — as
+ * does `en`. Only `fr` lists it, so on `nl` the ride had no entity and its
+ * wait time was dropped on the floor even though waitingtimes.v1.json reported
+ * it open the whole time. The park now runs on `fr`; the merge covers the same
+ * drift wherever it shows up next (today: Le Galion and Tam Tam Aventure on
+ * Walibi Rhône-Alpes).
  *
  * These fixtures are trimmed from real captures of
  * https://www.walibi.be/api/wbe/{nl,fr,en}/attractions.v1.json.
@@ -31,19 +34,26 @@ const VAMPIRE = {
   path: '/content/dam/wbe/fr/attractions/frissons-attractions/vampire-files/vampire',
 };
 
-/** FLASH-BACK — listed in both locales, spelled differently in each. */
+/**
+ * FLASH-BACK — one ride, listed in two locales under a different title *and* a
+ * different path. Only waitingTimeName is stable across locales, which is why
+ * it is the merge key.
+ */
 const FLASHBACK_NL = {title: 'FLASH-BACK', waitingTimeName: '9', path: '/nl/flash-back'};
 const FLASHBACK_FR = {title: 'FLASH BACK', waitingTimeName: '9', path: '/fr/flash-back'};
 
 const FEEDS: Record<string, any[]> = {
   nl: [KONDAA, FLASHBACK_NL],
-  fr: [{...KONDAA, title: 'KONDAA'}, FLASHBACK_FR, VAMPIRE],
-  en: [KONDAA, FLASHBACK_NL],
+  // `en` deliberately does not re-list FLASH-BACK: otherwise a fallback that
+  // overwrote the primary would still end on the `nl` spelling by accident,
+  // and the precedence test below would pass under that mutation.
+  fr: [KONDAA, FLASHBACK_FR, VAMPIRE],
+  en: [KONDAA],
 };
 
 /**
  * A park whose per-locale attraction feeds come from `feeds`; a locale mapped
- * to `null` throws, standing in for a 404 or a malformed response.
+ * to `null` throws, standing in for a transient 5xx or a malformed response.
  */
 function stubbedPark(feeds: Record<string, any[] | null> = FEEDS, waitTimes: any[] = []): WalibiBelgium {
   const park = new WalibiBelgium();
@@ -56,7 +66,7 @@ function stubbedPark(feeds: Record<string, any[] | null> = FEEDS, waitTimes: any
   park.fetchAttractions = (async (culture: string) => {
     const feed = feeds[culture];
     if (feed === undefined) return {json: async () => []} as any as HTTPObj;
-    if (feed === null) throw new Error(`no such locale: ${culture}`);
+    if (feed === null) throw new Error(`upstream failure for locale: ${culture}`);
     return {json: async () => feed} as any as HTTPObj;
   }) as any;
   park.getRestaurants = async () => [];
@@ -96,15 +106,32 @@ describe('WalibiBase.getAttractions — merging CMS locales', () => {
     expect(entities.find(e => e.id === '9')?.name).toBe('FLASH-BACK');
   });
 
-  test('a locale that fails to load is skipped without sinking the merge', async () => {
+  test('matches locales on waitingTimeName, not on title or path, so one ride stays one entity', async () => {
+    // FLASH-BACK differs in both title and path between `nl` and `fr`; keying
+    // the merge on either would emit a second entity under the same id.
+    const entities = await stubbedPark().getEntities();
+
+    const flashback = entities.filter(e => e.id === '9');
+    expect(flashback).toHaveLength(1);
+    expect(entities.filter(e => e.entityType === 'ATTRACTION')).toHaveLength(3); // KONDAA, FLASH-BACK, VAMPIRE
+  });
+
+  test('a fallback locale that fails to load is skipped without sinking the merge', async () => {
     const entities = await stubbedPark({...FEEDS, en: null}).getEntities();
 
     expect(entities.find(e => e.id === '45')).toBeDefined();
     expect(entities.find(e => e.id === '34')).toBeDefined();
   });
 
+  test('the configured locale failing propagates, rather than publishing an empty park', async () => {
+    // The merge must not turn a transient upstream error into a clean, empty,
+    // wrong answer — that would be cached for 24h and shared by every process.
+    await expect(stubbedPark({...FEEDS, nl: null}).getEntities()).rejects.toThrow(/upstream failure/);
+    await expect(stubbedPark({...FEEDS, nl: null}).getLiveData()).rejects.toThrow(/upstream failure/);
+  });
+
   test('a wait time with no attraction in any locale is skipped, and warned about once', async () => {
-    const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const park = stubbedPark(FEEDS, [{id: '45', time: 1200, status: 'open'}, {id: '999', time: 300, status: 'open'}]);
 
     const first = await park.getLiveData();
@@ -114,5 +141,76 @@ describe('WalibiBase.getAttractions — merging CMS locales', () => {
     expect(second.find(l => l.id === '45')).toBeDefined();
     const orphanWarnings = warn.mock.calls.filter(c => String(c[0]).includes('999'));
     expect(orphanWarnings).toHaveLength(1);
+  });
+
+  test('reports orphaned wait times as one summarised line, and names each locale once', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const waitTimes = Array.from({length: 12}, (_, i) => ({id: `90${i}`, time: 0, status: 'open'}));
+
+    await stubbedPark(FEEDS, waitTimes).getLiveData();
+
+    const orphanWarnings = warn.mock.calls.filter(c => String(c[0]).includes('not published'));
+    expect(orphanWarnings).toHaveLength(1);
+    const message = String(orphanWarnings[0][0]);
+    expect(message).toContain('12 wait time id(s)');
+    expect(message).toContain('(+2 more)');
+    expect(message).toContain('[nl, fr, en]'); // primary locale listed once, not twice
+  });
+});
+
+describe('WalibiBelgium — shipped locale', () => {
+  test('is configured on the locale that lists VAMPIRE', () => {
+    // `nl` and `en` both omit VAMPIRE; only `fr` lists it, and Wavre is
+    // francophone. Reverting this to `nl` silently drops the ride again.
+    expect(new WalibiBelgium().culture).toBe('fr');
+  });
+});
+
+/**
+ * The merge only works if each locale is actually requested from its own URL.
+ * Stubbing fetchAttractions cannot see that, so drive the real @http method
+ * against a local server that serves a different feed per path.
+ */
+describe('WalibiBase.fetchAttractions — per-locale URLs', () => {
+  let server: ReturnType<typeof createServer>;
+  let baseURL: string;
+  const requestedPaths: string[] = [];
+
+  beforeAll(async () => {
+    server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      requestedPaths.push(req.url || '');
+      const locale = (req.url || '').split('/')[3];
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify(FEEDS[locale] ?? []));
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}/`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(err => err ? reject(err) : resolve()));
+  });
+
+  beforeEach(() => {
+    CacheLib.clear();
+    requestedPaths.length = 0;
+  });
+  afterEach(() => CacheLib.clear());
+
+  test('requests each locale under its own path, so a fallback returns that locale', async () => {
+    const park = new WalibiBelgium();
+    park.baseURL = baseURL;
+    park.culture = 'nl';
+    park.mergeCultures = ['nl', 'fr', 'en'];
+
+    const attractions = await park.getAttractions();
+
+    expect(requestedPaths).toContain('/api/wbe/nl/attractions.v1.json');
+    expect(requestedPaths).toContain('/api/wbe/fr/attractions.v1.json');
+    expect(requestedPaths).toContain('/api/wbe/en/attractions.v1.json');
+    // VAMPIRE exists only in the `fr` feed: it can only be here if the fallback
+    // request actually carried its own culture.
+    expect(attractions.find(a => a.waitingTimeName === '34')?.title).toBe('VAMPIRE');
+    expect(attractions.find(a => a.waitingTimeName === '9')?.title).toBe('FLASH-BACK');
   });
 });

--- a/src/parks/walibi/__tests__/localeMerge.test.ts
+++ b/src/parks/walibi/__tests__/localeMerge.test.ts
@@ -1,0 +1,118 @@
+import {describe, test, expect, beforeEach, afterEach, vi} from 'vitest';
+import {WalibiBelgium} from '../walibi.js';
+import {CacheLib} from '../../../cache.js';
+import type {HTTPObj} from '../../../http.js';
+
+/**
+ * The CMS serves one attractions feed per locale and those locales drift.
+ * Walibi Belgium is configured on `nl`, whose feed silently omits VAMPIRE
+ * (waitingTimeName 34) — as does `en`. Only `fr` lists it. Because the ride
+ * was missing from the configured feed, buildEntityList never emitted an
+ * entity for it and buildLiveData dropped its wait time on the floor, even
+ * though waitingtimes.v1.json reported it open the whole time.
+ *
+ * These fixtures are trimmed from real captures of
+ * https://www.walibi.be/api/wbe/{nl,fr,en}/attractions.v1.json.
+ */
+
+/** KONDAA — listed identically in every locale, the canary for these tests. */
+const KONDAA = {
+  title: 'KONDAA',
+  waitingTimeName: '45',
+  latitude: 50.7015,
+  longitude: 4.5905,
+  path: '/content/dam/wbe/nl/attractions/frissons-attractions/kondaa-files/kondaa',
+};
+
+/** VAMPIRE — present only in the `fr` feed. */
+const VAMPIRE = {
+  title: 'VAMPIRE',
+  waitingTimeName: '34',
+  path: '/content/dam/wbe/fr/attractions/frissons-attractions/vampire-files/vampire',
+};
+
+/** FLASH-BACK — listed in both locales, spelled differently in each. */
+const FLASHBACK_NL = {title: 'FLASH-BACK', waitingTimeName: '9', path: '/nl/flash-back'};
+const FLASHBACK_FR = {title: 'FLASH BACK', waitingTimeName: '9', path: '/fr/flash-back'};
+
+const FEEDS: Record<string, any[]> = {
+  nl: [KONDAA, FLASHBACK_NL],
+  fr: [{...KONDAA, title: 'KONDAA'}, FLASHBACK_FR, VAMPIRE],
+  en: [KONDAA, FLASHBACK_NL],
+};
+
+/**
+ * A park whose per-locale attraction feeds come from `feeds`; a locale mapped
+ * to `null` throws, standing in for a 404 or a malformed response.
+ */
+function stubbedPark(feeds: Record<string, any[] | null> = FEEDS, waitTimes: any[] = []): WalibiBelgium {
+  const park = new WalibiBelgium();
+  // Pin the locale rather than inherit the park's configured one: these tests
+  // cover the merge in WalibiBase, which must hold whichever locale a park is
+  // set to. Walibi Belgium itself now runs on `fr`, the locale that does list
+  // VAMPIRE — driving it from `nl` here reproduces the original gap.
+  park.culture = 'nl';
+  park.mergeCultures = ['nl', 'fr', 'en'];
+  park.fetchAttractions = (async (culture: string) => {
+    const feed = feeds[culture];
+    if (feed === undefined) return {json: async () => []} as any as HTTPObj;
+    if (feed === null) throw new Error(`no such locale: ${culture}`);
+    return {json: async () => feed} as any as HTTPObj;
+  }) as any;
+  park.getRestaurants = async () => [];
+  park.getWaitTimes = async () => waitTimes;
+  return park;
+}
+
+describe('WalibiBase.getAttractions — merging CMS locales', () => {
+  beforeEach(() => CacheLib.clear());
+  afterEach(() => {
+    CacheLib.clear();
+    vi.restoreAllMocks();
+  });
+
+  test('publishes an attraction the configured locale omits but another locale lists', async () => {
+    const entities = await stubbedPark().getEntities();
+
+    expect(entities.find(e => e.id === '45')).toMatchObject({name: 'KONDAA', entityType: 'ATTRACTION'});
+    expect(entities.find(e => e.id === '34')).toMatchObject({name: 'VAMPIRE', entityType: 'ATTRACTION'});
+  });
+
+  test('publishes live data for an attraction only a fallback locale lists', async () => {
+    const waitTimes = [
+      {id: '45', time: 1200, status: 'open'},
+      {id: '34', time: 300, status: 'open'},
+    ];
+
+    const live = await stubbedPark(FEEDS, waitTimes).getLiveData();
+
+    expect(live.find(l => l.id === '45')).toMatchObject({status: 'OPERATING', queue: {STANDBY: {waitTime: 20}}});
+    expect(live.find(l => l.id === '34')).toMatchObject({status: 'OPERATING', queue: {STANDBY: {waitTime: 5}}});
+  });
+
+  test('keeps the configured locale name when a fallback locale spells it differently', async () => {
+    const entities = await stubbedPark().getEntities();
+
+    expect(entities.find(e => e.id === '9')?.name).toBe('FLASH-BACK');
+  });
+
+  test('a locale that fails to load is skipped without sinking the merge', async () => {
+    const entities = await stubbedPark({...FEEDS, en: null}).getEntities();
+
+    expect(entities.find(e => e.id === '45')).toBeDefined();
+    expect(entities.find(e => e.id === '34')).toBeDefined();
+  });
+
+  test('a wait time with no attraction in any locale is skipped, and warned about once', async () => {
+    const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const park = stubbedPark(FEEDS, [{id: '45', time: 1200, status: 'open'}, {id: '999', time: 300, status: 'open'}]);
+
+    const first = await park.getLiveData();
+    const second = await park.getLiveData();
+
+    expect(first.find(l => l.id === '999')).toBeUndefined();
+    expect(second.find(l => l.id === '45')).toBeDefined();
+    const orphanWarnings = warn.mock.calls.filter(c => String(c[0]).includes('999'));
+    expect(orphanWarnings).toHaveLength(1);
+  });
+});

--- a/src/parks/walibi/__tests__/untaggedAttractions.test.ts
+++ b/src/parks/walibi/__tests__/untaggedAttractions.test.ts
@@ -1,0 +1,93 @@
+import {describe, test, expect, beforeEach, afterEach} from 'vitest';
+import {WalibiBelgium} from '../walibi.js';
+import {CacheLib} from '../../../cache.js';
+import type {HTTPObj} from '../../../http.js';
+
+/**
+ * `waitingTimeName` is the CMS's wait-time id, and only rides with a queue
+ * board get one. Walibi Belgium hands out 16 of them across 41 POIs — every
+ * one of which the feed types `"poiType": "ATTRACTION"` — so keying the entity
+ * list on that field drops 25 real rides: GRAND CARROUSEL, TREE HOUSE,
+ * OCTOPUS, the whole family and kids side of the park.
+ *
+ * Those 25 were published until 42008c71 ("switch to stable API IDs instead of
+ * slugified names"), which introduced `.filter(a => a.waitingTimeName)` as a
+ * null-guard for the new id — the same guard the restaurants got in that
+ * commit, where it drops nothing because every restaurant has a path. On
+ * Walibi Holland and Bellewaerde the attraction guard drops nothing either
+ * (39/39 and 36/36 tagged), which is why it went unnoticed.
+ *
+ * So fall back to the CMS path, exactly as restaurants already do. A tagged
+ * ride keeps its wait-time id: those are live wiki records and must not shift.
+ */
+const attraction = (title: string, slug: string, waitingTimeName?: string) => ({
+  title,
+  path: `/content/wbe/fr/attractions/${slug}`,
+  waitingTimeName: waitingTimeName ?? null,
+  latitude: 50.7,
+  longitude: 4.59,
+});
+
+function stubbedPark(attractions: any[]): WalibiBelgium {
+  const park = new WalibiBelgium();
+  park.fetchAttractions = (async () => ({json: async () => attractions} as any as HTTPObj)) as any;
+  park.getRestaurants = async () => [];
+  park.getWaitTimes = async () => [];
+  return park;
+}
+
+describe('WalibiBase.buildEntityList — attractions with no wait-time id', () => {
+  beforeEach(() => CacheLib.clear());
+  afterEach(() => CacheLib.clear());
+
+  test('publishes a ride the CMS never gave a wait-time id', async () => {
+    const entities = await stubbedPark([
+      attraction('KONDAA', 'kondaa', '45'),
+      attraction('GRAND CARROUSEL', 'le-grand-carrousel'),
+    ]).getEntities();
+
+    const rides = entities.filter(e => e.entityType === 'ATTRACTION');
+    expect(rides.map(e => e.name)).toEqual(['KONDAA', 'GRAND CARROUSEL']);
+  });
+
+  test('keys a tagged ride on its wait-time id and an untagged one on its path', async () => {
+    // KONDAA's id is a live wiki record; the fallback must not reach it.
+    const entities = await stubbedPark([
+      attraction('KONDAA', 'kondaa', '45'),
+      attraction('GRAND CARROUSEL', 'le-grand-carrousel'),
+    ]).getEntities();
+
+    expect(entities.filter(e => e.entityType === 'ATTRACTION').map(e => e.id))
+      .toEqual(['45', 'attr_le-grand-carrousel']);
+  });
+
+  test('carries coordinates onto a ride keyed by path', async () => {
+    const entities = await stubbedPark([attraction('TREE HOUSE', 'tree-house')]).getEntities();
+
+    const ride = entities.find(e => e.entityType === 'ATTRACTION')!;
+    expect(ride.location).toEqual({latitude: 50.7, longitude: 4.59});
+  });
+
+  test('sanitises an attraction slug the id charset rejects', async () => {
+    // Walibi Belgium's `nl` and `en` feeds path 4X4 ADVENTURE at a segment with
+    // a literal space. Left raw it would fail the charset check and take the
+    // whole park's entity list down, the way `p-che-&-mignon` did.
+    const entities = await stubbedPark([
+      attraction('4X4 ADVENTURE', '4X4 ADVENTURE'),
+    ]).getEntities();
+
+    expect(entities.find(e => e.entityType === 'ATTRACTION')!.id).toBe('attr_4X4-ADVENTURE');
+    for (const entity of entities) {
+      expect(entity.id).toMatch(/^[\w.-]+$/);
+    }
+  });
+
+  test('drops a POI with neither a wait-time id nor a path, rather than minting a bare prefix', async () => {
+    const entities = await stubbedPark([
+      {title: 'NO PATH AT ALL', waitingTimeName: null},
+      attraction('KONDAA', 'kondaa', '45'),
+    ]).getEntities();
+
+    expect(entities.filter(e => e.entityType === 'ATTRACTION').map(e => e.name)).toEqual(['KONDAA']);
+  });
+});

--- a/src/parks/walibi/walibi.ts
+++ b/src/parks/walibi/walibi.ts
@@ -55,6 +55,8 @@ class WalibiBase extends Destination {
   apiShortcode: string = '';
   /** Culture/language code for API requests */
   culture: string = 'en';
+  /** Locales merged into the attraction list on top of `culture` (see getAttractions) */
+  mergeCultures: string[] = ['nl', 'fr', 'en'];
   /** Destination-level entity ID */
   destinationSlug: string = '';
   /** Park-level entity ID */
@@ -73,10 +75,22 @@ class WalibiBase extends Destination {
     return `walibi:${this.destinationSlug}`;
   }
 
-  /** Extract the last path segment from a CMS path as a stable slug */
+  /**
+   * Extract the last path segment from a CMS path as a stable slug.
+   *
+   * The CMS derives that segment from the display name without sanitising it,
+   * so it can carry characters the entity id charset (`/^[\w.-]+$/`) rejects —
+   * "Pêche & Mignon" arrives as `p-che-&-mignon`. Validation runs over the
+   * whole entity list, so one such restaurant used to reject every Walibi
+   * Belgium entity, rides included. Fold the rejected runs into a single
+   * hyphen; clean slugs come through unchanged, so existing ids do not shift.
+   */
   private pathSlug(path: string | undefined): string | null {
     if (!path) return null;
-    return path.split('/').pop() || null;
+    const segment = path.split('/').pop();
+    if (!segment) return null;
+    const slug = segment.replace(/[^\w.-]+/g, '-').replace(/-{2,}/g, '-').replace(/^-|-$/g, '');
+    return slug || null;
   }
 
   // ── Header injection ─────────────────────────────────────────
@@ -95,10 +109,10 @@ class WalibiBase extends Destination {
   // ── HTTP Methods ─────────────────────────────────────────────
 
   @http({cacheSeconds: 86400})
-  async fetchAttractions(): Promise<HTTPObj> {
+  async fetchAttractions(culture: string = this.culture): Promise<HTTPObj> {
     return {
       method: 'GET',
-      url: `${this.baseURL}api/${this.apiShortcode}/${this.culture}/attractions.v1.json`,
+      url: `${this.baseURL}api/${this.apiShortcode}/${culture}/attractions.v1.json`,
       options: {json: true},
     } as any as HTTPObj;
   }
@@ -132,10 +146,47 @@ class WalibiBase extends Destination {
 
   // ── Cached Data ──────────────────────────────────────────────
 
-  @cache({ttlSeconds: 86400})
+  /**
+   * The CMS serves one attractions feed per locale and those feeds are
+   * maintained independently, so they drift. Walibi Belgium's `nl` and `en`
+   * feeds both omit VAMPIRE (waitingTimeName 34) while `fr` lists it — the
+   * ride had no entity and no live data at all, even though
+   * waitingtimes.v1.json reported it open throughout.
+   *
+   * So merge the other locales in, keyed on waitingTimeName. The configured
+   * culture is authoritative for names and coordinates; a fallback locale can
+   * only ever add a ride the primary feed never listed. Entries without a
+   * waitingTimeName are ignored here — buildEntityList drops them anyway, and
+   * the CMS path they would have to be keyed on is itself locale-specific.
+   */
+  @cache({ttlSeconds: 86400, cacheVersion: 2})
   async getAttractions(): Promise<AttractionPOI[]> {
-    const resp = await this.fetchAttractions();
-    return await resp.json() || [];
+    const attractions = [...await this.fetchAttractionList(this.culture)];
+    const seen = new Set(attractions.map(a => a.waitingTimeName).filter(Boolean));
+
+    for (const culture of this.mergeCultures) {
+      if (culture === this.culture) continue;
+
+      for (const poi of await this.fetchAttractionList(culture)) {
+        if (!poi.waitingTimeName || seen.has(poi.waitingTimeName)) continue;
+        seen.add(poi.waitingTimeName);
+        attractions.push(poi);
+        console.log(`[${this.constructor.name}] "${poi.title}" (${poi.waitingTimeName}) is missing from the '${this.culture}' feed, taken from '${culture}'`);
+      }
+    }
+
+    return attractions;
+  }
+
+  /** One locale's attraction feed. A locale that 404s or returns junk is skipped. */
+  private async fetchAttractionList(culture: string): Promise<AttractionPOI[]> {
+    try {
+      const resp = await this.fetchAttractions(culture);
+      const data = await resp.json();
+      return Array.isArray(data) ? data : [];
+    } catch {
+      return [];
+    }
   }
 
   @cache({ttlSeconds: 86400})
@@ -235,7 +286,10 @@ class WalibiBase extends Destination {
       .map(entry => {
         // Match wait time entry to attraction via waitingTimeName
         const attraction = attractions.find(a => a.waitingTimeName === entry.id);
-        if (!attraction) return null;
+        if (!attraction) {
+          this.warnOrphanWaitTime(entry.id);
+          return null;
+        }
 
         if (SKIP_STATUSES.has(entry.status)) return null;
         const status = mapStatus(entry.status);
@@ -256,6 +310,19 @@ class WalibiBase extends Destination {
       })
       .filter((x): x is LiveData => x !== null);
   }
+
+  /**
+   * A wait time whose id matches no attraction in any locale cannot be
+   * published — we have no name for it. That used to happen silently; now it
+   * says so once per id, so the next CMS gap surfaces without a bug report.
+   */
+  private warnOrphanWaitTime(id: string): void {
+    if (this.warnedOrphanWaitTimes.has(id)) return;
+    this.warnedOrphanWaitTimes.add(id);
+    console.log(`[${this.constructor.name}] wait time id ${id} matches no attraction in any of [${[this.culture, ...this.mergeCultures].join(', ')}] — not published`);
+  }
+
+  private readonly warnedOrphanWaitTimes = new Set<string>();
 
   // ── Schedules ────────────────────────────────────────────────
 
@@ -362,7 +429,11 @@ export class WalibiBelgium extends WalibiBase {
     this.addConfigPrefix('WALIBIBELGIUM');
     this.baseURL = this.baseURL || 'https://www.walibi.be/';
     this.apiShortcode = 'wbe';
-    this.culture = 'nl';
+    // Wavre is francophone and the `fr` feed is the better maintained one —
+    // it is the only locale that lists VAMPIRE. Restaurant path slugs and
+    // attraction waitingTimeNames are identical across locales, so this
+    // changes display names only, not entity ids.
+    this.culture = 'fr';
     this.destinationSlug = 'walibibelgium';
     this.parkSlug = 'walibibelgiumpark';
     this.parkName = 'Walibi Belgium';

--- a/src/parks/walibi/walibi.ts
+++ b/src/parks/walibi/walibi.ts
@@ -84,19 +84,24 @@ class WalibiBase extends Destination {
    * harness's id check (`src/testRunner.ts`) and takes the whole Walibi
    * Belgium entity list down with it.
    *
-   * Replace only the runs the charset rejects. Anything already legal is
-   * untouched by construction — including the trailing hyphens the CMS emits
-   * (`wild-rock-caf-`, `stardocks-caf-`), which are live entity ids today and
-   * must not shift. Collapsing or trimming hyphens as well would rename those
-   * two restaurants and could silently merge distinct slugs into one id.
+   * Rewrite only runs that contain a rejected character, absorbing the hyphens
+   * immediately around them so `p-che-&-mignon` lands on `p-che-mignon` rather
+   * than `p-che---mignon`. A slug that already satisfies `/^[\w.-]+$/` matches
+   * nothing and comes through byte-identical — by construction, not by luck.
+   *
+   * That guarantee is the point: the CMS emits trailing hyphens
+   * (`stardocks-caf-`, `wild-rock-caf-`) and doubled ones (`cafe--rouge`),
+   * all legal and all live entity ids. Collapsing or trimming hyphens
+   * unconditionally would rename them, and would let `cafe--rouge` and
+   * `cafe-rouge` collide into one entity with nothing to detect it.
    */
   private pathSlug(path: string | undefined): string | null {
     if (!path) return null;
     const segment = path.split('/').pop();
     if (!segment) return null;
-    // A non-empty segment always sanitises to a non-empty slug: every rejected
-    // run becomes a hyphen, which the charset accepts.
-    return segment.replace(/[^\w.-]+/g, '-');
+    // A non-empty segment always sanitises to a non-empty slug: a rejected run
+    // becomes a hyphen, which the charset accepts.
+    return segment.replace(/-*[^\w.-]+-*/g, '-');
   }
 
   // ── Header injection ─────────────────────────────────────────

--- a/src/parks/walibi/walibi.ts
+++ b/src/parks/walibi/walibi.ts
@@ -80,17 +80,23 @@ class WalibiBase extends Destination {
    *
    * The CMS derives that segment from the display name without sanitising it,
    * so it can carry characters the entity id charset (`/^[\w.-]+$/`) rejects —
-   * "Pêche & Mignon" arrives as `p-che-&-mignon`. Validation runs over the
-   * whole entity list, so one such restaurant used to reject every Walibi
-   * Belgium entity, rides included. Fold the rejected runs into a single
-   * hyphen; clean slugs come through unchanged, so existing ids do not shift.
+   * "Pêche & Mignon" arrives as `p-che-&-mignon`, which trips the dev
+   * harness's id check (`src/testRunner.ts`) and takes the whole Walibi
+   * Belgium entity list down with it.
+   *
+   * Replace only the runs the charset rejects. Anything already legal is
+   * untouched by construction — including the trailing hyphens the CMS emits
+   * (`wild-rock-caf-`, `stardocks-caf-`), which are live entity ids today and
+   * must not shift. Collapsing or trimming hyphens as well would rename those
+   * two restaurants and could silently merge distinct slugs into one id.
    */
   private pathSlug(path: string | undefined): string | null {
     if (!path) return null;
     const segment = path.split('/').pop();
     if (!segment) return null;
-    const slug = segment.replace(/[^\w.-]+/g, '-').replace(/-{2,}/g, '-').replace(/^-|-$/g, '');
-    return slug || null;
+    // A non-empty segment always sanitises to a non-empty slug: every rejected
+    // run becomes a hyphen, which the charset accepts.
+    return segment.replace(/[^\w.-]+/g, '-');
   }
 
   // ── Header injection ─────────────────────────────────────────
@@ -149,15 +155,17 @@ class WalibiBase extends Destination {
   /**
    * The CMS serves one attractions feed per locale and those feeds are
    * maintained independently, so they drift. Walibi Belgium's `nl` and `en`
-   * feeds both omit VAMPIRE (waitingTimeName 34) while `fr` lists it — the
-   * ride had no entity and no live data at all, even though
-   * waitingtimes.v1.json reported it open throughout.
+   * feeds both omit VAMPIRE (waitingTimeName 34) while `fr` lists it, which is
+   * how the drift was found — that park is now configured on `fr`, so the
+   * merge is no longer what recovers VAMPIRE. What it does recover today is Le
+   * Galion and Tam Tam Aventure on Walibi Rhône-Alpes, absent from `fr` but
+   * listed elsewhere; and it makes the next such gap a non-event.
    *
-   * So merge the other locales in, keyed on waitingTimeName. The configured
-   * culture is authoritative for names and coordinates; a fallback locale can
-   * only ever add a ride the primary feed never listed. Entries without a
-   * waitingTimeName are ignored here — buildEntityList drops them anyway, and
-   * the CMS path they would have to be keyed on is itself locale-specific.
+   * Merge keyed on waitingTimeName — the only id stable across locales; title
+   * and path are both locale-specific. The configured culture is authoritative
+   * for names and coordinates; a fallback locale can only ever add a ride the
+   * primary feed never listed, never overwrite one. Entries without a
+   * waitingTimeName are ignored here — buildEntityList drops them anyway.
    */
   @cache({ttlSeconds: 86400, cacheVersion: 2})
   async getAttractions(): Promise<AttractionPOI[]> {
@@ -171,25 +179,41 @@ class WalibiBase extends Destination {
         if (!poi.waitingTimeName || seen.has(poi.waitingTimeName)) continue;
         seen.add(poi.waitingTimeName);
         attractions.push(poi);
-        console.log(`[${this.constructor.name}] "${poi.title}" (${poi.waitingTimeName}) is missing from the '${this.culture}' feed, taken from '${culture}'`);
+        console.warn(`[${this.constructor.name}] "${poi.title}" (${poi.waitingTimeName}) is missing from the '${this.culture}' feed, taken from '${culture}'`);
       }
     }
 
     return attractions;
   }
 
-  /** One locale's attraction feed. A locale that 404s or returns junk is skipped. */
+  /**
+   * One locale's attraction feed.
+   *
+   * A *fallback* locale that fails is skipped — the merge is a bonus and must
+   * not be able to sink the poll. The *configured* locale is not optional: a
+   * transient 5xx there has to propagate so the cycle is skipped, exactly as
+   * it did before the merge existed. Swallowing it would publish a clean,
+   * empty, wrong park and pin that `[]` in the 24h cache for every process
+   * sharing it.
+   *
+   * A locale the CMS doesn't serve answers 200 with `[]`, not 404, so an
+   * unknown locale costs a request and adds nothing rather than throwing.
+   */
   private async fetchAttractionList(culture: string): Promise<AttractionPOI[]> {
     try {
       const resp = await this.fetchAttractions(culture);
       const data = await resp.json();
       return Array.isArray(data) ? data : [];
-    } catch {
+    } catch (err) {
+      if (culture === this.culture) throw err;
       return [];
     }
   }
 
-  @cache({ttlSeconds: 86400})
+  // cacheVersion 2: the restaurants feed follows `culture`, and Walibi Belgium
+  // moved nl -> fr. Without the bump the park would serve `fr` attractions
+  // next to `nl` restaurant names and coordinates for up to 24h after deploy.
+  @cache({ttlSeconds: 86400, cacheVersion: 2})
   async getRestaurants(): Promise<AttractionPOI[]> {
     const resp = await this.fetchRestaurants();
     return await resp.json() || [];
@@ -282,12 +306,17 @@ class WalibiBase extends Destination {
       this.getWaitTimes(),
     ]);
 
-    return waitTimes
+    const orphans: string[] = [];
+
+    const live = waitTimes
       .map(entry => {
         // Match wait time entry to attraction via waitingTimeName
         const attraction = attractions.find(a => a.waitingTimeName === entry.id);
         if (!attraction) {
-          this.warnOrphanWaitTime(entry.id);
+          if (!this.warnedOrphanWaitTimes.has(entry.id)) {
+            this.warnedOrphanWaitTimes.add(entry.id);
+            orphans.push(entry.id);
+          }
           return null;
         }
 
@@ -309,17 +338,27 @@ class WalibiBase extends Destination {
         return ld;
       })
       .filter((x): x is LiveData => x !== null);
+
+    this.warnOrphanWaitTimes(orphans);
+    return live;
   }
 
   /**
    * A wait time whose id matches no attraction in any locale cannot be
-   * published — we have no name for it. That used to happen silently; now it
-   * says so once per id, so the next CMS gap surfaces without a bug report.
+   * published — we have no name for it. That used to happen silently.
+   *
+   * Most of these are permanent feed junk (Bellewaerde alone carries ~68
+   * unmapped ids), so one line per id would bury a genuinely new CMS gap in a
+   * wall of noise. Summarise instead: one line per poll listing only ids not
+   * already reported, so the steady state is silent and a new gap is a short
+   * line of its own.
    */
-  private warnOrphanWaitTime(id: string): void {
-    if (this.warnedOrphanWaitTimes.has(id)) return;
-    this.warnedOrphanWaitTimes.add(id);
-    console.log(`[${this.constructor.name}] wait time id ${id} matches no attraction in any of [${[this.culture, ...this.mergeCultures].join(', ')}] — not published`);
+  private warnOrphanWaitTimes(ids: string[]): void {
+    if (!ids.length) return;
+    const locales = [...new Set([this.culture, ...this.mergeCultures])].join(', ');
+    const shown = ids.slice(0, 10).join(', ');
+    const rest = ids.length > 10 ? ` (+${ids.length - 10} more)` : '';
+    console.warn(`[${this.constructor.name}] ${ids.length} wait time id(s) match no attraction in [${locales}] — not published: ${shown}${rest}`);
   }
 
   private readonly warnedOrphanWaitTimes = new Set<string>();

--- a/src/parks/walibi/walibi.ts
+++ b/src/parks/walibi/walibi.ts
@@ -2,8 +2,9 @@
  * Walibi / Bellewaerde / Compagnie des Alpes parks
  *
  * 4 parks sharing the same API pattern: each park has its own domain,
- * API shortcode, and API key. Entity IDs are slugified from names
- * (attr_xxx, dining_xxx) since the API provides no stable IDs.
+ * API shortcode, and API key. Rides with a queue board are keyed on the
+ * CMS wait-time id; everything else — the rest of the rides, and every
+ * restaurant — is keyed on its CMS path (attr_xxx, dining_xxx).
  *
  * Wait times are in seconds (divided by 60 for minutes).
  */
@@ -258,12 +259,17 @@ class WalibiBase extends Destination {
       location: {latitude: this.parkLat, longitude: this.parkLng},
     } as Entity;
 
-    // Attractions use waitingTimeName (UUID) as entity ID
+    // A ride with a queue board is keyed on its wait-time id — those are live
+    // wiki records and must not shift. Only rides that have one carry the
+    // field, so the rest fall back to the CMS path, exactly as restaurants do.
     const attrEntities = attractions
-      .filter(a => a.waitingTimeName)
       .map(a => {
+        const slug = this.pathSlug(a.path);
+        const id = a.waitingTimeName || (slug && `attr_${slug}`);
+        if (!id) return null;
+
         const entity: Entity = {
-          id: a.waitingTimeName!,
+          id,
           name: a.title,
           entityType: 'ATTRACTION',
           parentId: this.parkSlug,
@@ -277,7 +283,8 @@ class WalibiBase extends Destination {
           };
         }
         return entity;
-      });
+      })
+      .filter((e): e is Entity => e !== null);
 
     // Restaurants use CMS path slug as entity ID (no UUID available)
     const diningEntities = restaurants


### PR DESCRIPTION
Stacked on #303 — it needs that PR's `pathSlug()`, so the diff here shows #303's
three commits too. **Only the last commit is new**; the rest merges away with #303.

`buildEntityList` keyed attractions on `waitingTimeName`, so a POI without one was
dropped. Only rides with a queue board carry that field, and Walibi Belgium hands out
16 across 41 POIs — every one of them typed `"poiType": "ATTRACTION"` by the feed. The
other 25 are the whole family and kids side of the park: GRAND CARROUSEL, OCTOPUS,
TREE HOUSE, WAVE SWINGER, TAPIS VOLANT, the lot.

They published until 42008c71 ("switch to stable API IDs instead of slugified names"),
which added `.filter(a => a.waitingTimeName)` as a null-guard for the new id — the same
guard restaurants got in that commit, where it drops nothing because every restaurant
has a path. Nothing in the commit message or the code suggests the loss was intended,
and the file header still described the old `attr_xxx` scheme. It went unnoticed because
the guard is a no-op on the parks that tag everything: Walibi Holland is 39/39 and
Bellewaerde 36/36.

So fall back to the CMS path, exactly as restaurants already do. A tagged ride keeps its
wait-time id — those are live wiki records and must not shift. A POI with neither is
still dropped rather than minting a bare prefix. `pathSlug()` already sanitises the
segment, which matters here: the nl and en feeds path 4X4 ADVENTURE at a segment with a
literal space.

The 25 recovered rides all carry coordinates. They get no live data, since the
wait-times feed has no entry for them.

### Verification

`npx vitest run src/parks/walibi` — 20 tests green (5 new, in
`__tests__/untaggedAttractions.test.ts`).

Dev harness, all four parks on the live feeds, 4/4 each:

| park | attractions before | after |
|---|---|---|
| Walibi Belgium | 16 | **41** |
| Walibi Rhone-Alpes | 29 | **33** (its four Aire de Jeux) |
| Walibi Holland | 39 | 39 |
| Bellewaerde | 36 | 36 |

Rhone-Alpes' `Missing location: ATTRACTION:1` warning is pre-existing — it is already
there at 29 attractions, before this change.
