### PR TITLE
feat(harness): fail on duplicate entity ids, and unshare Walibi Express

### DIFF
--- a/src/__tests__/duplicateEntityCheck.test.ts
+++ b/src/__tests__/duplicateEntityCheck.test.ts
@@ -1,0 +1,121 @@
+import {describe, it, expect} from 'vitest';
+import {findDuplicateEntityIds, describeDuplicateEntityIds} from '../duplicateCheck.js';
+
+/**
+ * The invariant: an entity list claims each id exactly once.
+ *
+ * The case that motivated it is Walibi Holland, whose CMS gives one wait-time
+ * id to two Walibi Express stations 150m apart. Both are emitted, one wins,
+ * and the loser has never existed on the wiki. Nothing detected it because
+ * nothing looked.
+ */
+describe('findDuplicateEntityIds', () => {
+  it('returns nothing for a list where every id is distinct', () => {
+    expect(findDuplicateEntityIds([
+      {id: 'a', name: 'Alpha'},
+      {id: 'b', name: 'Beta'},
+      {id: 'c', name: 'Gamma'},
+    ])).toEqual([]);
+  });
+
+  it('returns nothing for an empty list', () => {
+    expect(findDuplicateEntityIds([])).toEqual([]);
+  });
+
+  it('reports the repeated id with every name competing for it', () => {
+    const dups = findDuplicateEntityIds([
+      {id: '460e803c', name: 'Walibi Express Station 1'},
+      {id: 'other', name: 'Something Else'},
+      {id: '460e803c', name: 'Walibi Express Station 2'},
+    ]);
+
+    expect(dups).toEqual([{
+      id: '460e803c',
+      names: ['Walibi Express Station 1', 'Walibi Express Station 2'],
+      count: 2,
+    }]);
+  });
+
+  it('keeps names in emission order, so the survivor is identifiable', () => {
+    // Which one wins downstream depends on order, so the report has to
+    // preserve it rather than sort or dedupe.
+    const [dup] = findDuplicateEntityIds([
+      {id: 'x', name: 'first'},
+      {id: 'x', name: 'second'},
+      {id: 'x', name: 'third'},
+    ]);
+
+    expect(dup.names).toEqual(['first', 'second', 'third']);
+    expect(dup.count).toBe(3);
+  });
+
+  it('reports several distinct collisions independently', () => {
+    const dups = findDuplicateEntityIds([
+      {id: 'a', name: 'A1'}, {id: 'b', name: 'B1'},
+      {id: 'a', name: 'A2'}, {id: 'b', name: 'B2'},
+    ]);
+
+    expect(dups.map((d) => d.id)).toEqual(['a', 'b']);
+  });
+
+  it('skips entities with no id rather than collapsing them together', () => {
+    // A missing id is a different defect and the harness fails on it
+    // separately; grouping them here would report a phantom collision.
+    expect(findDuplicateEntityIds([
+      {name: 'no id'},
+      {id: '', name: 'empty id'},
+      {name: 'also no id'},
+    ])).toEqual([]);
+  });
+
+  it('reads a localised name without throwing', () => {
+    const [dup] = findDuplicateEntityIds([
+      {id: 'x', name: {en: 'Dragon Lair', fr: 'La Tanière du Dragon'}},
+      {id: 'x', name: {fr: 'Autre'}},
+    ]);
+
+    expect(dup.names).toEqual(['Dragon Lair', 'Autre']);
+  });
+
+  it('falls back to a placeholder for an unusable name', () => {
+    const [dup] = findDuplicateEntityIds([
+      {id: 'x'},
+      {id: 'x', name: 42 as unknown as string},
+    ]);
+
+    expect(dup.names).toEqual(['(unnamed)', '(unnamed)']);
+  });
+
+  it('does not mutate the input', () => {
+    const entities = [{id: 'x', name: 'a'}, {id: 'x', name: 'b'}];
+    const copy = structuredClone(entities);
+
+    findDuplicateEntityIds(entities);
+
+    expect(entities).toEqual(copy);
+  });
+});
+
+describe('describeDuplicateEntityIds', () => {
+  it('names the id and everything claiming it', () => {
+    const message = describeDuplicateEntityIds(findDuplicateEntityIds([
+      {id: '460e803c', name: 'Walibi Express Station 1'},
+      {id: '460e803c', name: 'Walibi Express Station 2'},
+    ]));
+
+    expect(message).toBe(
+      '"460e803c" claimed by 2: "Walibi Express Station 1", "Walibi Express Station 2"',
+    );
+  });
+
+  it('separates several collisions', () => {
+    const message = describeDuplicateEntityIds(findDuplicateEntityIds([
+      {id: 'a', name: 'A1'}, {id: 'a', name: 'A2'},
+      {id: 'b', name: 'B1'}, {id: 'b', name: 'B2'},
+    ]));
+
+    expect(message).toContain('; ');
+    expect(message).toContain('"a" claimed by 2');
+    expect(message).toContain('"b" claimed by 2');
+  });
+});

--- a/src/duplicateCheck.ts
+++ b/src/duplicateCheck.ts
@@ -1,0 +1,76 @@
+/**
+ * Cross-check that an entity list claims each id exactly once.
+ *
+ * Deliberately dependency-free, for the same reasons as orphanCheck: the
+ * collector can assert the invariant on the push path rather than only when
+ * someone runs the harness, and the unit tests stay clear of the HTTP queue
+ * and the SQLite cache.
+ *
+ * A duplicate id is not a reporting curiosity like an orphan row. Two entities
+ * under one id means one of them is silently discarded downstream, and the
+ * loss is invisible: Walibi Holland published `Walibi Express Station 1` and
+ * `Station 2` under a single CMS wait-time id for as long as that feed has
+ * been read, and Station 2 has never existed on the wiki as a result.
+ */
+
+/** A repeated id, with the names competing for it in emission order. */
+export type DuplicateEntityId = {
+  id: string;
+  /** Every entity claiming this id, in the order getEntities() emitted them. */
+  names: string[];
+  /** How many entities claim it — always >= 2. */
+  count: number;
+};
+
+/**
+ * Ids claimed by more than one entity, in first-seen order.
+ *
+ * Entities without an id are skipped rather than grouped together under
+ * `undefined`: a missing id is a different defect, and the harness already
+ * fails on it separately.
+ */
+export function findDuplicateEntityIds(
+  entities: Array<{id?: string; name?: unknown}>,
+): DuplicateEntityId[] {
+  const seen = new Map<string, string[]>();
+
+  for (const entity of entities) {
+    if (!entity?.id) continue;
+    const names = seen.get(entity.id);
+    const name = nameToString(entity.name);
+    if (names) {
+      names.push(name);
+    } else {
+      seen.set(entity.id, [name]);
+    }
+  }
+
+  const duplicates: DuplicateEntityId[] = [];
+  for (const [id, names] of seen) {
+    if (names.length > 1) duplicates.push({id, names, count: names.length});
+  }
+  return duplicates;
+}
+
+/**
+ * A name for the report. Entity names are `LocalisedString`, so they are
+ * either a plain string or a language-keyed object; anything else is a defect
+ * the harness reports on its own terms, and here it just needs to not throw.
+ */
+function nameToString(name: unknown): string {
+  if (typeof name === 'string') return name;
+  if (name && typeof name === 'object') {
+    const first = Object.values(name as Record<string, unknown>).find(
+      (v) => typeof v === 'string',
+    );
+    if (typeof first === 'string') return first;
+  }
+  return '(unnamed)';
+}
+
+/** One-line summary for an error or a log line. */
+export function describeDuplicateEntityIds(duplicates: DuplicateEntityId[]): string {
+  return duplicates
+    .map((d) => `"${d.id}" claimed by ${d.count}: ${d.names.map((n) => `"${n}"`).join(', ')}`)
+    .join('; ');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export * from './htmlUtils.js';
 export * from './statusMap.js';
 export * from './promiseReuse.js';
 export * from './orphanCheck.js';
+export * from './duplicateCheck.js';
 
 // Export default as named export for config decorator
 export { default as config } from './config.js';

--- a/src/parks/walibi/__tests__/expressStations.test.ts
+++ b/src/parks/walibi/__tests__/expressStations.test.ts
@@ -1,0 +1,117 @@
+import {describe, test, expect, beforeEach, afterEach} from 'vitest';
+import {WalibiHolland} from '../walibi.js';
+import {CacheLib} from '../../../cache.js';
+import {findDuplicateEntityIds} from '../../../duplicateCheck.js';
+import type {HTTPObj} from '../../../http.js';
+
+/**
+ * Walibi Holland's two Walibi Express stations stand 150m apart, share one
+ * queue board, and the CMS gives both rows the same `waitingTimeName`. Keying
+ * attractions on that field emitted two entities under one id, and one of them
+ * was silently discarded downstream: Station 2 has never existed on the wiki.
+ *
+ * The feed lists Station 2 first, which is why the fix names the loser rather
+ * than picking by order. First-wins would hand the shared id to Station 2 and
+ * rename Station 1, orphaning the record that holds it today.
+ *
+ * Fixtures are the real rows, paths and coordinates included.
+ */
+const SHARED_ID = '460e803c-6f87-442c-86b6-3cd80280beaf';
+
+const STATION_2 = {
+  title: 'Walibi Express Station 2',
+  waitingTimeName: SHARED_ID,
+  path: '/content/dam/who/en/attractions/walibi-express-station-2',
+  latitude: 52.441642,
+  longitude: 5.765361,
+};
+
+const STATION_1 = {
+  title: 'Walibi Express Station 1',
+  waitingTimeName: SHARED_ID,
+  path: '/content/dam/who/en/attractions/walibi-express-station-1',
+  latitude: 52.440204,
+  longitude: 5.766208,
+};
+
+/** A ride with an id of its own, to prove the fix is narrow. */
+const UNTAMED = {
+  title: 'Untamed',
+  waitingTimeName: 'c0ffee00-0000-4000-8000-000000000001',
+  path: '/content/dam/who/en/attractions/untamed',
+  latitude: 52.4402,
+  longitude: 5.7661,
+};
+
+function stubbedPark(attractions: any[], waitTimes: any[] = []): WalibiHolland {
+  const park = new WalibiHolland();
+  park.fetchAttractions = (async () => ({json: async () => attractions} as any as HTTPObj)) as any;
+  park.getRestaurants = async () => [];
+  park.getWaitTimes = async () => waitTimes;
+  return park;
+}
+
+describe('WalibiHolland — Walibi Express stations sharing one wait-time id', () => {
+  beforeEach(() => CacheLib.clear());
+  afterEach(() => CacheLib.clear());
+
+  test('publishes both stations', async () => {
+    const entities = await stubbedPark([STATION_2, STATION_1, UNTAMED]).getEntities();
+
+    const names = entities.filter(e => e.entityType === 'ATTRACTION').map(e => e.name);
+    expect(names).toContain('Walibi Express Station 1');
+    expect(names).toContain('Walibi Express Station 2');
+  });
+
+  test('emits no duplicate ids', async () => {
+    const entities = await stubbedPark([STATION_2, STATION_1, UNTAMED]).getEntities();
+
+    expect(findDuplicateEntityIds(entities)).toEqual([]);
+  });
+
+  test('leaves the shared id with Station 1, which holds it on the wiki', async () => {
+    // The whole point of naming the loser explicitly. If this flips, the live
+    // record is orphaned and a new one minted in its place.
+    const entities = await stubbedPark([STATION_2, STATION_1, UNTAMED]).getEntities();
+
+    expect(entities.find(e => e.id === SHARED_ID)?.name).toBe('Walibi Express Station 1');
+  });
+
+  test('keys Station 2 on its CMS path', async () => {
+    const entities = await stubbedPark([STATION_2, STATION_1, UNTAMED]).getEntities();
+
+    const station2 = entities.find(e => e.name === 'Walibi Express Station 2');
+    expect(station2?.id).toBe('attr_walibi-express-station-2');
+    expect(station2?.location).toEqual({latitude: 52.441642, longitude: 5.765361});
+  });
+
+  test('holds the order-independence: Station 1 keeps the id whichever way the feed lists them', async () => {
+    // A first-wins or last-wins rule passes one of these two and fails the
+    // other. Naming the loser passes both.
+    for (const order of [[STATION_2, STATION_1], [STATION_1, STATION_2]]) {
+      const entities = await stubbedPark([...order, UNTAMED]).getEntities();
+      expect(entities.find(e => e.id === SHARED_ID)?.name).toBe('Walibi Express Station 1');
+      expect(findDuplicateEntityIds(entities)).toEqual([]);
+      CacheLib.clear();
+    }
+  });
+
+  test('leaves a ride with an unshared wait-time id keyed on it', async () => {
+    const entities = await stubbedPark([STATION_2, STATION_1, UNTAMED]).getEntities();
+
+    expect(entities.find(e => e.name === 'Untamed')?.id)
+      .toBe('c0ffee00-0000-4000-8000-000000000001');
+  });
+
+  test('gives the shared queue board wait to Station 1', async () => {
+    // One wait row for the shared id, and it stays with the entity that keeps
+    // that id. Station 2 publishes without live data, like any path-keyed ride.
+    const live = await stubbedPark(
+      [STATION_2, STATION_1, UNTAMED],
+      [{id: SHARED_ID, time: 600, status: 'open'}],
+    ).getLiveData();
+
+    expect(live.map(l => l.id)).toEqual([SHARED_ID]);
+    expect(live[0]).toMatchObject({status: 'OPERATING', queue: {STANDBY: {waitTime: 10}}});
+  });
+});

--- a/src/parks/walibi/walibi.ts
+++ b/src/parks/walibi/walibi.ts
@@ -29,6 +29,30 @@ const mapStatus = createStatusMap({
 /** Statuses that should be excluded from live data entirely */
 const SKIP_STATUSES = new Set(['not_operational']);
 
+/**
+ * CMS path slugs that must be keyed on the path rather than on
+ * `waitingTimeName`, because the feed hands their wait-time id to another POI
+ * as well.
+ *
+ * Walibi Holland's two Walibi Express stations are 150m apart and share one
+ * queue board, so the CMS gives both rows
+ * `460e803c-6f87-442c-86b6-3cd80280beaf`. Two entities under one id means one
+ * is silently discarded: Station 2 has never existed on the wiki.
+ *
+ * Listed explicitly rather than resolved by a first-wins or last-wins rule,
+ * because the winner has to be Station 1 and neither rule can guarantee that.
+ * Station 1 holds the shared id on the wiki today, and the feed happens to
+ * list Station 2 first — so first-wins would rename the live record and
+ * orphan its history, and last-wins would do the same the day the feed
+ * reorders. Naming the loser is the only order-independent answer.
+ *
+ * The wait feed carries a single row for the shared id, which stays with
+ * Station 1. Station 2 publishes without live data, like any path-keyed ride.
+ */
+const PATH_KEYED_ATTRACTIONS = new Set([
+  'walibi-express-station-2',
+]);
+
 // ── Types ──────────────────────────────────────────────────────
 
 interface AttractionPOI {
@@ -262,10 +286,15 @@ class WalibiBase extends Destination {
     // A ride with a queue board is keyed on its wait-time id — those are live
     // wiki records and must not shift. Only rides that have one carry the
     // field, so the rest fall back to the CMS path, exactly as restaurants do.
+    // A POI listed in PATH_KEYED_ATTRACTIONS gives up its shared wait-time id
+    // and takes the same path fallback.
     const attrEntities = attractions
       .map(a => {
         const slug = this.pathSlug(a.path);
-        const id = a.waitingTimeName || (slug && `attr_${slug}`);
+        const waitTimeId = slug !== null && PATH_KEYED_ATTRACTIONS.has(slug)
+          ? null
+          : a.waitingTimeName;
+        const id = waitTimeId || (slug && `attr_${slug}`);
         if (!id) return null;
 
         const entity: Entity = {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -9,6 +9,7 @@ import {getQueueLength} from './http.js';
 import {tracing} from './tracing.js';
 import {typeDetector} from './typeDetector.js';
 import {findOrphanIds} from './orphanCheck.js';
+import {findDuplicateEntityIds, describeDuplicateEntityIds} from './duplicateCheck.js';
 
 export type TestResult = {
   testName: string;
@@ -160,6 +161,23 @@ export async function testPark(
         throw new Error(`Entity ${idx} id has unsafe characters: ${escaped} ("${entity.name}")`);
       }
     });
+
+    // Structural uniqueness requirement: an id identifies one entity.
+    //
+    // A hard failure rather than a warning, unlike the orphan and missing-
+    // location reports below. An orphan row is dead weight a consumer ignores;
+    // a duplicate id means one of the two entities is silently discarded on
+    // the way out, and there is no legitimate reason to emit one twice. It
+    // stays invisible otherwise: Walibi Holland shipped two Walibi Express
+    // stations under one CMS wait-time id, and Station 2 has never existed on
+    // the wiki as a result.
+    //
+    // Safe to fail hard: surveyed across all 80 destinations, Walibi Holland
+    // was the only one, and it is fixed alongside this check.
+    const duplicateIds = findDuplicateEntityIds(entities);
+    if (duplicateIds.length > 0) {
+      throw new Error(`Duplicate entity ids: ${describeDuplicateEntityIds(duplicateIds)}`);
+    }
 
     // Structural location requirement: DESTINATION + PARK must have location.
     // These are the anchor points for the whole hierarchy — a missing coord


### PR DESCRIPTION
Closes #306.

Two halves, as the issue framed them. The library half is the valuable one.

## The gate

Nothing detected a repeated entity id. `getEntities()` does not check, and `testRunner.ts` validated the id charset but never uniqueness, so the class was invisible across all 80 destinations.

`findDuplicateEntityIds` goes in its own dependency-free module, mirroring `findOrphanIds` from #299, so the collector can assert the same invariant on the push path rather than only when someone runs the harness.

**A hard failure, not a warning.** An orphan row is dead weight a consumer ignores. A duplicate id means one of the two entities is discarded on the way out, silently, and there is no legitimate reason to emit one twice.

## The survey, before deciding that

Ran `getEntities()` across the whole registry first, since failing hard on an unknown blast radius would be reckless:

```
destinations   80
returned        78
errored          2   nigloland (Invalid URL), portaventuraworld (known upstream)
parks with duplicate ids    1
distinct duplicated ids     1
```

Walibi Holland is the only one, with a single id, and it is fixed here. Neither erroring destination failed on duplicates.

## The park

```
460e803c-6f87-442c-86b6-3cd80280beaf   Walibi Express Station 2   52.441642, 5.765361
460e803c-6f87-442c-86b6-3cd80280beaf   Walibi Express Station 1   52.440204, 5.766208
```

39 feed rows, 38 distinct `waitingTimeName`. Two stations 150m apart sharing one queue board, so the CMS gives both the same wait-time id. On the wiki, Walibi Holland has 57 children, no duplicates, and only Station 1 — Station 2 has never been published.

**The fix names the loser explicitly rather than resolving by order.** Station 1 holds the shared id on the wiki, and the feed lists Station 2 *first*, so:

- first-wins hands the id to Station 2 and orphans the live Station 1 record
- last-wins does the same the day the feed reorders

Naming the loser is the only order-independent answer, and there is a test that runs both feed orders to hold it.

Station 2 takes the CMS path fallback that untagged rides already use. Verified against the live feed:

```
attr_walibi-express-station-2          Walibi Express Station 2   52.441642, 5.765361
460e803c-6f87-442c-86b6-3cd80280beaf   Walibi Express Station 1   52.440204, 5.766208
duplicates: []
live rows for the shared id: 1   (stays with Station 1)
```

The wait feed carries one row for the shared id, and it stays with the entity that keeps that id. Station 2 publishes without live data, like any path-keyed ride.

## Tests

- `src/__tests__/duplicateEntityCheck.test.ts` — 11 cases on the pure function: distinct lists, emission order preserved so the survivor is identifiable, several collisions reported independently, entities with no id skipped rather than collapsed into a phantom collision, localised names, no mutation of the input.
- `src/parks/walibi/__tests__/expressStations.test.ts` — 7 cases on the real rows, including the order-independence one that a first-wins or last-wins rule fails.

Mutation check on the gate itself — with the park fix reverted, the harness goes red with the right message:

```
✗ Failed: Duplicate entity ids: "460e803c-..." claimed by 2:
  "Walibi Express Station 2", "Walibi Express Station 1"
❌ Walibi Holland: 3/4 tests passed
```

## Verification

- [x] `npx vitest run` — 88 files, 1928 tests
- [x] `npx tsc --noEmit`
- [x] `npm run dev -- walibiholland` — 4/4, 59 entities, both stations distinct
- [x] Registry-wide survey, numbers above

## Note for whoever merges

Station 2 is a new entity and will arrive in moderation as an addition. Station 1 is untouched, so nothing needs repointing this time.