### PR TITLE
fix(seaworld): request availability for the park-local date

### DIFF
--- a/.claude/skills/implementing-parks.md
+++ b/.claude/skills/implementing-parks.md
@@ -222,6 +222,26 @@ protected async buildSchedules(): Promise<EntitySchedule[]> {
 }
 ```
 
+**Never derive "today" from `toISOString()`.** That gives the UTC day, which is
+not the park's day for several hours of every evening — 4-7h behind for US
+parks, ahead for Asia-Pacific. A request keyed on it silently asks for the wrong
+date, and only during opening hours, so it looks fine whenever you check it.
+
+```typescript
+// WRONG — UTC day. After 20:00 Eastern this is already tomorrow.
+const today = new Date().toISOString().slice(0, 10);
+
+// RIGHT — the park's own calendar day.
+const today = formatDate(new Date(), this.timezone);
+```
+
+This has been shipped twice (`enchantedparks`, and SeaWorld in #314, where every
+show published the next day's showtimes through the evening event window).
+`src/__tests__/utcDateTrap.test.ts` now fails the build on it. Deliberate UTC
+arithmetic on a date that is *already* a calendar day is fine — anchor at
+`T00:00:00Z`, add days, read it back — and opts out with a `utc-date-ok:`
+comment giving the reason.
+
 ## Validation
 
 ### Health Check

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Gate checks. Deterministic, local, free, and fast enough that nobody wants to
+# skip them — a hook people reach for --no-verify on is worse than no hook.
+#
+# Three layers, roughly 10s total on a typical commit:
+#   1. typecheck        — vitest strips types with esbuild and never typechecks,
+#                         so without this a type error reaches CI unopposed
+#   2. affected tests   — vitest walks the module graph from the staged files,
+#                         so editing a park runs that park (~3s) while editing
+#                         src/datetime.ts correctly pulls in its 59 dependents
+#   3. structural gates — these read the tree from disk rather than importing
+#                         it, so change-detection cannot see them and they have
+#                         to run every time
+#
+# The full suite still runs in CI. This is the fast lane, not a replacement.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# Nothing staged that we can check — let non-source commits through untouched.
+if ! git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.(ts|json)$'; then
+  exit 0
+fi
+
+fail () {
+  echo ""
+  echo "  pre-commit: $1"
+  echo "  Fix it and commit again. Do not pass --no-verify."
+  echo ""
+  exit 1
+}
+
+echo "pre-commit: typecheck"
+npx tsc --noEmit || fail "typecheck failed"
+
+echo "pre-commit: tests affected by staged changes"
+npx vitest run --changed HEAD --passWithNoTests || fail "affected tests failed"
+
+# These scan the source tree and the README from disk. Nothing imports them, so
+# --changed will never select them, yet they are exactly the checks that catch
+# drift introduced somewhere unrelated.
+echo "pre-commit: structural gates"
+npx vitest run \
+  src/__tests__/utcDateTrap.test.ts \
+  src/__tests__/readmeDestinations.test.ts \
+  || fail "structural gate failed"
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "audit:live": "tsx --env-file=.env src/tools/audit/live.ts",
     "har": "tsx src/tools/har/index.ts",
     "docs": "typedoc",
-    "prepare": "tsc && (git config core.hooksPath .githooks || true)",
+    "prepare": "tsc && ([ \"$(git rev-parse --show-toplevel 2>/dev/null)\" = \"$(pwd -P)\" ] && git config core.hooksPath .githooks || true)",
     "readme": "tsx src/tools/readme/destinations.ts"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "audit:live": "tsx --env-file=.env src/tools/audit/live.ts",
     "har": "tsx src/tools/har/index.ts",
     "docs": "typedoc",
-    "prepare": "tsc",
+    "prepare": "tsc && (git config core.hooksPath .githooks || true)",
     "readme": "tsx src/tools/readme/destinations.ts"
   },
   "repository": {

--- a/src/__tests__/utcDateTrap.test.ts
+++ b/src/__tests__/utcDateTrap.test.ts
@@ -1,0 +1,105 @@
+import {describe, it, expect} from 'vitest';
+import {readFileSync, readdirSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve, relative} from 'node:path';
+
+/**
+ * The gate that stops the UTC-day trap being written a third time.
+ *
+ * Deriving a park's calendar day from `toISOString()` gives the UTC day, which
+ * is not the park's day for several hours of every evening (4-7h behind for the
+ * US parks, and the other way round for Asia-Pacific). Anything keyed on it
+ * silently asks for the wrong date.
+ *
+ * It has been written twice already, independently:
+ *
+ *   enchantedparks.ts — "off by ±1 day across the local-midnight boundary,
+ *   which could drop a day from the query range (e.g. at 11pm UTC for an
+ *   America/Chicago park, the local date is already the next day but UTC is
+ *   still on the current day)"
+ *
+ *   seaworld.ts (#314) — searchDate on every availability call, so from 20:00
+ *   Eastern the API was asked for tomorrow while the park was still open, and
+ *   every show published the next day's showtimes right through the evening
+ *   event window.
+ *
+ * Both fixes were the same one line: `formatDate(date, timezone)`, which has
+ * been in src/datetime.ts the whole time. The trap is that the broken idiom is
+ * shorter to type and looks right.
+ *
+ * Deliberate UTC arithmetic on a date that is ALREADY a calendar day is fine
+ * and common (anchor at T00:00:00Z or T12:00:00Z, add days, read it back).
+ * Those sites opt out with an `utc-date-ok:` marker giving the reason, which
+ * keeps the check narrow enough to stay switched on.
+ */
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** `x.toISOString()` immediately sliced down to a YYYY-MM-DD. */
+const DATE_SLICE = /\.toISOString\(\)\s*\.\s*(?:slice|substring)\(\s*0\s*,\s*10\s*\)|\.toISOString\(\)\s*\.\s*split\(\s*['"`]T['"`]\s*\)\s*\[\s*0\s*\]/;
+
+const OPT_OUT = 'utc-date-ok';
+
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, {withFileTypes: true})) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      sourceFiles(full, acc);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('UTC-day trap', () => {
+  it('never derives a calendar day from toISOString() without an explicit reason', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(SRC)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (!DATE_SLICE.test(line)) return;
+        // The marker may sit on the offending line or in the comment block
+        // immediately above it, so a reason can run to a few lines.
+        const context = [lines[i - 3], lines[i - 2], lines[i - 1], line]
+          .filter((l) => l !== undefined)
+          .join('\n');
+        if (context.includes(OPT_OUT)) return;
+        offenders.push(`${relative(SRC, file)}:${i + 1}\n      ${line.trim()}`);
+      });
+    }
+
+    expect(
+      offenders,
+      offenders.length === 0 ? '' :
+        `\n\nA calendar day is being derived from toISOString(), which yields the UTC ` +
+        `day, not the park's.\n\n` +
+        offenders.map((o) => `  ${o}`).join('\n\n') +
+        `\n\n  To fix: use formatDate(date, this.timezone) from src/datetime.ts.\n` +
+        `  If this really is deliberate UTC arithmetic on an already-anchored\n` +
+        `  calendar date, add a "${OPT_OUT}: <reason>" comment on or above the line.\n`,
+    ).toEqual([]);
+  });
+
+  it('still recognises the offending shapes', () => {
+    // Guards the regex itself: a check that cannot fail is worse than no check.
+    for (const shape of [
+      `const d = new Date().toISOString().slice(0, 10);`,
+      `return today.toISOString().slice(0,10);`,
+      `const s = now.toISOString().substring(0, 10);`,
+      `const s = now.toISOString().split('T')[0];`,
+    ]) {
+      expect(DATE_SLICE.test(shape), shape).toBe(true);
+    }
+
+    for (const shape of [
+      `const iso = d.toISOString();`,
+      `const t = d.toISOString().slice(11, 16);`,
+      `return formatDate(new Date(), this.timezone);`,
+    ]) {
+      expect(DATE_SLICE.test(shape), shape).toBe(false);
+    }
+  });
+});

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -222,6 +222,8 @@ export function shiftDateString(dateStr: string, days: number): string {
     throw new RangeError(`shiftDateString: unparseable date "${dateStr}"`);
   }
   anchored.setUTCDate(anchored.getUTCDate() + days);
+  // utc-date-ok: date-only arithmetic on a calendar date the caller supplied,
+  // anchored at noon UTC so no offset can shift the day. Not "today".
   return anchored.toISOString().slice(0, 10);
 }
 

--- a/src/parks/europapark/europapark.ts
+++ b/src/parks/europapark/europapark.ts
@@ -1169,6 +1169,8 @@ class EuropaParkBase extends Destination {
     // boundary; _applyDateToTime re-derives the correct offset for the new day.
     const closingDate = new Date(`${closingTime.substring(0, 10)}T00:00:00Z`);
     closingDate.setUTCDate(closingDate.getUTCDate() + 1);
+    // utc-date-ok: closingDate was anchored at T00:00:00Z from an existing
+    // date string, so this reads back the same calendar day plus one.
     const nextDay = closingDate.toISOString().substring(0, 10);
     return this._applyDateToTime(closingTime, nextDay);
   }

--- a/src/parks/fantawild/fantawild.ts
+++ b/src/parks/fantawild/fantawild.ts
@@ -272,6 +272,8 @@ function closeDateAcrossMidnight(date: string, openTime: string, closeTime: stri
   // YYYY-MM-DD → next day. Date.UTC handles month/year rollover correctly.
   const [y, m, d] = date.split('-').map(Number);
   const next = new Date(Date.UTC(y, (m - 1), d + 1));
+  // utc-date-ok: built from a parsed YYYY-MM-DD via Date.UTC, so this is
+  // date-only arithmetic on a supplied calendar day, not on "today".
   return next.toISOString().slice(0, 10);
 }
 

--- a/src/parks/oceanpark/oceanpark.ts
+++ b/src/parks/oceanpark/oceanpark.ts
@@ -388,6 +388,8 @@ export function parseHourRange(text: string): {open: string; close: string} | nu
  */
 export function addDaysToDateString(dateStr: string, days: number): string {
   const [y, m, d] = dateStr.split('-').map(Number);
+  // utc-date-ok: built from a parsed YYYY-MM-DD via Date.UTC, so this shifts a
+  // supplied calendar day rather than reading one off the clock.
   return new Date(Date.UTC(y, m - 1, d + days)).toISOString().slice(0, 10);
 }
 

--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -718,6 +718,43 @@ describe('SeaworldOrlando', () => {
       expect(row!.queue?.STANDBY?.waitTime).toBeNull();
     });
 
+    it('asks for the park-local date, not the UTC date', async () => {
+      // 21:30 on 15 Aug in New York is already 16 Aug in UTC. Asking for the
+      // UTC date fetches TOMORROW's availability while the park is still open,
+      // which is when summer nights and Howl-O-Scream run. The app itself sends
+      // LocalDate.now(), i.e. the device-local date.
+      vi.useFakeTimers({toFake: ['Date']});
+      vi.setSystemTime(new Date('2026-08-16T01:30:00Z'));
+
+      const seen: string[] = [];
+      const park = createMockedOrlando();
+      (park as any).getAvailability = async (_id: string, searchDate: string) => {
+        seen.push(searchDate);
+        return {WaitTimes: [], ShowTimes: []} as any;
+      };
+      await (park as any).buildLiveData();
+
+      expect(seen.length).toBeGreaterThan(0);
+      for (const d of seen) expect(d).toBe('2026-08-15');
+    });
+
+    it('asks for the park-local date in a western timezone too', async () => {
+      // 17:30 on 15 Aug in Los Angeles is likewise 16 Aug in UTC.
+      vi.useFakeTimers({toFake: ['Date']});
+      vi.setSystemTime(new Date('2026-08-16T00:30:00Z'));
+
+      const seen: string[] = [];
+      const park = new SeaworldSanDiego();
+      (park as any).getParkDetail = async () => ({...MOCK_PARK_DETAIL_SWO, open_hours: []}) as any;
+      (park as any).getAvailability = async (_id: string, searchDate: string) => {
+        seen.push(searchDate);
+        return {WaitTimes: [], ShowTimes: []} as any;
+      };
+      await (park as any).buildLiveData();
+
+      expect(seen).toContain('2026-08-15');
+    });
+
     it('never emits a bare waitTime of undefined', async () => {
       // `{waitTime: undefined}` serialises to `"STANDBY": {}`, which says
       // nothing. Every branch must produce an explicit number or null.

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -31,7 +31,7 @@ import {http, type HTTPObj} from '../../http.js';
 import {cache} from '../../cache.js';
 import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
-import {localFromFakeUtc} from '../../datetime.js';
+import {formatDate, localFromFakeUtc} from '../../datetime.js';
 
 // ---------------------------------------------------------------------------
 // API response types
@@ -225,10 +225,20 @@ export class SeaworldDestination extends Destination {
   }
 
   /**
-   * Return today's date string in YYYY-MM-DD format (used as searchDate).
+   * Today's date in the PARK's timezone, YYYY-MM-DD, for use as searchDate.
+   *
+   * Must not be the UTC date. UTC is 4-7h ahead of the US parks, so from 20:00
+   * Eastern (17:00 Pacific) the UTC date has already rolled over and we would
+   * ask the API for tomorrow while the park is still open — precisely the
+   * window when summer nights, Howl-O-Scream and other ticketed evening events
+   * run. searchDate selects which day's ShowTimes come back, so the evening
+   * schedule would be replaced by the next day's.
+   *
+   * The app agrees: DefaultAvailabilityRepository sends
+   * `LocalDate.now().toString()`, i.e. the device-local date.
    */
   private getTodayDateString(): string {
-    return new Date().toISOString().slice(0, 10);
+    return formatDate(new Date(), this.timezone);
   }
 
   /**
@@ -257,9 +267,7 @@ export class SeaworldDestination extends Destination {
       return false;
     }
 
-    const todayLocal = new Intl.DateTimeFormat('en-CA', {
-      timeZone: this.timezone, year: 'numeric', month: '2-digit', day: '2-digit',
-    }).format(new Date(nowMs));
+    const todayLocal = formatDate(new Date(nowMs), this.timezone);
     let sawToday = false;
 
     for (const oh of parkDetail.open_hours) {

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -90,6 +90,8 @@ function rollDateBackOneDay(localIso: string): string {
   const tIdx = localIso.indexOf('T');
   const d = new Date(`${localIso.slice(0, tIdx)}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() - 1);
+  // utc-date-ok: the date half of a local ISO string, re-anchored at T00:00:00Z
+  // purely to decrement it. The time and offset are carried over untouched.
   return d.toISOString().slice(0, 10) + localIso.slice(tIdx);
 }
 


### PR DESCRIPTION
Closes the last of the three follow-ups from #313.

## Problem

`searchDate` came from `new Date().toISOString().slice(0, 10)` — the **UTC** date. UTC runs 4-7h ahead of these parks, so from **20:00 Eastern / 17:00 Pacific** the date has already rolled over and we ask the API for *tomorrow* while the park is still open.

That window is exactly when the ticketed evening events run: summer nights, Howl-O-Scream, Christmas Celebration.

## What searchDate actually controls

Verified by requesting three dates against SeaWorld Orlando:

| searchDate | WaitTimes | ShowTimes slots | slot dates |
|---|---|---|---|
| 2026-08-16 | 17 (sig `87e7bf37`) | 28 | `2026-08-16` |
| 2026-08-17 | 17 (sig `87e7bf37`) | 22 | `2026-08-17` |
| 2026-08-23 | 17 (sig `87e7bf37`) | 27 | `2026-08-23` |

Showtimes track the requested date exactly. So during those evening hours, every show published the **next day's** times.

Wait rows came back byte-identical across all three dates, which suggests they're `searchDate`-independent and the practical damage is limited to showtimes. That sample was taken overnight with every ride at `-1`, so treat it as suggestive rather than settled — it doesn't change the fix either way.

## Ground truth

`DefaultAvailabilityRepository` in `com.seaworld.mobile` sends `LocalDate.now().toString()` — the device-local date — and caches it against a timezone-less `LocalDateTime`. Local-date semantics, confirmed from the operator's own client.

## Fix

Reuse `formatDate(date, timezone)` from `src/datetime.ts`, which already produced `YYYY-MM-DD` in a given zone. No new helper. The same call also replaces the one-off `Intl` formatter I added to `isParkOpenNow` in #313, so the file now has one way to ask what the local date is.

## Tests

Two regression tests, Eastern and Pacific, both pinned to an evening instant where the UTC date has rolled over:

```
× asks for the park-local date, not the UTC date
    expected '2026-08-16' to be '2026-08-15'
× asks for the park-local date in a western timezone too
    expected [ '2026-08-16' ] to include '2026-08-15'
```

Both fail against the old expression; reverting the fix under mutation turns them red again. Full suite 2007 tests, harness 4/4, green under UTC / Pacific/Kiritimati / Pacific/Midway.

## Note

I scanned for the same pattern elsewhere. `oceanpark`, `fantawild` and `europapark` use `toISOString().slice(0,10)` but on dates they construct themselves rather than on "now", so they aren't affected. `enchantedparks` already carries a comment about having hit this exact bug.