### PR TITLE
test: take the gate suite off the network

### DIFF
--- a/src/__tests__/helpers/localHttpServer.ts
+++ b/src/__tests__/helpers/localHttpServer.ts
@@ -1,0 +1,96 @@
+/**
+ * A throwaway HTTP server on loopback, for tests that need the real
+ * `node:http` path rather than a mock of it.
+ *
+ * The tracing tests exercise `src/http.ts`, which is built on `node:http` /
+ * `node:https` rather than `fetch` precisely so proxying behaves. Mocking that
+ * module would leave the code under test unexercised, so these tests get a
+ * server instead: same sockets, same queue, same tracing events, no third
+ * party and no DNS.
+ *
+ * The port is assigned by the OS (`listen(0)`), which also keeps every run on
+ * its own URLs — the `@http` cache key is derived from the URL, so nothing can
+ * survive from a previous run's SQLite cache into this one.
+ */
+import {createServer, IncomingMessage, Server, ServerResponse} from 'node:http';
+import type {AddressInfo} from 'node:net';
+
+export type LocalServer = {
+  /** e.g. `http://127.0.0.1:38273` — no trailing slash. */
+  baseURL: string;
+  /** Every path this server was asked for, in order. */
+  requests: string[];
+  close: () => Promise<void>;
+};
+
+/** Fixtures the tracing tests read back. Small and stable on purpose. */
+const USERS = [
+  {id: 1, name: 'Ada Lovelace'},
+  {id: 2, name: 'Alan Turing'},
+  {id: 3, name: 'Grace Hopper'},
+  {id: 4, name: 'Edsger Dijkstra'},
+];
+
+const POSTS = [
+  {id: 1, userId: 1, title: 'first'},
+  {id: 2, userId: 2, title: 'second'},
+];
+
+/**
+ * Routes cover what the two tracing suites used to reach for on httpbin.org
+ * and jsonplaceholder.typicode.com. `/delay/:ms` is capped well below the
+ * old one-second sleep: the test needs a request that finishes later than
+ * its sibling, not a real second of wall clock.
+ */
+function handle(req: IncomingMessage, res: ServerResponse): void {
+  const path = (req.url || '/').split('?')[0];
+
+  const status = /^\/status\/(\d{3})$/.exec(path);
+  if (status) {
+    res.writeHead(Number(status[1]), {'Content-Type': 'application/json'});
+    res.end('{}');
+    return;
+  }
+
+  const delay = /^\/delay\/(\d+)$/.exec(path);
+  if (delay) {
+    const ms = Math.min(Number(delay[1]), 50);
+    setTimeout(() => {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({delayed: true}));
+    }, ms);
+    return;
+  }
+
+  const body =
+    path === '/users' ? USERS :
+    path === '/posts' ? POSTS :
+    {path};
+
+  res.writeHead(200, {'Content-Type': 'application/json'});
+  res.end(JSON.stringify(body));
+}
+
+export async function startLocalServer(): Promise<LocalServer> {
+  const requests: string[] = [];
+  const server: Server = createServer((req, res) => {
+    requests.push((req.url || '').split('?')[0]);
+    handle(req, res);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const {port} = server.address() as AddressInfo;
+
+  return {
+    baseURL: `http://127.0.0.1:${port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}

--- a/src/__tests__/helpers/localHttpServer.ts
+++ b/src/__tests__/helpers/localHttpServer.ts
@@ -38,10 +38,15 @@ const POSTS = [
 
 /**
  * Routes cover what the two tracing suites used to reach for on httpbin.org
- * and jsonplaceholder.typicode.com. `/delay/:ms` is capped well below the
- * old one-second sleep: the test needs a request that finishes later than
- * its sibling, not a real second of wall clock.
+ * and jsonplaceholder.typicode.com.
+ *
+ * `/delay/<n>` keeps httpbin's path shape but ignores the number and sleeps a
+ * fixed DELAY_MS. The caller only needs a request that finishes later than its
+ * sibling, not a real second of wall clock — and taking the duration from the
+ * URL would be a request-controlled timer, which is worth avoiding on
+ * principle even in a test fixture.
  */
+const DELAY_MS = 25;
 function handle(req: IncomingMessage, res: ServerResponse): void {
   const path = (req.url || '/').split('?')[0];
 
@@ -52,13 +57,11 @@ function handle(req: IncomingMessage, res: ServerResponse): void {
     return;
   }
 
-  const delay = /^\/delay\/(\d+)$/.exec(path);
-  if (delay) {
-    const ms = Math.min(Number(delay[1]), 50);
+  if (/^\/delay\/\d+$/.test(path)) {
     setTimeout(() => {
       res.writeHead(200, {'Content-Type': 'application/json'});
       res.end(JSON.stringify({delayed: true}));
-    }, ms);
+    }, DELAY_MS);
     return;
   }
 

--- a/src/__tests__/traceContextPropagation.test.ts
+++ b/src/__tests__/traceContextPropagation.test.ts
@@ -1,15 +1,33 @@
+/**
+ * Trace context has to survive the hop into an injection handler and into any
+ * request that handler makes of its own. That is a property of `src/tracing.ts`
+ * and `src/http.ts`, not of any particular endpoint, so these run against a
+ * loopback server rather than httpbin.org — see helpers/localHttpServer.ts.
+ */
 import { tracing } from '../tracing';
 import { http, HTTPObj, stopHttpQueue, waitForHttpQueue } from '../http';
 import { inject } from '../injector';
+import { startLocalServer, LocalServer } from './helpers/localHttpServer';
+
+/** Loopback, so the `@inject` hostname matcher has a literal to match on. */
+const HOST = '127.0.0.1';
 
 describe('Trace Context Propagation', () => {
-  afterAll(() => {
+  let server: LocalServer;
+
+  beforeAll(async () => {
+    server = await startLocalServer();
+  });
+
+  afterAll(async () => {
     stopHttpQueue();
+    await server.close();
   });
 
   it('should propagate trace context through injection handlers', async () => {
     const capturedTraceIds: string[] = [];
     const capturedEvents: string[] = [];
+    const baseURL = server.baseURL;
 
     class TestClass {
       @http({ cacheSeconds: 0 })
@@ -22,7 +40,7 @@ describe('Trace Context Propagation', () => {
 
         return {
           method: 'GET',
-          url: 'http://httpbin.org/get',
+          url: `${baseURL}/get`,
           tags: ['test'],
         } as HTTPObj;
       }
@@ -37,14 +55,14 @@ describe('Trace Context Propagation', () => {
 
         return {
           method: 'GET',
-          url: 'http://httpbin.org/delay/1',
+          url: `${baseURL}/delay/1`,
           tags: ['nested'],
         } as HTTPObj;
       }
 
       @inject({
         eventName: 'httpRequest',
-        hostname: 'httpbin.org',
+        hostname: HOST,
         tags: { $nin: ['nested'] }
       })
       async injectHandler(req: any) {
@@ -82,21 +100,28 @@ describe('Trace Context Propagation', () => {
     // All captured trace IDs should be the same
     expect(capturedTraceIds.length).toBeGreaterThan(0);
     const firstTraceId = capturedTraceIds[0];
-    capturedTraceIds.forEach((id, index) => {
+    capturedTraceIds.forEach((id) => {
       expect(id).toBe(firstTraceId);
     });
 
     // All should match the trace result
     expect(firstTraceId).toBe(result.traceId);
-  }, 35000); // Increased timeout to account for external HTTP requests
+
+    // The requests really went out over the socket, rather than the assertions
+    // above passing on a request that never left.
+    expect(server.requests).toContain('/get');
+    expect(server.requests).toContain('/delay/1');
+  });
 
   it('should capture HTTP events in trace when requests are made in injection handlers', async () => {
+    const baseURL = server.baseURL;
+
     class TestClass {
       @http({ cacheSeconds: 0 })
       async mainRequest(): Promise<HTTPObj> {
         return {
           method: 'GET',
-          url: 'http://httpbin.org/status/200',
+          url: `${baseURL}/status/200`,
           tags: ['main'],
         } as HTTPObj;
       }
@@ -105,14 +130,14 @@ describe('Trace Context Propagation', () => {
       async authRequest(): Promise<HTTPObj> {
         return {
           method: 'GET',
-          url: 'http://httpbin.org/status/201',
+          url: `${baseURL}/status/201`,
           tags: ['auth'],
         } as HTTPObj;
       }
 
       @inject({
         eventName: 'httpRequest',
-        hostname: 'httpbin.org',
+        hostname: HOST,
         tags: { $nin: ['auth'] }
       })
       async injectAuth(req: any) {
@@ -138,10 +163,10 @@ describe('Trace Context Propagation', () => {
     const startEvents = result.events.filter(e => e.eventType === 'http.request.start');
     const urls = startEvents.map(e => e.url);
 
-    expect(urls).toContain('http://httpbin.org/status/200');
-    expect(urls).toContain('http://httpbin.org/status/201');
+    expect(urls).toContain(`${baseURL}/status/200`);
+    expect(urls).toContain(`${baseURL}/status/201`);
 
     // All events should have the same trace ID
     expect(result.events.every(e => e.traceId === result.traceId)).toBe(true);
-  }, 35000); // Increased timeout to account for external HTTP requests
+  });
 });

--- a/src/__tests__/tracingIntegration.test.ts
+++ b/src/__tests__/tracingIntegration.test.ts
@@ -1,5 +1,10 @@
 /**
- * Integration test demonstrating HTTP request tracing with Destination methods
+ * Integration test demonstrating HTTP request tracing with Destination methods.
+ *
+ * The endpoints are a loopback server, not jsonplaceholder.typicode.com: what
+ * is under test is that `getLiveData()` emits paired start/complete events on
+ * one trace id, which no third party is needed to demonstrate. See
+ * helpers/localHttpServer.ts.
  */
 
 import { Destination } from '../destination';
@@ -8,12 +13,14 @@ import { http } from '../http';
 import { tracing } from '../tracing';
 import { LiveData, Entity } from '@themeparks/typelib';
 import { stopHttpQueue } from '../http';
+import { startLocalServer, LocalServer } from './helpers/localHttpServer';
 
 // Simple test destination with HTTP requests
 @config
 class TestDestination extends Destination {
+  /** Injected per-run: the loopback server picks its own port. */
   @config
-  baseUrl: string = 'https://jsonplaceholder.typicode.com';
+  baseUrl: string = '';
 
   @http({ cacheSeconds: 60 })
   async fetchUsers(): Promise<any> {
@@ -56,13 +63,16 @@ class TestDestination extends Destination {
 
 describe('Tracing Integration', () => {
   let destination: TestDestination;
+  let server: LocalServer;
 
-  beforeAll(() => {
-    destination = new TestDestination();
+  beforeAll(async () => {
+    server = await startLocalServer();
+    destination = new TestDestination({ config: { baseUrl: server.baseURL } });
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     stopHttpQueue();
+    await server.close();
   });
 
   it('should trace HTTP requests during getLiveData call', async () => {
@@ -95,7 +105,7 @@ describe('Tracing Integration', () => {
     expect(traceIds.has(result.traceId)).toBe(true);
 
     tracing.removeListener('http', listener);
-  }, 30000);
+  });
 
   it('should track request durations and status codes', async () => {
     const result = await tracing.trace(() => destination.getLiveData());
@@ -110,7 +120,7 @@ describe('Tracing Integration', () => {
       expect(event.status).toBe(200);
       expect(event.method).toBe('GET');
     });
-  }, 30000);
+  });
 
   it('should indicate cache hits on subsequent calls', async () => {
     // First call - should make real requests
@@ -125,7 +135,7 @@ describe('Tracing Integration', () => {
 
     // At least some requests should be cache hits
     expect(cacheHits.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('should work with event listeners for real-time monitoring', async () => {
     const requestLog: string[] = [];
@@ -151,7 +161,7 @@ describe('Tracing Integration', () => {
 
     tracing.removeListener('http.request.start', startListener);
     tracing.removeListener('http.request.complete', completeListener);
-  }, 30000);
+  });
 
   it('should return trace summary with duration', async () => {
     const result = await tracing.trace(() => destination.getLiveData());
@@ -160,5 +170,5 @@ describe('Tracing Integration', () => {
     expect(result.duration).toBeGreaterThan(0);
     expect(Array.isArray(result.result)).toBe(true);
     expect(Array.isArray(result.events)).toBe(true);
-  }, 30000);
+  });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,51 @@
-// Vitest setup file for cache testing
+// Vitest setup file
 // This file runs before the test suite
+
+import dns from 'node:dns';
 
 // Set up test-specific environment variables
 process.env.CACHE_DB_PATH = ':memory:';
+
+// ---------------------------------------------------------------------------
+// The gate suite does not touch the network.
+//
+// It used to: two tracing tests drove live requests at httpbin.org and
+// jsonplaceholder.typicode.com, so every run depended on two free public
+// services being up and quick from whatever IP the runner had. That produced
+// exactly the failure you would expect — a 35s timeout in CI on a commit that
+// touched neither file.
+//
+// Rewriting those two to run against a loopback server fixed the instances.
+// This makes the class unreachable: any hostname that is not loopback fails at
+// resolution, with a message naming the offender, rather than opening a socket
+// to the internet. A test that needs an endpoint gets a local server
+// (src/__tests__/helpers/localHttpServer.ts); a test that only needs a URL to
+// assert on never resolves it and is unaffected.
+// ---------------------------------------------------------------------------
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
+
+function blockedLookup(hostname: string): Error | null {
+  if (LOOPBACK.has(hostname)) return null;
+  return new Error(
+    `Blocked DNS lookup for "${hostname}" — the test suite must not touch the network. ` +
+    `Use src/__tests__/helpers/localHttpServer.ts for a real endpoint on loopback.`,
+  );
+}
+
+const realLookup = dns.lookup;
+// @ts-expect-error — overload-heavy signature; the wrapper forwards verbatim
+dns.lookup = function patchedLookup(hostname: string, ...args: any[]) {
+  const blocked = blockedLookup(hostname);
+  if (!blocked) return (realLookup as any)(hostname, ...args);
+  const callback = args[args.length - 1];
+  if (typeof callback === 'function') return callback(blocked);
+  throw blocked;
+};
+
+const realPromisesLookup = dns.promises.lookup;
+// @ts-expect-error — as above
+dns.promises.lookup = function patchedPromisesLookup(hostname: string, ...args: any[]) {
+  const blocked = blockedLookup(hostname);
+  if (blocked) return Promise.reject(blocked);
+  return (realPromisesLookup as any)(hostname, ...args);
+};


### PR DESCRIPTION
Closes #304.

## The two offenders

- `traceContextPropagation.test.ts` — four live requests to `httpbin.org`, 35s timeout
- `tracingIntegration.test.ts` — `jsonplaceholder.typicode.com` through `fetchUsers` / `fetchPosts`

Both now run against a loopback server on an OS-assigned port: `src/__tests__/helpers/localHttpServer.ts`.

**A server, not a mock of `node:http`.** What these two actually test is `src/http.ts` — the queue, the injectors, the tracing events it emits. Mocking the transport would leave the thing under test unexercised, so they get real sockets pointed somewhere honest instead. `@inject({hostname: ...})` matches on `127.0.0.1`, and the URL assertions are built from the server's own address.

The port being dynamic has a second benefit: the `@http` cache key is derived from the URL, so no run can inherit a cache entry from a previous one. `tracingIntegration`'s cache-hit test used to be at the mercy of whether the last run was inside the 60s TTL.

## Making the class unreachable, not just the instances

Rewriting two files fixes today's flake and does nothing about the next one. `vitest.setup.ts` now blocks `dns.lookup` for any hostname that is not loopback, with a message that names the offender and points at the helper:

```
Blocked DNS lookup for "httpbin.org" — the test suite must not touch the network.
Use src/__tests__/helpers/localHttpServer.ts for a real endpoint on loopback.
```

Tests that merely hold a URL string to assert on — `configWithHttp`, `proxy`, `config` and friends, which have plenty — never resolve it and are untouched. The whole suite passes with the guard on, so nothing else in `src/` was quietly reaching out either.

Verified the guard bites: a throwaway test pointed at `http://httpbin.org/get` fails in 111ms with the message above, rather than hanging for 35s.

## Result

```
before   86 files / 1910 tests   ~85s in CI, 2 files dependent on third parties
after    86 files / 1910 tests    28s, none
```

The 35s and 30s per-test timeouts came out with the network dependency that justified them.

## Acceptance, against the issue

- [x] `npm test` passes with the network unavailable — enforced now, not just true
- [x] No test in `src/__tests__/` resolves an external hostname — the guard is the proof
- [x] `--retry=1` removed from `.github/workflows/dev_container.yml` — already done on #302, which runs a plain `make test`. Nothing to change here, and that job should stop being the one that goes red.