### PR TITLE
docs: generate the destination table from the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThemeParks.wiki Park Data Backend
 
-An open-source TypeScript library for fetching real-time theme park data — wait times, schedules, and entity metadata — from 75+ destinations worldwide.
+An open-source TypeScript library for fetching real-time theme park data — wait times, schedules, and entity metadata — from <!-- destinations:count -->80<!-- /destinations:count -->+ destinations worldwide.
 
 This library powers the free API at [ThemeParks.wiki](https://themeparks.wiki).
 
@@ -115,9 +115,12 @@ make COMPOSE="podman-compose --env-file /dev/null --podman-run-args=--userns=kee
 
 ## Supported Destinations
 
+<!-- destinations:table -->
 80 destinations across Disney, Universal, Cedar Fair, Six Flags, Merlin, and many more.
 
-Run `npm run dev -- --list` for the full list with IDs and categories, or see below:
+Some parks are served through a parent destination rather than an id of their own — Cedar Point and Knott's Berry Farm arrive under the Six Flags controller, for instance — so they are entities in the output rather than rows here.
+
+Run `npm run dev -- --list` for the same list with categories.
 
 <details>
 <summary>All destinations</summary>
@@ -126,32 +129,33 @@ Run `npm run dev -- --list` for the full list with IDs and categories, or see be
 |---|---|
 | Alton Towers | `altontowers` |
 | Bellewaerde | `bellewaerde` |
+| Blackpool Pleasure Beach | `blackpoolpleasurebeach` |
 | Bobbejaanland | `bobbejaanland` |
 | Busch Gardens Tampa | `buschgardenstampa` |
 | Busch Gardens Williamsburg | `buschgardenswilliamsburg` |
-| California's Great America | `californiasgreatamerica` |
-| Canada's Wonderland | `canadaswonderland` |
-| Carowinds | `carowinds` |
-| Cedar Point | `cedarpoint` |
-| Chessington World of Adventures | `chessingtonworldofadventures` |
+| Chessington World Of Adventures | `chessingtonworldofadventures` |
 | Chimelong | `chimelong` |
 | Disneyland Paris | `disneylandparis` |
 | Djurs Sommerland | `djurssommerland` |
 | Dollywood | `dollywood` |
-| Dorney Park | `dorneypark` |
 | Efteling | `efteling` |
-| Europa-Park | `europapark` |
+| Energylandia | `energylandia` |
+| Europa Park | `europapark` |
 | Everland | `everland` |
+| Fantawild | `fantawild` |
+| Flamingo Land | `flamingoland` |
+| Fuji Q Highland | `fujiqhighland` |
 | Futuroscope | `futuroscope` |
+| Galveston Island Waterpark | `galvestonislandwaterpark` |
 | Gardaland | `gardaland` |
-| Hansa-Park | `hansapark` |
+| Genting Skyworlds | `gentingskyworlds` |
+| Great Escape Parks | `greatescapeparks` |
+| Hansa Park | `hansapark` |
 | Heide Park | `heidepark` |
 | Hersheypark | `hersheypark` |
 | Kennywood | `kennywood` |
-| Kings Dominion | `kingsdominion` |
-| Kings Island | `kingsisland` |
+| Kentucky Kingdom | `kentuckykingdom` |
 | Knoebels | `knoebels` |
-| Knott's Berry Farm | `knottsberryfarm` |
 | Legoland Billund | `legolandbillund` |
 | Legoland California | `legolandcalifornia` |
 | Legoland Deutschland | `legolanddeutschland` |
@@ -162,27 +166,32 @@ Run `npm run dev -- --list` for the full list with IDs and categories, or see be
 | Legoland Windsor | `legolandwindsor` |
 | Liseberg | `liseberg` |
 | Lotte World | `lotteworld` |
-| Michigan's Adventure | `michigansadventure` |
+| Michigans Adventure | `michigansadventure` |
+| Mid America Parks | `midamericaparks` |
 | Mirabilandia | `mirabilandia` |
 | Movie Park Germany | `movieparkgermany` |
-| Parc Asterix | `parcasterix` |
+| Nigloland | `nigloland` |
+| Ocean Park Hong Kong | `oceanparkhongkong` |
 | Paradise Country | `paradisecountry` |
-| Parque de Atracciones Madrid | `parquedeatraccionesmadrid` |
+| Parc Asterix | `parcasterix` |
+| Parque De Atracciones Madrid | `parquedeatraccionesmadrid` |
 | Parque Warner Madrid | `parquewarnermadrid` |
 | Paultons Park | `paultonspark` |
 | Peppa Pig Theme Park Florida | `peppapigthemeparkflorida` |
 | Phantasialand | `phantasialand` |
 | Plopsaland | `plopsaland` |
 | Plopsaland Deutschland | `plopsalanddeutschland` |
-| PortAventura World | `portaventuraworld` |
+| Port Aventura World | `portaventuraworld` |
+| Qiddiya City | `qiddiyacity` |
 | Sea World Gold Coast | `seaworldgoldcoast` |
-| SeaWorld Orlando | `seaworldorlando` |
-| SeaWorld San Antonio | `seaworldsanantonio` |
-| SeaWorld San Diego | `seaworldsandiego` |
+| Seaworld Orlando | `seaworldorlando` |
+| Seaworld San Antonio | `seaworldsanantonio` |
+| Seaworld San Diego | `seaworldsandiego` |
+| Sesame Place Philadelphia | `sesameplacephiladelphia` |
+| Sesame Place San Diego | `sesameplacesandiego` |
 | Shanghai Disneyland Resort | `shanghaidisneylandresort` |
 | Silver Dollar City | `silverdollarcity` |
 | Six Flags | `sixflags` |
-| Six Flags Qiddiya City | `sixflagsqiddiyacity` |
 | Thorpe Park | `thorpepark` |
 | Tokyo Disney Resort | `tokyodisneyresort` |
 | Toverland | `toverland` |
@@ -194,12 +203,14 @@ Run `npm run dev -- --list` for the full list with IDs and categories, or see be
 | Valleyfair | `valleyfair` |
 | Walibi Belgium | `walibibelgium` |
 | Walibi Holland | `walibiholland` |
-| Walibi Rhone-Alpes | `walibirhonealpes` |
-| Warner Bros. Movie World | `warnerbrosmovieworld` |
-| Wet'n'Wild Gold Coast | `wetnwildgoldcoast` |
-| Worlds of Fun | `worldsoffun` |
+| Walibi Rhone Alpes | `walibirhonealpes` |
+| Warner Bros Movie World | `warnerbrosmovieworld` |
+| Wet N Wild Gold Coast | `wetnwildgoldcoast` |
+| Worlds Of Fun | `worldsoffun` |
 
 </details>
+<!-- /destinations:table -->
+
 
 ## Entity Types
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "audit:live": "tsx --env-file=.env src/tools/audit/live.ts",
     "har": "tsx src/tools/har/index.ts",
     "docs": "typedoc",
-    "prepare": "tsc"
+    "prepare": "tsc",
+    "readme": "tsx src/tools/readme/destinations.ts"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/readmeDestinations.test.ts
+++ b/src/__tests__/readmeDestinations.test.ts
@@ -1,0 +1,64 @@
+import {describe, it, expect, afterAll} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve} from 'node:path';
+import {renderReadme, buildBlocks, replaceBlock} from '../tools/readme/destinations.js';
+import {getAllDestinations} from '../destinationRegistry.js';
+import {stopHttpQueue} from '../http.js';
+
+/**
+ * The gate that stops the table drifting again.
+ *
+ * It stood at 74 rows against 80 registered destinations — missing 15, and
+ * listing 9 sub-parks that are not registry entries — while the line above it
+ * claimed to be the output of `npm run dev -- --list`. Generating it is only
+ * half a fix; without this, the next destination lands and the file is stale
+ * again with nothing to say so.
+ */
+const README = resolve(dirname(fileURLToPath(import.meta.url)), '../../README.md');
+
+// Loading the registry imports every park module, which starts the HTTP
+// queue's interval. Nothing here makes a request.
+afterAll(() => stopHttpQueue());
+
+describe('README destination list', () => {
+  it('is up to date with the registry', async () => {
+    const current = readFileSync(README, 'utf8');
+
+    expect(await renderReadme(current)).toBe(current);
+  });
+
+  it('lists every registered destination exactly once', async () => {
+    const current = readFileSync(README, 'utf8');
+    const destinations = await getAllDestinations();
+
+    for (const d of destinations) {
+      const rows = current.split('\n').filter((l) => l.includes(`| \`${d.id}\` |`));
+      expect(rows, `${d.id} (${d.name})`).toHaveLength(1);
+    }
+  });
+
+  it('lists nothing that is not registered', async () => {
+    const current = readFileSync(README, 'utf8');
+    const registered = new Set((await getAllDestinations()).map((d) => d.id));
+
+    const listed = [...current.matchAll(/^\| .+ \| `([a-z0-9]+)` \|$/gm)].map((m) => m[1]);
+
+    expect(listed.length).toBeGreaterThan(0);
+    expect(listed.filter((id) => !registered.has(id))).toEqual([]);
+  });
+
+  it('states the registry size in the opening paragraph', async () => {
+    const current = readFileSync(README, 'utf8');
+    const {count} = await buildBlocks();
+
+    expect(current).toContain(
+      `<!-- destinations:count -->${count}<!-- /destinations:count -->`,
+    );
+  });
+
+  it('fails loudly if the markers are removed rather than writing a mangled file', () => {
+    expect(() => replaceBlock('no markers here', '<!-- a -->', '<!-- /a -->', 'x'))
+      .toThrow(/missing the <!-- a -->/);
+  });
+});

--- a/src/tools/readme/destinations.ts
+++ b/src/tools/readme/destinations.ts
@@ -1,0 +1,134 @@
+/**
+ * README destination table generator.
+ *
+ * Usage:
+ *   npm run readme            Rewrite the generated blocks in README.md
+ *   npm run readme -- --check Exit 1 if they are stale (used by the gate test)
+ *
+ * The table is derived data that was living in prose, so it drifted: it stood
+ * at 74 rows against 80 registered destinations, missing 15 and listing 9 that
+ * are not registry entries at all. Generating it from the registry is the only
+ * way it stays true, since the alternative is remembering to hand-edit a table
+ * every time a destination lands.
+ *
+ * Two blocks are owned here, both marker-delimited so the surrounding prose
+ * stays hand-written:
+ *
+ *   <!-- destinations:count -->80<!-- /destinations:count -->
+ *   <!-- destinations:table --> … <!-- /destinations:table -->
+ */
+
+import {readFileSync, writeFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve} from 'node:path';
+import {getAllDestinations} from '../../destinationRegistry.js';
+import {stopHttpQueue} from '../../http.js';
+
+const README = resolve(dirname(fileURLToPath(import.meta.url)), '../../../README.md');
+
+const COUNT_OPEN = '<!-- destinations:count -->';
+const COUNT_CLOSE = '<!-- /destinations:count -->';
+const TABLE_OPEN = '<!-- destinations:table -->';
+const TABLE_CLOSE = '<!-- /destinations:table -->';
+
+/**
+ * Sub-parks are not registry entries: Cedar Point, Knott's Berry Farm and the
+ * rest of that estate are served through a single parent controller, so they
+ * have no id of their own to list. They used to sit in the table unmarked,
+ * which is what made it look longer than the registry while still being
+ * short of it.
+ */
+const SUBPARK_NOTE =
+  'Some parks are served through a parent destination rather than an id of ' +
+  'their own — Cedar Point and Knott\'s Berry Farm arrive under the Six Flags ' +
+  'controller, for instance — so they are entities in the output rather than ' +
+  'rows here.';
+
+export type ReadmeBlocks = {count: string; table: string};
+
+/** The two generated blocks, from the live registry. */
+export async function buildBlocks(): Promise<ReadmeBlocks> {
+  const destinations = await getAllDestinations();
+  const rows = [...destinations]
+    .sort((a, b) => a.name.localeCompare(b.name, 'en'))
+    .map((d) => `| ${d.name} | \`${d.id}\` |`);
+
+  const table = [
+    '',
+    `${destinations.length} destinations across Disney, Universal, Cedar Fair, Six Flags, Merlin, and many more.`,
+    '',
+    SUBPARK_NOTE,
+    '',
+    'Run `npm run dev -- --list` for the same list with categories.',
+    '',
+    '<details>',
+    '<summary>All destinations</summary>',
+    '',
+    '| Destination | ID |',
+    '|---|---|',
+    ...rows,
+    '',
+    '</details>',
+    '',
+  ].join('\n');
+
+  return {count: String(destinations.length), table};
+}
+
+/** Replace the content between a marker pair. Throws if the pair is missing. */
+export function replaceBlock(
+  source: string,
+  open: string,
+  close: string,
+  content: string,
+): string {
+  const start = source.indexOf(open);
+  const end = source.indexOf(close);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(
+      `README.md is missing the ${open}…${close} markers. ` +
+      `They delimit generated content and must not be removed.`,
+    );
+  }
+  return source.slice(0, start + open.length) + content + source.slice(end);
+}
+
+/** README.md with both generated blocks brought up to date. */
+export async function renderReadme(source: string): Promise<string> {
+  const {count, table} = await buildBlocks();
+  return replaceBlock(
+    replaceBlock(source, COUNT_OPEN, COUNT_CLOSE, count),
+    TABLE_OPEN,
+    TABLE_CLOSE,
+    table,
+  );
+}
+
+async function main(): Promise<void> {
+  const check = process.argv.includes('--check');
+  const current = readFileSync(README, 'utf8');
+  const rendered = await renderReadme(current);
+
+  if (current === rendered) {
+    console.log(check ? 'README destination list is up to date' : 'README already up to date');
+    return;
+  }
+
+  if (check) {
+    console.error('README destination list is stale. Run: npm run readme');
+    process.exitCode = 1;
+    return;
+  }
+
+  writeFileSync(README, rendered);
+  console.log('README destination list rewritten');
+}
+
+// Only run when invoked directly, so the gate test can import the helpers.
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  await main();
+  // Loading the registry imports every park module, which starts the HTTP
+  // queue's interval. Nothing here makes a request, but the timer keeps the
+  // event loop alive and the command would never return.
+  stopHttpQueue();
+}


### PR DESCRIPTION
Closes #305.

The table was derived data living in prose, so it drifted in both directions: 74 rows against 80 registered destinations, under a sentence at `README.md:88` claiming it was the output of `npm run dev -- --list`.

Taking the generate-and-gate option from the issue rather than deleting the table.

## What changed in the file

```
rows before   74
rows after    80

removed (9)   californiasgreatamerica  canadaswonderland  carowinds
              cedarpoint  dorneypark  kingsdominion  kingsisland
              knottsberryfarm  sixflagsqiddiyacity

added (15)    blackpoolpleasurebeach  energylandia  fantawild  flamingoland
              fujiqhighland  galvestonislandwaterpark  gentingskyworlds
              greatescapeparks  kentuckykingdom  midamericaparks  nigloland
              oceanparkhongkong  qiddiyacity  sesameplacephiladelphia
              sesameplacesandiego
```

Exactly the two sets the issue measured.

## The sub-park decision

The 9 removed rows are the ones the issue flagged as needing a call. They are sub-parks reached through a parent controller — Cedar Point, Knott's Berry Farm and that estate arrive under the Six Flags controller — so they have no registry id to list. They were in the table unmarked, which is precisely what made it look longer than the registry while still being short of it.

**They are out, with a generated line explaining why** rather than a second column or a hand-maintained section:

> Some parks are served through a parent destination rather than an id of their own — Cedar Point and Knott's Berry Farm arrive under the Six Flags controller, for instance — so they are entities in the output rather than rows here.

The alternative, a separate sub-park section, would be hand-maintained data next to generated data and would drift the same way the table just did. Happy to change it if you would rather they were listed — it is your call on whether the table is registry-facing or user-facing, and I have made it registry-facing to match the sentence above it.

## How it works

`npm run readme` rewrites two marker-delimited blocks; `npm run readme -- --check` exits 1 when they are stale:

```
<!-- destinations:count -->80<!-- /destinations:count -->
<!-- destinations:table --> … <!-- /destinations:table -->
```

Both numbers come from one source, so `:3` and the count above the table can no longer disagree. Everything outside the markers stays hand-written.

One wrinkle worth recording: loading the registry imports every park module, which starts the HTTP queue's interval, so the command hung after doing its work. It calls `stopHttpQueue()` on the way out and now returns in about a second.

## The gate

Generating is only half a fix — without a check, the next destination lands and the file is stale again with nothing to say so. `src/__tests__/readmeDestinations.test.ts`:

- the file matches what the generator produces
- every registered id appears exactly once, failing with the offending id named
- nothing unregistered is listed
- the count in the opening paragraph is the registry size
- removing the markers throws rather than writing a mangled file

Proof it bites — deleting one row:

```
× is up to date with the registry
× lists every registered destination exactly once
  → altontowers (Alton Towers)
```

and `npm run readme` puts it back.

## Verification

- [x] `npx vitest run` — 89 files, 1933 tests
- [x] `npx tsc --noEmit`
- [x] `npm run readme` and `--check` both return in ~1s