### PR TITLE
fix(dlp): stop publishing buildings as attractions

### DIFF
--- a/src/parks/dlp/__tests__/ignoredEntities.test.ts
+++ b/src/parks/dlp/__tests__/ignoredEntities.test.ts
@@ -1,0 +1,112 @@
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+
+/**
+ * IGNORE_ENTITIES drops POI records Disney types as attractions but which are
+ * not venues we publish: a land-entry pass (P2EA02), an entrance building
+ * (P2FD03), assorted test rows.
+ *
+ * Nothing in the POI record distinguishes them. World Premiere arrives with
+ * the same shape as Phantom Manor — `type: "Attraction"`, empty `subType`,
+ * `anyHeight`, one Guest Entrance coordinate — so the id list is the only
+ * place the distinction can live, and it has to hold across all three of
+ * entities, live data and schedules.
+ */
+function stubbedPark(): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [
+      {id: 'P1', name: 'Disneyland Park', type: 'ThemePark'},
+      {id: 'P2', name: 'Disney Adventure World', type: 'ThemePark'},
+    ],
+    Attraction: [
+      {
+        // The entrance building. Byte-for-byte the shape of a real ride.
+        id: 'P2FD03',
+        name: 'World Premiere',
+        type: 'Attraction',
+        subType: '',
+        location: {id: 'P2'},
+        coordinates: [{lat: 48.867857, lng: 2.780041, type: 'Guest Entrance'}],
+        height: [{id: 'anyHeight'}],
+        schedules: [],
+      },
+      {
+        // The land-entry pass, already ignored — the control that proves this
+        // test would catch a regression in the mechanism, not just the new id.
+        id: 'P2EA02',
+        name: 'Entry to World of Frozen',
+        type: 'Attraction',
+        subType: '',
+        location: {id: 'P2'},
+      },
+      {
+        // A real ride with the identical record shape: must publish.
+        id: 'P1RA03',
+        name: 'Phantom Manor',
+        type: 'Attraction',
+        subType: '',
+        location: {id: 'P1'},
+        coordinates: [{lat: 48.8725, lng: 2.7762, type: 'Guest Entrance'}],
+        height: [{id: 'anyHeight'}],
+        schedules: [],
+      },
+    ],
+  });
+
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([
+    // The wait feed carries World Premiere as a bare OPERATING row, which is
+    // what would otherwise pull it back in through the live path.
+    {id: 'P2FD03', status: 'OPERATING'},
+    {id: 'P1RA03', status: 'OPERATING', postedWaitMinutes: 25},
+  ]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue([
+    {
+      id: 'P2FD03',
+      name: 'World Premiere',
+      location: {id: 'P2'},
+      schedules: [{date: '2026-08-20', startTime: '09:30', endTime: '22:00', status: 'OPERATING'}],
+    },
+  ]);
+
+  return park;
+}
+
+describe('DLP ignored entities', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does not publish World Premiere as an attraction', async () => {
+    const entities = await stubbedPark().getEntities();
+
+    expect(entities.find((e) => e.id === 'P2FD03')).toBeUndefined();
+  });
+
+  it('still publishes a real ride carrying the identical record shape', async () => {
+    const entities = await stubbedPark().getEntities();
+
+    const manor = entities.find((e) => e.id === 'P1RA03');
+    expect(manor?.entityType).toBe('ATTRACTION');
+  });
+
+  it('keeps the land-entry pass out, so the mechanism is under test too', async () => {
+    const entities = await stubbedPark().getEntities();
+
+    expect(entities.find((e) => e.id === 'P2EA02')).toBeUndefined();
+  });
+
+  it('publishes no live row for an ignored id the wait feed still reports', async () => {
+    const live = await stubbedPark().getLiveData();
+
+    expect(live.find((l) => l.id === 'P2FD03')).toBeUndefined();
+    expect(live.find((l) => l.id === 'P1RA03')).toBeDefined();
+  });
+
+  it('leaves no orphan schedule behind for an ignored id', async () => {
+    const schedules = await stubbedPark().getSchedules();
+
+    expect(schedules.find((s) => s.id === 'P2FD03')).toBeUndefined();
+  });
+});

--- a/src/parks/dlp/__tests__/ignoredEntities.test.ts
+++ b/src/parks/dlp/__tests__/ignoredEntities.test.ts
@@ -12,6 +12,21 @@ import {DisneylandParis} from '../disneylandparis.js';
  * place the distinction can live, and it has to hold across all three of
  * entities, live data and schedules.
  */
+/** The buildings, each with the record shape of a real ride. */
+const BUILDINGS = [
+  {id: 'P1MA00', name: 'Discovery Arcade'},
+  {id: 'P1MA03', name: 'Liberty Arcade'},
+  {id: 'P1NA04', name: 'Sleeping Beauty Castle'},
+].map((b) => ({
+  ...b,
+  type: 'Attraction',
+  subType: '',
+  location: {id: 'P1'},
+  coordinates: [{lat: 48.8722, lng: 2.7758, type: 'Guest Entrance'}],
+  height: [{id: 'anyHeight'}],
+  schedules: [],
+}));
+
 function stubbedPark(): DisneylandParis {
   const park = new DisneylandParis();
 
@@ -52,6 +67,34 @@ function stubbedPark(): DisneylandParis {
         height: [{id: 'anyHeight'}],
         schedules: [],
       },
+      ...BUILDINGS,
+      {
+        // Shares the shape and stays: a vehicle you ride, not a building you
+        // are inside. The line the buildings are on the other side of.
+        id: 'P1MA02',
+        name: 'Horse-Drawn Streetcars',
+        type: 'Attraction',
+        subType: '',
+        location: {id: 'P1'},
+        height: [{id: 'anyHeight'}],
+        schedules: [],
+      },
+      {
+        // The castle's contents publish in their own right, which is what
+        // makes dropping the shell lossless.
+        id: 'P1NA06',
+        name: 'La Galerie de la Belle au Bois Dormant',
+        type: 'Attraction',
+        subType: '',
+        location: {id: 'P1'},
+      },
+      {
+        id: 'P1NA12',
+        name: 'La Tanière du Dragon',
+        type: 'Attraction',
+        subType: '',
+        location: {id: 'P1'},
+      },
     ],
   });
 
@@ -78,10 +121,29 @@ function stubbedPark(): DisneylandParis {
 describe('DLP ignored entities', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('does not publish World Premiere as an attraction', async () => {
+  it.each([
+    ['World Premiere', 'P2FD03'],
+    ['Discovery Arcade', 'P1MA00'],
+    ['Liberty Arcade', 'P1MA03'],
+    ['Sleeping Beauty Castle', 'P1NA04'],
+  ])('does not publish %s as an attraction', async (_name, id) => {
     const entities = await stubbedPark().getEntities();
 
-    expect(entities.find((e) => e.id === 'P2FD03')).toBeUndefined();
+    expect(entities.find((e) => e.id === id)).toBeUndefined();
+  });
+
+  it('keeps Horse-Drawn Streetcars, which shares the shape but is ridden', async () => {
+    const entities = await stubbedPark().getEntities();
+
+    expect(entities.find((e) => e.id === 'P1MA02')?.entityType).toBe('ATTRACTION');
+  });
+
+  it('still publishes what is inside the castle', async () => {
+    // Dropping the shell is only lossless because these stand on their own.
+    const entities = await stubbedPark().getEntities();
+
+    expect(entities.find((e) => e.id === 'P1NA06')).toBeDefined();
+    expect(entities.find((e) => e.id === 'P1NA12')).toBeDefined();
   });
 
   it('still publishes a real ride carrying the identical record shape', async () => {

--- a/src/parks/dlp/__tests__/parkHours.test.ts
+++ b/src/parks/dlp/__tests__/parkHours.test.ts
@@ -4,7 +4,7 @@ import {CacheLib} from '../../../cache.js';
 import {formatInTimezone} from '../../../datetime.js';
 
 /**
- * Walkthrough attractions (Discovery Arcade, Sleeping Beauty Castle, …) never
+ * Walkthrough attractions (La Cabane des Robinson, La Tanière du Dragon, …) never
  * appear in the wait feed, so their live status falls back to park hours.
  *
  * Those hours come from each park's own row in the schedule feed. They used to
@@ -51,8 +51,8 @@ function stubbedPark(opts: {
     ],
     Attraction: [
       {
-        id: 'P1MA00',
-        name: 'Discovery Arcade',
+        id: 'P1AA01',
+        name: 'La Cabane des Robinson',
         type: 'Attraction',
         location: {id: opts.walkthroughPark ?? 'P1'},
         // No `schedules` — this is the whole point: it must fall back.
@@ -66,8 +66,8 @@ function stubbedPark(opts: {
         // No `schedules` here either. The POI blob is never the source for
         // own-hours: it carries only the date it was fetched and is cached
         // 12h, so past park-local midnight it is empty for the current date.
-        id: 'P1MA03',
-        name: 'Liberty Arcade',
+        id: 'P1NA12',
+        name: 'La Tanière du Dragon',
         type: 'Attraction',
         location: {id: 'P1'},
       },
@@ -82,8 +82,8 @@ function stubbedPark(opts: {
   // wide enough to always contain it, narrow enough never to straddle
   // midnight at any pinned clock.
   const canaryRow = {
-    id: 'P1MA03',
-    name: 'Liberty Arcade',
+    id: 'P1NA12',
+    name: 'La Tanière du Dragon',
     schedules: [{
       startTime: parkClock(-5),
       endTime: parkClock(5),
@@ -108,8 +108,8 @@ function stubbedPark(opts: {
  */
 async function walkthroughStatus(park: DisneylandParis): Promise<string | undefined> {
   const live = await park.getLiveData();
-  expect(live.find((l) => l.id === 'P1MA03')?.status).toBe('OPERATING');
-  return live.find((l) => l.id === 'P1MA00')?.status;
+  expect(live.find((l) => l.id === 'P1NA12')?.status).toBe('OPERATING');
+  return live.find((l) => l.id === 'P1AA01')?.status;
 }
 
 function parkRow(id: string, startTime: string, endTime: string, extra: Record<string, unknown> = {}) {
@@ -156,8 +156,8 @@ describe('DLP park-hours fallback for walkthroughs', () => {
       parkSchedules: [openNow('P1'), openNow('P2')],
       entitySchedules: [
         {
-          id: 'P1MA00',
-          name: 'Discovery Arcade',
+          id: 'P1AA01',
+          name: 'La Cabane des Robinson',
           schedules: [{
             startTime: parkClock(-180),
             endTime: parkClock(-120),
@@ -167,8 +167,8 @@ describe('DLP park-hours fallback for walkthroughs', () => {
         },
         // Canary carried explicitly, since the default is replaced.
         {
-          id: 'P1MA03',
-          name: 'Liberty Arcade',
+          id: 'P1NA12',
+          name: 'La Tanière du Dragon',
           schedules: [{
             startTime: parkClock(-5),
             endTime: parkClock(5),
@@ -362,7 +362,7 @@ describe('DLP park-hours fallback for walkthroughs', () => {
       vi.spyOn(park as any, 'getScheduleForDate').mockRejectedValue(new Error('upstream 500'));
 
       const live = await park.getLiveData();
-      for (const id of ['P1MA00', 'P1MA03']) {
+      for (const id of ['P1AA01', 'P1NA12']) {
         const row = live.find((l) => l.id === id);
         expect(row, `expected a live row for ${id}`).toBeDefined();
         expect(row?.status).toBe('CLOSED');
@@ -375,8 +375,8 @@ describe('DLP park-hours fallback for walkthroughs', () => {
       // case, asserted explicitly rather than only as a precondition.
       const park = stubbedPark({parkSchedules: []});
       const live = await park.getLiveData();
-      expect(live.find((l) => l.id === 'P1MA03')?.status).toBe('OPERATING');
-      expect(live.find((l) => l.id === 'P1MA00')?.status).toBe('CLOSED');
+      expect(live.find((l) => l.id === 'P1NA12')?.status).toBe('OPERATING');
+      expect(live.find((l) => l.id === 'P1AA01')?.status).toBe('CLOSED');
     });
   });
 });

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -29,12 +29,21 @@ const IGNORE_ENTITIES = new Set([
   'P2AC00',
   'armageddon',
   'P2EA02', // Entry to World of Frozen (land-entry pass, not a ride)
-  // Disney Adventure World's entrance building. POI types it "Attraction" with
-  // the same shape as every ride — empty subType, anyHeight, a Guest Entrance
-  // coordinate — so nothing in the record separates it from Phantom Manor. It
-  // is a place you walk through, carries no schedules and never a wait, and the
-  // wait feed reports only a bare OPERATING. Same class as P2EA02 above.
-  'P2FD03', // World Premiere
+  // Buildings, not attractions. POI types each of these "Attraction" with the
+  // same shape as every ride — empty subType, anyHeight, a Guest Entrance
+  // coordinate — so nothing in the record separates them from Phantom Manor.
+  // They are places you walk through: no schedules, never a wait, and the wait
+  // feed reports only a bare OPERATING row. Same class as P2EA02 above.
+  //
+  // Horse-Drawn Streetcars (P1MA02) shares the shape and deliberately stays:
+  // it is a vehicle you ride, not a building you are inside.
+  'P2FD03', // World Premiere — Disney Adventure World's entrance building
+  'P1MA00', // Discovery Arcade
+  'P1MA03', // Liberty Arcade
+  // The castle itself. What is inside it publishes separately, as
+  // P1NA06 La Galerie de la Belle au Bois Dormant and P1NA12 La Tanière du
+  // Dragon, so dropping the shell loses nothing.
+  'P1NA04', // Sleeping Beauty Castle
 ]);
 
 /** Entities that bypass visibility/hide rules */

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -29,6 +29,12 @@ const IGNORE_ENTITIES = new Set([
   'P2AC00',
   'armageddon',
   'P2EA02', // Entry to World of Frozen (land-entry pass, not a ride)
+  // Disney Adventure World's entrance building. POI types it "Attraction" with
+  // the same shape as every ride — empty subType, anyHeight, a Guest Entrance
+  // coordinate — so nothing in the record separates it from Phantom Manor. It
+  // is a place you walk through, carries no schedules and never a wait, and the
+  // wait feed reports only a bare OPERATING. Same class as P2EA02 above.
+  'P2FD03', // World Premiere
 ]);
 
 /** Entities that bypass visibility/hide rules */


### PR DESCRIPTION
Four POI records that publish as `ATTRACTION` but are buildings, not venues:

| id | name | on the wiki today |
|---|---|---|
| `P2FD03` | World Premiere (Disney Adventure World's entrance building) | no, pending |
| `P1MA00` | Discovery Arcade | yes |
| `P1MA03` | Liberty Arcade | yes |
| `P1NA04` | Sleeping Beauty Castle | yes |

Disney gives each of them the same record shape as a real ride, so nothing in the data separates them from Phantom Manor:

```json
{
 "id": "P2FD03", "name": "World Premiere", "type": "Attraction",
 "subType": "", "location": {"id": "P2"},
 "coordinates": [{"lat": 48.867857, "lng": 2.780041, "type": "Guest Entrance"}],
 "height": [{"id": "anyHeight"}], "schedules": [], "singleRider": false
}
```

`IGNORE_ENTITIES` already carries this class — `P2EA02`, the World of Frozen land-entry pass — so that is where they go.

**Horse-Drawn Streetcars (`P1MA02`) shares the shape and deliberately stays.** It is a vehicle you ride, not a building you are inside. That is the line this PR draws, and there is a test on it.

**Dropping the castle is lossless.** What is inside it publishes in its own right, as `P1NA06` La Galerie de la Belle au Bois Dormant and `P1NA12` La Tanière du Dragon. Also under test.

### Why not a general rule

I looked for one first, and there isn't a usable one:

- **subType** — all 61 in-park `Attraction` records have `subType: ""`. No signal at all.
- **interests** — `relaxingWalks` looked promising until the other members turned out to be Adventure Isle, Alice's Curious Labyrinth, Main Street Vehicles, Horse-Drawn Streetcars, La Cabane des Robinson, Le Passage Enchanté d'Aladdin, Thunder Mesa Riverboat Landing and Disneyland Railroad Main Street Station. Every one a real published walkthrough or transport attraction.
- **empty schedules** — exactly these four plus Horse-Drawn Streetcars, so it separates the class but takes the streetcars with it.

The id list is the only place the distinction can live, which is what it is there for.

### The live feed pulls them back in

Worth noting because it dictates where the fix goes: the wait feed carries `{"id": "P2FD03", "status": "OPERATING"}` and the equivalent for the others. Dropping the entity alone would leave live rows keyed to nothing. `IGNORE_ENTITIES` is checked in `filterPOIEntities`, which all three of `buildEntityList`, `buildLiveData` and `buildSchedules` reach through `getEmittablePOIEntities`, so entity, live row and schedule go together.

### `parkHours.test.ts`

#298 used the two arcades as the archetype walkthroughs for deriving live status from park hours, so its fixtures were built on `P1MA00` and `P1MA03` and 17 of its tests went red here. Swapped to La Cabane des Robinson and La Tanière du Dragon, both walkthroughs that survive this change.

The fallback itself is untouched and still has plenty of real members: Adventure Isle, Alice's Curious Labyrinth, Le Passage Enchanté d'Aladdin, Thunder Mesa Riverboat Landing, and the two castle interiors.

### Tests

`IGNORE_ENTITIES` had no coverage at all. `__tests__/ignoredEntities.test.ts` adds:

- each of the four buildings is not published
- Phantom Manor, stubbed with the byte-identical record shape, still is
- Horse-Drawn Streetcars still is — the line
- both castle interiors still are — what makes dropping the shell lossless
- `P2EA02` stays out, so the mechanism is under test and not just the new ids
- no live row for an ignored id the wait feed still reports
- no orphan schedule for an ignored id

Removing `P2FD03` again turns 3 of them red.

### Verification

- [x] `npx vitest run src/parks/dlp` — 7 files, 157 tests
- [x] `npx tsc --noEmit`
- [x] `npm run dev -- disneylandparis` — 4/4, entities 131 → 127, ATTRACTION 55 → 51

### Note for whoever merges

Three of the four are live wiki records with history. The next entity sync after this lands will queue deletions for them:

```
7d90d4e6-8c15-44ee-9e94-feb07788f02f  Discovery Arcade
a61aeee6-bed5-4890-8209-5249e689b1a1  Liberty Arcade
a620015d-091d-4f82-b8b2-a97bc8641f07  Sleeping Beauty Castle
```