### PR TITLE
fix(seaworld): stop publishing unmeasured rides as CLOSED

### DIFF
--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -102,14 +102,25 @@ const MOCK_PARK_DETAIL_SWO = {
   ],
 };
 
+// Field shapes here mirror real captured payloads. The three wait-time states
+// the feed actually uses are all represented:
+//   Status non-empty          -> genuinely closed
+//   Minutes >= 0              -> operating with a reading
+//   Minutes < 0, Status empty -> no current reading (the common case, 45% of
+//                                observations across a 41-round census)
 const MOCK_AVAILABILITY_SWO = {
   WaitTimes: [
     // Normal wait time
     {Id: 'ride-001', Minutes: 30, Status: '', StatusDisplay: null, Title: 'Ice Breaker', LastUpDateTime: '2026-04-01T10:00:00Z'},
-    // Closed ride (negative minutes)
-    {Id: 'ride-002', Minutes: -1, Status: '', StatusDisplay: null, Title: 'Closed Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    // No current reading: -1 sentinel with a blank status. NOT a closure.
+    {Id: 'ride-002', Minutes: -1, Status: '', StatusDisplay: null, Title: 'Unmeasured Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
     // Zero wait time (walk-on)
     {Id: 'ride-003', Minutes: 0, Status: '', StatusDisplay: null, Title: 'Walk On Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    // Genuinely closed, with the closure reason in both status fields
+    {Id: 'ride-004', Minutes: -1, Status: 'Closed Temporarily', StatusDisplay: 'Closed Temporarily', Title: 'Closed Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    // Closure string that did not exist when this park was first implemented —
+    // guards against anyone reintroducing a hardcoded list of known strings
+    {Id: 'ride-005', Minutes: -1, Status: 'Closed Due To Weather', StatusDisplay: 'Closed Due To Weather', Title: 'Weathered Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
   ],
   ShowTimes: [
     // Show with actual times
@@ -128,6 +139,37 @@ const MOCK_AVAILABILITY_SWO = {
     {Id: 'show-002', ShowTimes: []},
   ],
 };
+
+// ---------------------------------------------------------------------------
+// Operating-hours helpers
+//
+// An unmeasured ride is read as open or closed depending on whether the park is
+// currently operating, so tests that exercise that path must pin the hours
+// rather than inherit the fixture's fixed April dates.
+// ---------------------------------------------------------------------------
+
+/**
+ * Wall-clock string in the park's timezone, offset by `hours` from now.
+ * open_hours values are "fake UTC" (local wall time carrying a Z), which is
+ * what localFromFakeUtc expects.
+ */
+function localWallTime(hours: number, timeZone = 'America/New_York'): string {
+  const t = new Date(Date.now() + hours * 3600 * 1000);
+  const p = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false,
+  }).formatToParts(t).reduce((acc: any, part) => (acc[part.type] = part.value, acc), {});
+  return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}:${p.second}.0000000Z`;
+}
+
+/** open_hours that bracket the current moment (park open) or sit in the past. */
+function openHours(open: boolean) {
+  return open
+    ? [{opens_at: localWallTime(-1), closes_at: localWallTime(1), date: 'today'}]
+    : [{opens_at: '2020-01-01T09:00:00.0000000Z', closes_at: '2020-01-01T17:00:00.0000000Z', date: 'past'}];
+}
 
 // ---------------------------------------------------------------------------
 // Helper to create an instance with mocked HTTP
@@ -320,12 +362,38 @@ describe('SeaworldOrlando', () => {
       expect(ride001.queue?.STANDBY?.waitTime).toBe(30);
     });
 
-    it('marks rides with negative minutes as CLOSED', async () => {
+    it('treats a -1 with blank status as "no reading", not a closure', async () => {
       const park = createMockedOrlando();
+      // Pin the park open: the no-reading state is read against operating hours.
+      const detail = (park as any).getParkDetail;
+      (park as any).getParkDetail = async (id: string) => ({
+        ...(await detail(id)), open_hours: openHours(true),
+      });
       const liveData = await (park as any).buildLiveData();
       const ride002 = liveData.find((ld: any) => ld.id === 'ride-002');
       expect(ride002).toBeDefined();
-      expect(ride002.status).toBe('CLOSED');
+      // The ride is open, we simply have no wait time for it. Publishing CLOSED
+      // here mislabelled 59 of 122 rides family-wide and, worse, meant a ride
+      // already showing CLOSED produced no visible change when it really closed.
+      expect(ride002.status).toBe('OPERATING');
+      expect(ride002.queue?.STANDBY?.waitTime).toBeNull();
+    });
+
+    it('marks a ride carrying a closure status as CLOSED', async () => {
+      const park = createMockedOrlando();
+      const liveData = await (park as any).buildLiveData();
+      const ride004 = liveData.find((ld: any) => ld.id === 'ride-004');
+      expect(ride004).toBeDefined();
+      expect(ride004.status).toBe('CLOSED');
+      expect(ride004.queue?.STANDBY?.waitTime).toBeNull();
+    });
+
+    it('honours a closure string it has never seen before', async () => {
+      const park = createMockedOrlando();
+      const liveData = await (park as any).buildLiveData();
+      const ride005 = liveData.find((ld: any) => ld.id === 'ride-005');
+      expect(ride005).toBeDefined();
+      expect(ride005.status).toBe('CLOSED');
     });
 
     it('handles zero wait time (walk-on) as OPERATING', async () => {
@@ -366,6 +434,164 @@ describe('SeaworldOrlando', () => {
       expect(show001.showtimes[0].startTime).toMatch(/^2026-04-01T12:00:00/);
       expect(show001.showtimes[0].startTime).toContain('-04:00');
       expect(show001.showtimes[0].type).toBe('Performance');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: the three wait-time states must stay distinct.
+  //
+  // Sequences below are taken verbatim from a 41-round census (5207 observations,
+  // 2026-08-15). They are the real transitions the feed produced, not invented
+  // shapes.
+  // -------------------------------------------------------------------------
+  describe('wait-time state semantics', () => {
+    function availabilityWith(waitTimes: any[]) {
+      return {WaitTimes: waitTimes, ShowTimes: []};
+    }
+
+    /**
+     * `open` controls whether now falls inside published operating hours, which
+     * is what decides how an unmeasured ride is read.
+     */
+    function parkReturning(waitTimes: any[], open = true) {
+      const park = createMockedOrlando();
+      (park as any).getAvailability = async () => availabilityWith(waitTimes) as any;
+      (park as any).getParkDetail = async () => ({
+        ...MOCK_PARK_DETAIL_SWO,
+        open_hours: openHours(open),
+      }) as any;
+      return park;
+    }
+
+    // Observed: Elmo's Choo Choo Train, Slimey's Slider and Sunny Day Carousel
+    // each ran norecord (18:30Z) -> Closed Due To Weather (20:41Z) -> 0 min
+    // (21:52Z). The same ride is unmeasured, then closed, then reporting — so
+    // the states are distinct and none of them is a permanent ride property.
+    const OBSERVED_SEQUENCE = [
+      {
+        label: 'no reading',
+        row: {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'Sunny Day Carousel', LastUpDateTime: 'x'},
+        expected: {status: 'OPERATING', waitTime: null},
+      },
+      {
+        label: 'weather closure',
+        row: {Id: 'r', Minutes: -1, Status: 'Closed Due To Weather', StatusDisplay: 'Closed Due To Weather', Title: 'Sunny Day Carousel', LastUpDateTime: 'x'},
+        expected: {status: 'CLOSED', waitTime: null},
+      },
+      {
+        label: 'reporting a walk-on',
+        row: {Id: 'r', Minutes: 0, Status: '', StatusDisplay: null, Title: 'Sunny Day Carousel', LastUpDateTime: 'x'},
+        expected: {status: 'OPERATING', waitTime: 0},
+      },
+    ];
+
+    for (const step of OBSERVED_SEQUENCE) {
+      it(`maps the observed "${step.label}" state correctly`, async () => {
+        const park = parkReturning([step.row]);
+        const liveData = await (park as any).buildLiveData();
+        const row = liveData.find((ld: any) => ld.id === 'r');
+        expect(row.status).toBe(step.expected.status);
+        expect(row.queue?.STANDBY?.waitTime).toBe(step.expected.waitTime);
+      });
+    }
+
+    it('distinguishes a real closure from an absent reading on the same payload', async () => {
+      // Busch Gardens Tampa is the stress case: 10 genuine closures sitting
+      // beside 12 rides with no reading in a single response.
+      const park = parkReturning([
+        {Id: 'closed', Minutes: -1, Status: 'Closed For The Day', StatusDisplay: 'Closed For The Day', Title: 'A', LastUpDateTime: 'x'},
+        {Id: 'noreading', Minutes: -1, Status: '', StatusDisplay: null, Title: 'B', LastUpDateTime: 'x'},
+      ]);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'closed').status).toBe('CLOSED');
+      expect(liveData.find((ld: any) => ld.id === 'noreading').status).toBe('OPERATING');
+    });
+
+    it('reads the closure from StatusDisplay when Status is blank', async () => {
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: '', StatusDisplay: 'Closed Temporarily', Title: 'A', LastUpDateTime: 'x'},
+      ]);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('reports unmeasured rides as CLOSED once the park has shut', async () => {
+      // Overnight the feed drops every ride to "no reading" and strips all
+      // closure markers — a 02:16 local sample had all 17 SeaWorld Orlando
+      // rides in that state. Without the operating-hours check this published
+      // a shut park's whole ride list as OPERATING all night.
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('CLOSED');
+      expect(row.queue?.STANDBY?.waitTime).toBeNull();
+    });
+
+    it('still reports a real wait time after hours if the feed publishes one', async () => {
+      // Operating hours only arbitrate the no-reading case. An actual number is
+      // evidence in its own right and must not be overridden by the clock.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 20, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('OPERATING');
+      expect(row.queue?.STANDBY?.waitTime).toBe(20);
+    });
+
+    it('falls back to CLOSED when operating hours cannot be determined', async () => {
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ]);
+      (park as any).getParkDetail = async () => {
+        throw new Error('park detail unavailable');
+      };
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      // Conservative: never claim OPERATING on a guess.
+      expect(row.status).toBe('CLOSED');
+    });
+
+    it('keeps live data when only the park detail fetch fails', async () => {
+      // The hours lookup must not cost us the availability data we already have.
+      const park = parkReturning([
+        {Id: 'measured', Minutes: 45, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ]);
+      (park as any).getParkDetail = async () => {
+        throw new Error('park detail unavailable');
+      };
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'measured')?.queue?.STANDBY?.waitTime).toBe(45);
+    });
+
+    it('does not let a ride fall through to the CLOSED default', async () => {
+      // getOrCreate seeds new entries as CLOSED. A missing Minutes field must
+      // still be classified explicitly rather than inheriting that default.
+      const park = parkReturning([
+        {Id: 'r', Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'} as any,
+      ]);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('OPERATING');
+      expect(row.queue?.STANDBY?.waitTime).toBeNull();
+    });
+
+    it('never emits a bare waitTime of undefined', async () => {
+      // `{waitTime: undefined}` serialises to `"STANDBY": {}`, which says
+      // nothing. Every branch must produce an explicit number or null.
+      const park = parkReturning([
+        {Id: 'a', Minutes: 15, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+        {Id: 'b', Minutes: -1, Status: '', StatusDisplay: null, Title: 'B', LastUpDateTime: 'x'},
+        {Id: 'c', Minutes: -1, Status: 'Closed Temporarily', StatusDisplay: 'Closed Temporarily', Title: 'C', LastUpDateTime: 'x'},
+      ]);
+      const liveData = await (park as any).buildLiveData();
+      for (const row of liveData) {
+        if (!row.queue?.STANDBY) continue;
+        expect(row.queue.STANDBY).toHaveProperty('waitTime');
+        expect(row.queue.STANDBY.waitTime).not.toBeUndefined();
+      }
     });
   });
 

--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -369,6 +369,80 @@ describe('SeaworldOrlando', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Regression: upstream 403 on one park UUID must not take its siblings down.
+  //
+  // All three Orlando parks share one upstream. src/http.ts treats 4xx as
+  // non-retryable, so a bot-protection block rejects immediately; before the
+  // fix the unguarded `await` in the resortIds loop propagated that rejection
+  // and buildLiveData() emitted nothing for the entire destination.
+  // -------------------------------------------------------------------------
+  describe('per-park failure isolation', () => {
+    const DISCOVERY_COVE = '1FB04DFC-B6C0-4918-BE36-EE6DD14FE741';
+
+    // Reject for one park UUID only; the others keep serving the fixture.
+    function failOnePark(park: any, failingParkId: string) {
+      park.getAvailability = async (parkId: string) => {
+        if (parkId === failingParkId) {
+          throw new Error('Request failed with status code 403');
+        }
+        return MOCK_AVAILABILITY_SWO as any;
+      };
+    }
+
+    it('still returns sibling park live data when one park 403s', async () => {
+      const park = createMockedOrlando();
+      failOnePark(park, DISCOVERY_COVE);
+
+      const liveData = await (park as any).buildLiveData();
+
+      // SeaWorld Orlando's own rides must still report.
+      const ride001 = liveData.find((ld: any) => ld.id === 'ride-001');
+      expect(ride001).toBeDefined();
+      expect(ride001.status).toBe('OPERATING');
+      expect(ride001.queue.STANDBY.waitTime).toBe(30);
+    });
+
+    it('returns an empty list rather than throwing when every park 403s', async () => {
+      const park = createMockedOrlando();
+      park.getAvailability = async () => {
+        throw new Error('Request failed with status code 403');
+      };
+
+      // No rows is correct here: emitting a fabricated CLOSED for a park we
+      // cannot see would push invented state to the wiki.
+      await expect((park as any).buildLiveData()).resolves.toEqual([]);
+    });
+
+    // The next two guard the deliberate asymmetry. The collector diffs the
+    // entity list and issues DELETE v1/entity/<id> for anything missing, so
+    // swallowing a failure here would delete the failed park's entities from
+    // the wiki. These must keep throwing.
+    it('buildEntityList still throws when a park fetch fails', async () => {
+      const park = createMockedOrlando();
+      park.getParkDetail = async (parkId: string) => {
+        if (parkId === DISCOVERY_COVE) {
+          throw new Error('Request failed with status code 403');
+        }
+        return MOCK_PARK_DETAIL_SWO as any;
+      };
+
+      await expect((park as any).buildEntityList()).rejects.toThrow(/403/);
+    });
+
+    it('buildSchedules still throws when a park fetch fails', async () => {
+      const park = createMockedOrlando();
+      park.getParkDetail = async (parkId: string) => {
+        if (parkId === DISCOVERY_COVE) {
+          throw new Error('Request failed with status code 403');
+        }
+        return MOCK_PARK_DETAIL_SWO as any;
+      };
+
+      await expect((park as any).buildSchedules()).rejects.toThrow(/403/);
+    });
+  });
+
   describe('buildSchedules', () => {
     it('returns schedule for each park with open_hours', async () => {
       const park = createMockedOrlando();

--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -102,20 +102,21 @@ const MOCK_PARK_DETAIL_SWO = {
   ],
 };
 
-// Field shapes here mirror real captured payloads. The three wait-time states
-// the feed actually uses are all represented:
-//   Status non-empty          -> genuinely closed
-//   Minutes >= 0              -> operating with a reading
-//   Minutes < 0, Status empty -> no current reading (the common case, 45% of
-//                                observations across a 41-round census)
+// Field shapes match the five combinations seen across a 41-round census
+// (5002 observations, 2026-08-15). Note measured rows carry StatusDisplay: ''
+// while no-reading rows carry null — the API distinguishes them, so the
+// fixture does too:
+//   Status non-empty          -> genuinely closed        (842 obs)
+//   Minutes >= 0, Display ''  -> operating with a reading (1890 obs)
+//   Minutes < 0, Display null -> no current reading       (2270 obs, 45%)
 const MOCK_AVAILABILITY_SWO = {
   WaitTimes: [
     // Normal wait time
-    {Id: 'ride-001', Minutes: 30, Status: '', StatusDisplay: null, Title: 'Ice Breaker', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-001', Minutes: 30, Status: '', StatusDisplay: '', Title: 'Ice Breaker', LastUpDateTime: '2026-04-01T10:00:00Z'},
     // No current reading: -1 sentinel with a blank status. NOT a closure.
     {Id: 'ride-002', Minutes: -1, Status: '', StatusDisplay: null, Title: 'Unmeasured Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
     // Zero wait time (walk-on)
-    {Id: 'ride-003', Minutes: 0, Status: '', StatusDisplay: null, Title: 'Walk On Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-003', Minutes: 0, Status: '', StatusDisplay: '', Title: 'Walk On Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
     // Genuinely closed, with the closure reason in both status fields
     {Id: 'ride-004', Minutes: -1, Status: 'Closed Temporarily', StatusDisplay: 'Closed Temporarily', Title: 'Closed Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
     // Closure string that did not exist when this park was first implemented —
@@ -143,32 +144,27 @@ const MOCK_AVAILABILITY_SWO = {
 // ---------------------------------------------------------------------------
 // Operating-hours helpers
 //
-// An unmeasured ride is read as open or closed depending on whether the park is
-// currently operating, so tests that exercise that path must pin the hours
-// rather than inherit the fixture's fixed April dates.
+// An unmeasured ride reads as open or closed depending on whether the park is
+// operating, so those tests pin BOTH the hours and the clock. An earlier
+// version derived the window from Date.now(), which failed for the 60 minutes
+// of the DST fall-back when the ambiguous wall clock resolved to the earlier
+// offset and the window stopped bracketing now. Gate tests must never be flaky,
+// so the clock is injected instead.
 // ---------------------------------------------------------------------------
 
-/**
- * Wall-clock string in the park's timezone, offset by `hours` from now.
- * open_hours values are "fake UTC" (local wall time carrying a Z), which is
- * what localFromFakeUtc expects.
- */
-function localWallTime(hours: number, timeZone = 'America/New_York'): string {
-  const t = new Date(Date.now() + hours * 3600 * 1000);
-  const p = new Intl.DateTimeFormat('en-CA', {
-    timeZone,
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
-    hour12: false,
-  }).formatToParts(t).reduce((acc: any, part) => (acc[part.type] = part.value, acc), {});
-  return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}:${p.second}.0000000Z`;
-}
+/** Local 09:00-21:00 on 2026-08-15, in "fake UTC" (local wall time with a Z). */
+const HOURS_TODAY = [
+  {opens_at: '2026-08-15T09:00:00.0000000Z', closes_at: '2026-08-15T21:00:00.0000000Z', date: '08/15/2026'},
+];
 
-/** open_hours that bracket the current moment (park open) or sit in the past. */
-function openHours(open: boolean) {
-  return open
-    ? [{opens_at: localWallTime(-1), closes_at: localWallTime(1), date: 'today'}]
-    : [{opens_at: '2020-01-01T09:00:00.0000000Z', closes_at: '2020-01-01T17:00:00.0000000Z', date: 'past'}];
+/** 14:00 America/New_York — inside HOURS_TODAY. */
+const CLOCK_PARK_OPEN = new Date('2026-08-15T18:00:00Z');
+/** 08:00 America/New_York, same local day — before opening, so hours for today exist. */
+const CLOCK_PARK_SHUT = new Date('2026-08-15T12:00:00Z');
+
+function pinClock(at: Date) {
+  vi.useFakeTimers({toFake: ['Date']});
+  vi.setSystemTime(at);
 }
 
 // ---------------------------------------------------------------------------
@@ -200,9 +196,15 @@ function createMockedOrlando() {
     } as any;
   };
 
-  // Mock getAvailability
-  park.getAvailability = async (_parkId: string, _searchDate: string) => {
-    return MOCK_AVAILABILITY_SWO as any;
+  // Mock getAvailability, per park. Returning the SWO fixture for every resort
+  // id (as this used to) made the wait-time rows get processed three times, and
+  // the last park's verdict overwrote the first two. That silently defanged the
+  // closure tests: deleting closure detection entirely still left them green,
+  // because they were really asserting Discovery Cove's no-hours fallback.
+  // The real feed returns each park's own rides, so mirror that.
+  park.getAvailability = async (parkId: string, _searchDate: string) => {
+    if (parkId === MOCK_PARK_ID_SWO) return MOCK_AVAILABILITY_SWO as any;
+    return {WaitTimes: [], ShowTimes: []} as any;
   };
 
   return park;
@@ -363,17 +365,19 @@ describe('SeaworldOrlando', () => {
     });
 
     it('treats a -1 with blank status as "no reading", not a closure', async () => {
-      const park = createMockedOrlando();
       // Pin the park open: the no-reading state is read against operating hours.
+      pinClock(CLOCK_PARK_OPEN);
+      const park = createMockedOrlando();
       const detail = (park as any).getParkDetail;
       (park as any).getParkDetail = async (id: string) => ({
-        ...(await detail(id)), open_hours: openHours(true),
+        ...(await detail(id)), open_hours: HOURS_TODAY,
       });
       const liveData = await (park as any).buildLiveData();
       const ride002 = liveData.find((ld: any) => ld.id === 'ride-002');
       expect(ride002).toBeDefined();
       // The ride is open, we simply have no wait time for it. Publishing CLOSED
-      // here mislabelled 59 of 122 rides family-wide and, worse, meant a ride
+      // here mislabelled 59 of 122 rides in a sampled round family-wide and,
+      // worse, meant a ride
       // already showing CLOSED produced no visible change when it really closed.
       expect(ride002.status).toBe('OPERATING');
       expect(ride002.queue?.STANDBY?.waitTime).toBeNull();
@@ -440,25 +444,33 @@ describe('SeaworldOrlando', () => {
   // -------------------------------------------------------------------------
   // Regression: the three wait-time states must stay distinct.
   //
-  // Sequences below are taken verbatim from a 41-round census (5207 observations,
-  // 2026-08-15). They are the real transitions the feed produced, not invented
-  // shapes.
+  // OBSERVED_SEQUENCE below is a real transition from a 41-round census (5002
+  // observations, 2026-08-15). Other rows in this block are deliberately
+  // defensive shapes that the census never produced (blank Status with only
+  // StatusDisplay set, a missing Minutes field, whitespace) — they pin
+  // behaviour the code claims to have rather than behaviour the feed exhibits.
   // -------------------------------------------------------------------------
   describe('wait-time state semantics', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     function availabilityWith(waitTimes: any[]) {
       return {WaitTimes: waitTimes, ShowTimes: []};
     }
 
     /**
-     * `open` controls whether now falls inside published operating hours, which
-     * is what decides how an unmeasured ride is read.
+     * `open` controls whether the pinned clock falls inside published operating
+     * hours, which is what decides how an unmeasured ride is read. `hours` lets
+     * a test supply its own blocks (events, corrupt spans).
      */
-    function parkReturning(waitTimes: any[], open = true) {
+    function parkReturning(waitTimes: any[], open = true, hours: any[] = HOURS_TODAY) {
+      pinClock(open ? CLOCK_PARK_OPEN : CLOCK_PARK_SHUT);
       const park = createMockedOrlando();
       (park as any).getAvailability = async () => availabilityWith(waitTimes) as any;
       (park as any).getParkDetail = async () => ({
         ...MOCK_PARK_DETAIL_SWO,
-        open_hours: openHours(open),
+        open_hours: hours,
       }) as any;
       return park;
     }
@@ -576,6 +588,134 @@ describe('SeaworldOrlando', () => {
       const row = liveData.find((ld: any) => ld.id === 'r');
       expect(row.status).toBe('OPERATING');
       expect(row.queue?.STANDBY?.waitTime).toBeNull();
+    });
+
+    // The following pin behaviours that survived deliberate mutation of the
+    // implementation, i.e. the code could be broken in these specific ways with
+    // the rest of the suite still green.
+
+    it('closes on Status alone, while the park is open', async () => {
+      // Status carries the closure in 100% of real observations, yet ignoring
+      // it entirely used to pass. Park pinned OPEN so the hours fallback cannot
+      // produce the CLOSED verdict for us.
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: 'Closed For The Day', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], true);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('closes on an unseen closure string, while the park is open', async () => {
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: 'Closed For Private Event', StatusDisplay: 'Closed For Private Event', Title: 'A', LastUpDateTime: 'x'},
+      ], true);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('treats a whitespace-only Status as no reading, not a closure', async () => {
+      // '   ' is truthy, so `Status || StatusDisplay` would pick it and then
+      // trim to empty, throwing away a real closure. Each field is trimmed
+      // separately for this reason.
+      const park = parkReturning([
+        {Id: 'blank', Minutes: -1, Status: '   ', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+        {Id: 'real', Minutes: -1, Status: '   ', StatusDisplay: 'Closed Temporarily', Title: 'B', LastUpDateTime: 'x'},
+      ], true);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'blank').status).toBe('OPERATING');
+      expect(liveData.find((ld: any) => ld.id === 'real').status).toBe('CLOSED');
+    });
+
+    it('does not throw the whole destination on a non-string Status', async () => {
+      // This loop runs outside the per-park try, so a TypeError here would take
+      // down every park in the destination and undo #312's isolation.
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: 5 as any, StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], true);
+      await expect((park as any).buildLiveData()).resolves.toBeInstanceOf(Array);
+    });
+
+    it('does not invent a walk-on from a null or empty Minutes', async () => {
+      // Number(null) and Number('') are both 0, which is finite and >= 0.
+      const park = parkReturning([
+        {Id: 'nul', Minutes: null as any, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+        {Id: 'empty', Minutes: '' as any, Status: '', StatusDisplay: null, Title: 'B', LastUpDateTime: 'x'},
+      ], true);
+      const liveData = await (park as any).buildLiveData();
+      for (const id of ['nul', 'empty']) {
+        expect(liveData.find((ld: any) => ld.id === id).queue?.STANDBY?.waitTime).toBeNull();
+      }
+    });
+
+    it('honours an evening event block, not just the first block of the day', async () => {
+      // Real event-day shape: daytime session already over, ticketed evening
+      // session in progress. Only considering open_hours[0] would report closed.
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], true, [
+        {opens_at: '2026-08-15T09:00:00.0000000Z', closes_at: '2026-08-15T13:00:00.0000000Z', date: '08/15/2026'},
+        {opens_at: '2026-08-15T13:30:00.0000000Z', closes_at: '2026-08-15T23:00:00.0000000Z', date: '08/15/2026'},
+      ]);
+      // Clock is 14:00 local, inside the SECOND block only.
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('OPERATING');
+    });
+
+    it('applies the >25h glitch guard so a mis-dated close does not hold the park open', async () => {
+      // closes_at dated a day late yields a ~34h span. Ungurarded, the park
+      // reads open right through the night and every unmeasured ride flips to
+      // OPERATING. Clock is 08:00 local, before the 09:00 open.
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], false, [
+        {opens_at: '2026-08-14T09:00:00.0000000Z', closes_at: '2026-08-15T19:00:00.0000000Z', date: '08/14/2026'},
+      ]);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('does not report open for an inverted block whose close precedes its open', async () => {
+      const park = parkReturning([
+        {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], true, [
+        {opens_at: '2026-08-15T09:00:00.0000000Z', closes_at: '2026-08-14T21:00:00.0000000Z', date: '08/15/2026'},
+      ]);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('treats the opening instant as open and the closing instant as shut', async () => {
+      const row = {Id: 'r', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'};
+      // Exactly 09:00 local = 13:00Z.
+      vi.useFakeTimers({toFake: ['Date']});
+      vi.setSystemTime(new Date('2026-08-15T13:00:00Z'));
+      let park = createMockedOrlando();
+      (park as any).getAvailability = async () => availabilityWith([row]) as any;
+      (park as any).getParkDetail = async () => ({...MOCK_PARK_DETAIL_SWO, open_hours: HOURS_TODAY}) as any;
+      let liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('OPERATING');
+
+      // Exactly 21:00 local = 01:00Z next day.
+      vi.setSystemTime(new Date('2026-08-16T01:00:00Z'));
+      park = createMockedOrlando();
+      (park as any).getAvailability = async () => availabilityWith([row]) as any;
+      (park as any).getParkDetail = async () => ({...MOCK_PARK_DETAIL_SWO, open_hours: HOURS_TODAY}) as any;
+      liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('survives sanitisation on the public getLiveData path', async () => {
+      // Every other assertion here reads buildLiveData() output, before the base
+      // class sanitises and strips undefined. The null-vs-undefined argument is
+      // about what actually reaches consumers, so check the public path too.
+      const park = parkReturning([
+        {Id: 'ride-001', Minutes: -1, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+      ], true);
+      const liveData = await park.getLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'ride-001');
+      expect(row).toBeDefined();
+      expect(row!.queue?.STANDBY).toHaveProperty('waitTime');
+      expect(row!.queue?.STANDBY?.waitTime).toBeNull();
     });
 
     it('never emits a bare waitTime of undefined', async () => {

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -274,6 +274,13 @@ export class SeaworldDestination extends Destination {
     entities.push(...await this.getDestinations());
 
     // Parks, Attractions, Shows, Restaurants
+    //
+    // Deliberately NOT wrapped in a per-park try/catch (unlike buildLiveData).
+    // The collector diffs this list against the live API and issues
+    // `DELETE v1/entity/<id>` for anything present remotely but missing here.
+    // Swallowing a fetch failure would emit a partial list and delete every
+    // entity of the failed park from the wiki — far worse than the outage it
+    // would be papering over. Throwing aborts the sync and changes nothing.
     for (const parkId of this.resortIds) {
       const parkDetail = await this.getParkDetail(parkId);
 
@@ -383,7 +390,27 @@ export class SeaworldDestination extends Destination {
     };
 
     for (const parkId of this.resortIds) {
-      const availability = await this.getAvailability(parkId, searchDate);
+      // Isolate per-park failures. Every park in this destination shares one
+      // upstream, so an unguarded throw here loses live data for the whole
+      // family: a single 403 on Discovery Cove would take SeaWorld Orlando and
+      // Aquatica down with it. src/http.ts treats 4xx as non-retryable
+      // (correctly — a rejection is definitive, and retrying a bot-protection
+      // block in-cycle just adds load), so the throw arrives immediately.
+      // Skipping omits this park's rows for this cycle only; the next cycle
+      // retries from scratch. Sibling parks keep reporting.
+      //
+      // buildEntityList/buildSchedules deliberately do NOT do this — see the
+      // comment on their loops.
+      let availability: SeaworldAvailabilityResponse;
+      try {
+        availability = await this.getAvailability(parkId, searchDate);
+      } catch (err: any) {
+        console.warn(
+          `[${this.constructor.name}] live data unavailable for park ${parkId}, ` +
+          `skipping it this cycle: ${err?.message ?? err}`
+        );
+        continue;
+      }
 
       // --- Wait times ---
       for (const wt of (availability.WaitTimes || [])) {
@@ -457,6 +484,11 @@ export class SeaworldDestination extends Destination {
   protected async buildSchedules(): Promise<EntitySchedule[]> {
     const schedules: EntitySchedule[] = [];
 
+    // Also deliberately un-isolated, for the same reason as buildEntityList:
+    // a partial schedule set silently drops a park's operating hours rather
+    // than reporting them as unknown. Both loops read the same 12h-cached
+    // getParkDetail, so a transient upstream failure is usually absorbed by
+    // the cache before it ever reaches here.
     for (const parkId of this.resortIds) {
       const parkDetail = await this.getParkDetail(parkId);
       if (!parkDetail.open_hours || parkDetail.open_hours.length === 0) continue;

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -231,6 +231,42 @@ export class SeaworldDestination extends Destination {
     return new Date().toISOString().slice(0, 10);
   }
 
+  /**
+   * Is this park within its published operating hours right now?
+   *
+   * Needed because the feed's "no reading" state (Minutes < 0 with a blank
+   * Status) carries no information about whether a ride is running, and the
+   * right reading flips with the clock. Overnight the feed drops EVERY ride to
+   * that state with no closure marker at all — a 02:16 local sample had all 17
+   * SeaWorld Orlando rides there — so treating it as OPERATING unconditionally
+   * would show a shut park's rides as open all night.
+   *
+   * Returns null when the answer cannot be determined (no hours published, or
+   * the park detail fetch failed); callers fall back to the conservative
+   * reading rather than guessing.
+   */
+  private isParkOpenNow(parkDetail: SeaworldParkDetail): boolean | null {
+    if (!parkDetail?.open_hours || parkDetail.open_hours.length === 0) return null;
+
+    const now = Date.now();
+    for (const oh of parkDetail.open_hours) {
+      const openingTime = localFromFakeUtc(oh.opens_at, this.timezone);
+      let closingTime = localFromFakeUtc(oh.closes_at, this.timezone);
+      // Same source-glitch guard as buildSchedules: a closes_at dated a day
+      // late produces an impossible 34-35h span, which would otherwise report
+      // the park open right through the night.
+      if (new Date(closingTime).getTime() - new Date(openingTime).getTime() > 25 * 60 * 60 * 1000) {
+        closingTime = rollDateBackOneDay(closingTime);
+      }
+      const open = new Date(openingTime).getTime();
+      const close = new Date(closingTime).getTime();
+      if (Number.isFinite(open) && Number.isFinite(close) && now >= open && now < close) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // -------------------------------------------------------------------------
   // Destination entity (optional override for custom names)
   // -------------------------------------------------------------------------
@@ -380,6 +416,11 @@ export class SeaworldDestination extends Destination {
     const liveDataMap = new Map<string, LiveData>();
     const searchDate = this.getTodayDateString();
 
+    // Note the CLOSED default: it is only ever observable for a SHOW that has
+    // no showtimes today, which is the correct reading for a show. Every
+    // wait-time branch below assigns a status explicitly, so a ride can never
+    // fall through to this default — do not rely on `continue` to leave a ride
+    // unset, as that silently republishes it as CLOSED.
     const getOrCreate = (id: string): LiveData => {
       let entry = liveDataMap.get(id);
       if (!entry) {
@@ -402,8 +443,21 @@ export class SeaworldDestination extends Destination {
       // buildEntityList/buildSchedules deliberately do NOT do this — see the
       // comment on their loops.
       let availability: SeaworldAvailabilityResponse;
+      let parkIsOpen: boolean | null = null;
       try {
         availability = await this.getAvailability(parkId, searchDate);
+        // Operating hours decide how to read the "no reading" state below.
+        // Cached 12h, so this is normally free. A failure here must not cost us
+        // the live data we already have: fall back to parkIsOpen = null, which
+        // takes the conservative branch.
+        try {
+          parkIsOpen = this.isParkOpenNow(await this.getParkDetail(parkId));
+        } catch (err: any) {
+          console.warn(
+            `[${this.constructor.name}] operating hours unavailable for park ${parkId}, ` +
+            `treating unmeasured rides as closed: ${err?.message ?? err}`
+          );
+        }
       } catch (err: any) {
         console.warn(
           `[${this.constructor.name}] live data unavailable for park ${parkId}, ` +
@@ -413,19 +467,57 @@ export class SeaworldDestination extends Destination {
       }
 
       // --- Wait times ---
+      //
+      // The feed carries three states, not two. `Minutes: -1` alone does NOT
+      // mean closed; it is the sentinel for "no value", and `Status` is what
+      // separates a real closure from an absent reading:
+      //
+      //   Status non-empty          -> genuinely closed, text says why
+      //   Minutes >= 0              -> operating, real wait time
+      //   Minutes < 0, Status empty -> upstream has no current reading
+      //
+      // This matches the vendor app's own parser, which discards the entire
+      // wait-time object when minutes are negative AND status is blank
+      // (PoiAvailabilityEntityMapper.checkWaitTimeNull), then renders the ride
+      // normally with no wait badge. It never shows such a ride as closed.
+      //
+      // Mapping the third case to CLOSED (the previous behaviour) was wrong for
+      // 59 of 122 rides family-wide, and it also swallowed real closures: a ride
+      // already published as CLOSED shows no change at the moment it actually
+      // closes, so the event never reaches consumers.
+      //
+      // Test `Status` generically rather than matching known strings. A 41-round
+      // census saw three ("Closed Temporarily", "Closed For The Day", "Closed Due
+      // To Weather"), and the newest was the most frequent — the set is open.
       for (const wt of (availability.WaitTimes || [])) {
         if (!wt.Id) continue;
         const entry = getOrCreate(wt.Id);
 
-        if (wt.Minutes !== undefined) {
-          if (wt.Minutes < 0) {
-            // Negative minutes = closed (e.g. -1 = "Closed Temporarily")
-            entry.status = 'CLOSED';
-            entry.queue = {STANDBY: {waitTime: undefined}};
-          } else {
-            entry.status = 'OPERATING';
-            entry.queue = {STANDBY: {waitTime: wt.Minutes}};
-          }
+        // Either field carries the closure text; StatusDisplay is null when absent.
+        const closureText = (wt.Status || wt.StatusDisplay || '').trim();
+        const minutes = Number(wt.Minutes);
+
+        if (closureText) {
+          entry.status = 'CLOSED';
+          entry.queue = {STANDBY: {waitTime: null}};
+        } else if (Number.isFinite(minutes) && minutes >= 0) {
+          entry.status = 'OPERATING';
+          entry.queue = {STANDBY: {waitTime: minutes}};
+        } else {
+          // No reading available, so the feed tells us nothing about this ride
+          // and the operating hours decide the reading. Open: the ride is
+          // presumed running, we simply have no wait time. Shut (or unknown):
+          // closed, which is also the safe default — overnight every ride lands
+          // here with no closure marker, and claiming OPERATING would show a
+          // shut park as open.
+          //
+          // Either way waitTime is null, never undefined: the queue exists and
+          // does produce values later (observed: rides sat unmeasured for
+          // hours, then reported a real wait), which is exactly the schema's
+          // "queue exists but no current value is available". Omitting `queue`
+          // would instead claim the entity has no queue at all.
+          entry.status = parkIsOpen ? 'OPERATING' : 'CLOSED';
+          entry.queue = {STANDBY: {waitTime: null}};
         }
       }
 
@@ -692,13 +784,16 @@ export class SesamePlacePhiladelphia extends SeaworldDestination {
 /**
  * Sesame Place San Diego
  *
- * Publishes a `WaitTimes` array covering all 7 rides, though a midday sample
- * found every entry at the `Minutes: -1` sentinel. That is not peculiar to this
- * park and is not a reason to treat it differently: the same sample had SeaWorld
- * Orlando at 1 live reading out of 17 rows and Busch Gardens Williamsburg at 10
- * of 33, both long-shipping destinations. The operator uses -1 widely for a ride
- * it is not currently reporting, and the base class maps it to CLOSED, which is
- * the established semantic here rather than a new judgement made for this park.
+ * Publishes a `WaitTimes` array covering all 7 rides. A full operating day of
+ * sampling found every entry at the `Minutes: -1` sentinel with an empty
+ * `Status`, i.e. "no current reading" rather than closed. That is not peculiar
+ * to this park — it is the most common state family-wide (45% of observations)
+ * — but this park is the extreme, being the only one where no ride produced a
+ * reading all day.
+ *
+ * The base class maps that state to OPERATING with a null standby wait time, so
+ * this park correctly shows its rides as open with no wait data, instead of the
+ * seven all-day CLOSED rows it published before.
  */
 @destinationController({category: 'Sesame Place'})
 export class SesamePlaceSanDiego extends SeaworldDestination {

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -241,14 +241,27 @@ export class SeaworldDestination extends Destination {
    * SeaWorld Orlando rides there — so treating it as OPERATING unconditionally
    * would show a shut park's rides as open all night.
    *
-   * Returns null when the answer cannot be determined (no hours published, or
-   * the park detail fetch failed); callers fall back to the conservative
-   * reading rather than guessing.
+   * Every published block counts, including ticketed evening events: the park
+   * is operating for whoever holds that ticket, and a ride running during a
+   * summer-nights session is not closed.
+   *
+   * Returns false when nothing covers the current moment. That is deliberately
+   * indistinguishable from "shut" at the call site, because the conservative
+   * reading is the same either way, but the two cases that are NOT ordinary
+   * closures get a warning so they are visible in logs rather than silently
+   * flipping a park's unmeasured rides to CLOSED at midday.
    */
-  private isParkOpenNow(parkDetail: SeaworldParkDetail): boolean | null {
-    if (!parkDetail?.open_hours || parkDetail.open_hours.length === 0) return null;
+  private isParkOpenNow(parkDetail: SeaworldParkDetail, nowMs: number = Date.now()): boolean {
+    if (!parkDetail?.open_hours || parkDetail.open_hours.length === 0) {
+      console.warn(`[${this.constructor.name}] no operating hours published; treating unmeasured rides as closed`);
+      return false;
+    }
 
-    const now = Date.now();
+    const todayLocal = new Intl.DateTimeFormat('en-CA', {
+      timeZone: this.timezone, year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date(nowMs));
+    let sawToday = false;
+
     for (const oh of parkDetail.open_hours) {
       const openingTime = localFromFakeUtc(oh.opens_at, this.timezone);
       let closingTime = localFromFakeUtc(oh.closes_at, this.timezone);
@@ -260,9 +273,20 @@ export class SeaworldDestination extends Destination {
       }
       const open = new Date(openingTime).getTime();
       const close = new Date(closingTime).getTime();
-      if (Number.isFinite(open) && Number.isFinite(close) && now >= open && now < close) {
-        return true;
-      }
+      if (!Number.isFinite(open) || !Number.isFinite(close)) continue;
+      // No explicit guard for an inverted span (closes_at dated a day early,
+      // the mirror of the >25h case): the half-open test below cannot match an
+      // empty interval, so such a block is skipped naturally. An extra check
+      // would be unreachable by any observable behaviour.
+      if (openingTime.slice(0, 10) === todayLocal) sawToday = true;
+      if (nowMs >= open && nowMs < close) return true;
+    }
+
+    if (!sawToday) {
+      console.warn(
+        `[${this.constructor.name}] operating hours contain no block for ${todayLocal}; ` +
+        `treating unmeasured rides as closed`
+      );
     }
     return false;
   }
@@ -493,9 +517,22 @@ export class SeaworldDestination extends Destination {
         if (!wt.Id) continue;
         const entry = getOrCreate(wt.Id);
 
-        // Either field carries the closure text; StatusDisplay is null when absent.
-        const closureText = (wt.Status || wt.StatusDisplay || '').trim();
-        const minutes = Number(wt.Minutes);
+        // Either field carries the closure text; StatusDisplay is null when
+        // absent. Coerce with String() before trimming: a non-string here would
+        // throw, and this loop sits outside the per-park try above, so one
+        // malformed row would take down every park in the destination and undo
+        // the isolation that block exists to provide.
+        //
+        // Trim each field separately rather than `a || b`. A whitespace-only
+        // Status is truthy, so it would win the || and then trim to empty,
+        // discarding a real closure sitting in StatusDisplay.
+        const closureText = String(wt.Status ?? '').trim() || String(wt.StatusDisplay ?? '').trim();
+
+        // Only trust an actual number. Number() maps null, '', '  ' and [] to 0,
+        // which is finite and >= 0, so coercing here would invent a walk-on out
+        // of an absent field. The base-class sanitiser cannot catch that either,
+        // because 0 is a perfectly valid wait time.
+        const minutes = typeof wt.Minutes === 'number' ? wt.Minutes : NaN;
 
         if (closureText) {
           entry.status = 'CLOSED';

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -261,9 +261,9 @@ export async function testPark(
       }, {} as Record<string, number>);
 
       // Count entries with an actual wait time. `null` is a deliberate value
-      // meaning "queue exists, no current reading" (SeaWorld, SHDR, Universal,
-      // DLP all emit it), so it must not be counted as having a wait time —
-      // otherwise a park where nothing is measured reports 100% coverage.
+      // meaning "queue exists, no current reading" — DLP, Phantasialand and
+      // SeaWorld all emit it on STANDBY — so it must not be counted as having a
+      // wait time, or a park where nothing is measured reports 100% coverage.
       const withWaitTimes = liveData.filter(l => l.queue?.STANDBY?.waitTime != null).length;
 
       const orphanIds = findOrphans(liveData);

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -260,8 +260,11 @@ export async function testPark(
         return acc;
       }, {} as Record<string, number>);
 
-      // Count entries with wait times
-      const withWaitTimes = liveData.filter(l => l.queue?.STANDBY?.waitTime !== undefined).length;
+      // Count entries with an actual wait time. `null` is a deliberate value
+      // meaning "queue exists, no current reading" (SeaWorld, SHDR, Universal,
+      // DLP all emit it), so it must not be counted as having a wait time —
+      // otherwise a park where nothing is measured reports 100% coverage.
+      const withWaitTimes = liveData.filter(l => l.queue?.STANDBY?.waitTime != null).length;
 
       const orphanIds = findOrphans(liveData);
 


### PR DESCRIPTION
> Stacked on #312. Base is `fix/seaworld-per-park-live-isolation`; merge that first and this retargets to main.

## Problem

The availability feed carries **three** wait-time states and we collapsed two of them. `Minutes: -1` is a sentinel for "no value"; `Status` separates a real closure from an absent reading.

| `Status` | `Minutes` | Meaning | We published |
|---|---|---|---|
| empty | `-1` | **no current reading** | ❌ `CLOSED` |
| empty | `>= 0` | operating | ✅ `OPERATING` |
| `Closed Temporarily` / `For The Day` / `Due To Weather` | `-1` | genuinely closed | ✅ `CLOSED` |

59 of 122 rides family-wide were mislabelled while parks were open, including Pantheon and The Big Bad Wolf at Williamsburg. Sesame Place San Diego is the extreme: all 7 rides unmeasured all day, so it published **zero operating attractions every operating day**.

Worse than the mislabelling: it **swallowed real closures**. A ride already showing `CLOSED` produces no visible change at the moment it actually closes, so the event never reaches consumers.

## Ground truth

`PoiAvailabilityEntityMapper.checkWaitTimeNull` in the vendor app (`com.seaworld.mobile`, two builds two months apart) discards the entire wait-time object when minutes are negative **and** status is blank, then renders the ride normally with no wait badge. It never shows such a ride as closed.

## Operating hours are load-bearing

The no-reading state says nothing about the ride, so hours arbitrate it. This is not decoration: **overnight the feed drops every ride into this state and strips all closure markers**. A 02:16 local sample had all 17 SeaWorld Orlando rides there, so without the check a shut park publishes its whole ride list as `OPERATING`.

Failure handling: hours undeterminable falls back to `CLOSED` rather than guessing, and a failed hours lookup never costs us the availability data already fetched. Both are tested.

## null, not undefined or omitted

`waitTime` is now always a number or `null`. Undefined serialised to `"STANDBY": {}`, which says nothing. `null` is the schema's documented *"queue exists but no current value is available"*, and that's accurate: rides sat unmeasured for hours, then reported real waits.

## Generic status matching

A 41-round census saw three closure strings, and `Closed Due To Weather` — absent from the first sample — was the **most frequent** (432 vs 287 vs 123). A hardcoded list would have shipped broken. There's a test asserting an unseen string still closes the ride.

## Evidence

41 rounds, 5207 observations, 12 park UUIDs, zero HTTP errors. Regression tests use observed sequences verbatim, e.g. Sunny Day Carousel: `norecord` 18:30Z → `Closed Due To Weather` 20:41Z → `0 min` 21:52Z.

## Verification

- 8 new tests fail against the old logic, all 59 pass with it
- Full suite 92 files / 1995 tests green
- Harness 4/4 on all 7 destinations. Overnight check at 02:20 ET confirms the hours gating: SWO dropped from 39 OPERATING to 24, Sesame San Diego from 12 to 5. Daytime behaviour is covered by unit tests against captured daytime payloads rather than a live sample, since parks were shut at commit time.
- Blast radius measured, not estimated: nothing outside `src/parks/seaworld/` imports `SeaworldDestination`; shows are on a separate path and unaffected; the 16 rides carrying genuine closure markers stay `CLOSED`.

## Also

`testRunner.ts` counted `waitTime !== undefined`, so `null` registered as a present wait time and a park where nothing is measured reported 100% coverage. Now counts actual values.