### PR TITLE
fix(seaworld): isolate per-park live data failures

### DIFF
--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -369,6 +369,80 @@ describe('SeaworldOrlando', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Regression: upstream 403 on one park UUID must not take its siblings down.
+  //
+  // All three Orlando parks share one upstream. src/http.ts treats 4xx as
+  // non-retryable, so a bot-protection block rejects immediately; before the
+  // fix the unguarded `await` in the resortIds loop propagated that rejection
+  // and buildLiveData() emitted nothing for the entire destination.
+  // -------------------------------------------------------------------------
+  describe('per-park failure isolation', () => {
+    const DISCOVERY_COVE = '1FB04DFC-B6C0-4918-BE36-EE6DD14FE741';
+
+    // Reject for one park UUID only; the others keep serving the fixture.
+    function failOnePark(park: any, failingParkId: string) {
+      park.getAvailability = async (parkId: string) => {
+        if (parkId === failingParkId) {
+          throw new Error('Request failed with status code 403');
+        }
+        return MOCK_AVAILABILITY_SWO as any;
+      };
+    }
+
+    it('still returns sibling park live data when one park 403s', async () => {
+      const park = createMockedOrlando();
+      failOnePark(park, DISCOVERY_COVE);
+
+      const liveData = await (park as any).buildLiveData();
+
+      // SeaWorld Orlando's own rides must still report.
+      const ride001 = liveData.find((ld: any) => ld.id === 'ride-001');
+      expect(ride001).toBeDefined();
+      expect(ride001.status).toBe('OPERATING');
+      expect(ride001.queue.STANDBY.waitTime).toBe(30);
+    });
+
+    it('returns an empty list rather than throwing when every park 403s', async () => {
+      const park = createMockedOrlando();
+      park.getAvailability = async () => {
+        throw new Error('Request failed with status code 403');
+      };
+
+      // No rows is correct here: emitting a fabricated CLOSED for a park we
+      // cannot see would push invented state to the wiki.
+      await expect((park as any).buildLiveData()).resolves.toEqual([]);
+    });
+
+    // The next two guard the deliberate asymmetry. The collector diffs the
+    // entity list and issues DELETE v1/entity/<id> for anything missing, so
+    // swallowing a failure here would delete the failed park's entities from
+    // the wiki. These must keep throwing.
+    it('buildEntityList still throws when a park fetch fails', async () => {
+      const park = createMockedOrlando();
+      park.getParkDetail = async (parkId: string) => {
+        if (parkId === DISCOVERY_COVE) {
+          throw new Error('Request failed with status code 403');
+        }
+        return MOCK_PARK_DETAIL_SWO as any;
+      };
+
+      await expect((park as any).buildEntityList()).rejects.toThrow(/403/);
+    });
+
+    it('buildSchedules still throws when a park fetch fails', async () => {
+      const park = createMockedOrlando();
+      park.getParkDetail = async (parkId: string) => {
+        if (parkId === DISCOVERY_COVE) {
+          throw new Error('Request failed with status code 403');
+        }
+        return MOCK_PARK_DETAIL_SWO as any;
+      };
+
+      await expect((park as any).buildSchedules()).rejects.toThrow(/403/);
+    });
+  });
+
   describe('buildSchedules', () => {
     it('returns schedule for each park with open_hours', async () => {
       const park = createMockedOrlando();

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -274,6 +274,13 @@ export class SeaworldDestination extends Destination {
     entities.push(...await this.getDestinations());
 
     // Parks, Attractions, Shows, Restaurants
+    //
+    // Deliberately NOT wrapped in a per-park try/catch (unlike buildLiveData).
+    // The collector diffs this list against the live API and issues
+    // `DELETE v1/entity/<id>` for anything present remotely but missing here.
+    // Swallowing a fetch failure would emit a partial list and delete every
+    // entity of the failed park from the wiki — far worse than the outage it
+    // would be papering over. Throwing aborts the sync and changes nothing.
     for (const parkId of this.resortIds) {
       const parkDetail = await this.getParkDetail(parkId);
 
@@ -383,7 +390,27 @@ export class SeaworldDestination extends Destination {
     };
 
     for (const parkId of this.resortIds) {
-      const availability = await this.getAvailability(parkId, searchDate);
+      // Isolate per-park failures. Every park in this destination shares one
+      // upstream, so an unguarded throw here loses live data for the whole
+      // family: a single 403 on Discovery Cove would take SeaWorld Orlando and
+      // Aquatica down with it. src/http.ts treats 4xx as non-retryable
+      // (correctly — a rejection is definitive, and retrying a bot-protection
+      // block in-cycle just adds load), so the throw arrives immediately.
+      // Skipping omits this park's rows for this cycle only; the next cycle
+      // retries from scratch. Sibling parks keep reporting.
+      //
+      // buildEntityList/buildSchedules deliberately do NOT do this — see the
+      // comment on their loops.
+      let availability: SeaworldAvailabilityResponse;
+      try {
+        availability = await this.getAvailability(parkId, searchDate);
+      } catch (err: any) {
+        console.warn(
+          `[${this.constructor.name}] live data unavailable for park ${parkId}, ` +
+          `skipping it this cycle: ${err?.message ?? err}`
+        );
+        continue;
+      }
 
       // --- Wait times ---
       for (const wt of (availability.WaitTimes || [])) {
@@ -457,6 +484,11 @@ export class SeaworldDestination extends Destination {
   protected async buildSchedules(): Promise<EntitySchedule[]> {
     const schedules: EntitySchedule[] = [];
 
+    // Also deliberately un-isolated, for the same reason as buildEntityList:
+    // a partial schedule set silently drops a park's operating hours rather
+    // than reporting them as unknown. Both loops read the same 12h-cached
+    // getParkDetail, so a transient upstream failure is usually absorbed by
+    // the cache before it ever reaches here.
     for (const parkId of this.resortIds) {
       const parkDetail = await this.getParkDetail(parkId);
       if (!parkDetail.open_hours || parkDetail.open_hours.length === 0) continue;


### PR DESCRIPTION
## Problem

Every park in a SeaWorld destination shares one upstream API. `buildLiveData` awaited each park's availability unguarded:

```ts
for (const parkId of this.resortIds) {
  const availability = await this.getAvailability(parkId, searchDate);
```

`src/http.ts:909` classifies 4xx as non-retryable, correctly, so a rejection for one park UUID arrives immediately, rejects the whole method, and the destination emits **no live data at all**. A 403 on Discovery Cove alone drops SeaWorld Orlando and Aquatica with it.

That turns a partial, single-park upstream problem into a whole-family outage.

## Fix

Catch per park in `buildLiveData` and skip that park for the cycle. Siblings keep reporting; the failed park retries from scratch next cycle. If every park fails the result is an empty list rather than a throw, since inventing a `CLOSED` status for a park we cannot see would push made-up state downstream.

## Deliberate asymmetry

`buildEntityList` and `buildSchedules` keep throwing, and now say so in a comment. Consumers diff the entity list and remove entities absent from it, so swallowing a failure there would delete the failed park's entities outright. Aborting the sync changes nothing, which is the safer failure. Two of the new tests assert this stays true.

## Tests

Four regression tests. The two `buildLiveData` ones fail without the source change and pass with it:

```
× still returns sibling park live data when one park 403s
× returns an empty list rather than throwing when every park 403s
```

Full suite: 92 files, 1982 tests passing. Harness `npm run dev` green 4/4 on all seven destinations (Orlando, San Antonio, San Diego, Busch Gardens Tampa + Williamsburg, Sesame Place Philadelphia + San Diego).