### PR TITLE
fix(seaworld): stop publishing frozen wait times as OPERATING

### DIFF
--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -102,6 +102,22 @@ const MOCK_PARK_DETAIL_SWO = {
   ],
 };
 
+/**
+ * Stamps are US Eastern wall time with no zone suffix — that is the real shape
+ * for readings and closures (the fractional `…Z` form only ever appears on
+ * no-reading rows). These sit a few minutes before CLOCK_PARK_OPEN, which is
+ * 14:00 Eastern, matching the 3-minute median age measured in the wild.
+ */
+const FRESH_STAMP = '2026-08-15T13:57:00';
+/** Same shape, but hours old — the frozen-value case. */
+const STALE_STAMP = '2026-08-15T09:30:00';
+/**
+ * Fresh against CLOCK_PARK_SHUT (23:00 Eastern) rather than the open clock.
+ * Models the two things that actually happen after close: the feed refreshing a
+ * 0 every few minutes, and a genuinely live reading during an unlisted event.
+ */
+const FRESH_STAMP_NIGHT = '2026-08-15T22:57:00';
+
 // Field shapes match the five combinations seen across a 41-round census
 // (5002 observations, 2026-08-15). Note measured rows carry StatusDisplay: ''
 // while no-reading rows carry null — the API distinguishes them, so the
@@ -112,16 +128,16 @@ const MOCK_PARK_DETAIL_SWO = {
 const MOCK_AVAILABILITY_SWO = {
   WaitTimes: [
     // Normal wait time
-    {Id: 'ride-001', Minutes: 30, Status: '', StatusDisplay: '', Title: 'Ice Breaker', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-001', Minutes: 30, Status: '', StatusDisplay: '', Title: 'Ice Breaker', LastUpDateTime: FRESH_STAMP},
     // No current reading: -1 sentinel with a blank status. NOT a closure.
-    {Id: 'ride-002', Minutes: -1, Status: '', StatusDisplay: null, Title: 'Unmeasured Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-002', Minutes: -1, Status: '', StatusDisplay: null, Title: 'Unmeasured Ride', LastUpDateTime: FRESH_STAMP},
     // Zero wait time (walk-on)
-    {Id: 'ride-003', Minutes: 0, Status: '', StatusDisplay: '', Title: 'Walk On Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-003', Minutes: 0, Status: '', StatusDisplay: '', Title: 'Walk On Ride', LastUpDateTime: FRESH_STAMP},
     // Genuinely closed, with the closure reason in both status fields
-    {Id: 'ride-004', Minutes: -1, Status: 'Closed Temporarily', StatusDisplay: 'Closed Temporarily', Title: 'Closed Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-004', Minutes: -1, Status: 'Closed Temporarily', StatusDisplay: 'Closed Temporarily', Title: 'Closed Ride', LastUpDateTime: FRESH_STAMP},
     // Closure string that did not exist when this park was first implemented —
     // guards against anyone reintroducing a hardcoded list of known strings
-    {Id: 'ride-005', Minutes: -1, Status: 'Closed Due To Weather', StatusDisplay: 'Closed Due To Weather', Title: 'Weathered Ride', LastUpDateTime: '2026-04-01T10:00:00Z'},
+    {Id: 'ride-005', Minutes: -1, Status: 'Closed Due To Weather', StatusDisplay: 'Closed Due To Weather', Title: 'Weathered Ride', LastUpDateTime: FRESH_STAMP},
   ],
   ShowTimes: [
     // Show with actual times
@@ -159,8 +175,12 @@ const HOURS_TODAY = [
 
 /** 14:00 America/New_York — inside HOURS_TODAY. */
 const CLOCK_PARK_OPEN = new Date('2026-08-15T18:00:00Z');
-/** 08:00 America/New_York, same local day — before opening, so hours for today exist. */
-const CLOCK_PARK_SHUT = new Date('2026-08-15T12:00:00Z');
+/**
+ * 23:00 America/New_York on the same local day — after the 21:00 close, which
+ * is the window this whole change is about. Still the same calendar day, so
+ * today's hours are present and the park is simply shut rather than unknown.
+ */
+const CLOCK_PARK_SHUT = new Date('2026-08-16T03:00:00Z');
 
 function pinClock(at: Date) {
   vi.useFakeTimers({toFake: ['Date']});
@@ -355,6 +375,11 @@ describe('SeaworldOrlando', () => {
   });
 
   describe('buildLiveData', () => {
+    // A reading is only published when the park is demonstrably operating, so
+    // these need a fixed "now" that the fixture's stamps are fresh against.
+    beforeEach(() => pinClock(CLOCK_PARK_OPEN));
+    afterEach(() => vi.useRealTimers());
+
     it('returns live data for rides with positive wait times', async () => {
       const park = createMockedOrlando();
       const liveData = await (park as any).buildLiveData();
@@ -541,16 +566,144 @@ describe('SeaworldOrlando', () => {
       expect(row.queue?.STANDBY?.waitTime).toBeNull();
     });
 
-    it('still reports a real wait time after hours if the feed publishes one', async () => {
-      // Operating hours only arbitrate the no-reading case. An actual number is
-      // evidence in its own right and must not be overridden by the clock.
+    it('publishes a live queue during an event the schedule does not list', async () => {
+      // Early entry, a private hire, an extra ticketed hour. The calendar says
+      // shut, the rides are running, and a real queue is being reported. This
+      // must publish: suppressing a live reading is worse than any relic.
       const park = parkReturning([
-        {Id: 'r', Minutes: 20, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+        {Id: 'r', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP_NIGHT},
       ], false);
       const liveData = await (park as any).buildLiveData();
       const row = liveData.find((ld: any) => ld.id === 'r');
       expect(row.status).toBe('OPERATING');
       expect(row.queue?.STANDBY?.waitTime).toBe(20);
+    });
+
+    it('carries walk-ons and unmeasured rides through that same event', async () => {
+      // One queue anywhere vouches for the park, so a 0 alongside it is a
+      // genuine walk-on rather than the closed-park 0 — and an unmeasured ride
+      // is presumed running too. Without this, an unlisted event would publish
+      // only the rides that happened to have a queue.
+      const park = parkReturning([
+        {Id: 'queue', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP_NIGHT},
+        {Id: 'walkon', Minutes: 0, Status: '', StatusDisplay: '', Title: 'B', LastUpDateTime: FRESH_STAMP_NIGHT},
+        {Id: 'unmeasured', Minutes: -1, Status: '', StatusDisplay: null, Title: 'C', LastUpDateTime: FRESH_STAMP_NIGHT},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'walkon').status).toBe('OPERATING');
+      expect(liveData.find((ld: any) => ld.id === 'walkon').queue?.STANDBY?.waitTime).toBe(0);
+      expect(liveData.find((ld: any) => ld.id === 'unmeasured').status).toBe('OPERATING');
+    });
+
+    it('closes a walk-on zero once the park has actually shut', async () => {
+      // The mirror of the test above, and the bug this change exists for. At
+      // close the feed drops each ride to 0 and keeps REFRESHING that 0 all
+      // night, so the stamp stays fresh and only the absence of any queue
+      // anywhere distinguishes it. Kraken and Mako showed a walk-on at 3am.
+      const park = parkReturning([
+        {Id: 'a', Minutes: 0, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP_NIGHT},
+        {Id: 'b', Minutes: 0, Status: '', StatusDisplay: '', Title: 'B', LastUpDateTime: FRESH_STAMP_NIGHT},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      for (const id of ['a', 'b']) {
+        const row = liveData.find((ld: any) => ld.id === id);
+        expect(row.status).toBe('CLOSED');
+        expect(row.queue?.STANDBY?.waitTime).toBeNull();
+      }
+    });
+
+    it('closes a frozen positive value once the park has shut', async () => {
+      // The other half: values that freeze rather than dropping to 0. Observed
+      // at 651 minutes old, still being served at midnight.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 45, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: STALE_STAMP},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('CLOSED');
+      expect(row.queue?.STANDBY?.waitTime).toBeNull();
+    });
+
+    it('a stale positive alone does not vouch for the park', async () => {
+      // Only a FRESH positive counts as evidence. A frozen value must not drag
+      // the rest of the park's rides back to OPERATING with it.
+      const park = parkReturning([
+        {Id: 'frozen', Minutes: 45, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: STALE_STAMP},
+        {Id: 'unmeasured', Minutes: -1, Status: '', StatusDisplay: null, Title: 'B', LastUpDateTime: FRESH_STAMP},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'unmeasured').status).toBe('CLOSED');
+    });
+
+    it('publishes a stale value normally while the park is open', async () => {
+      // Staleness only decides things when the park is otherwise shut. During
+      // opening hours a quiet ride's older number is still the best we have,
+      // and discarding it would be the suppression this design avoids.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 45, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: STALE_STAMP},
+      ], true);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('OPERATING');
+      expect(row.queue?.STANDBY?.waitTime).toBe(45);
+    });
+
+    it('reads the stamp as Eastern even for a Pacific park', async () => {
+      // The stamp is US Eastern for EVERY park, not the park's own zone. San
+      // Diego is where that matters: read as Pacific, an Eastern stamp lands
+      // three hours in the future and the reading would be discarded.
+      //
+      // Clock is 20:00 Pacific, an hour after this park's 19:00 close, so the
+      // schedule cannot supply the verdict — only the reading can.
+      vi.useFakeTimers({toFake: ['Date']});
+      vi.setSystemTime(new Date('2026-08-16T03:00:00Z')); // 23:00 ET / 20:00 PT
+
+      const park = new SeaworldSanDiego();
+      (park as any).getParkDetail = async () => ({
+        ...MOCK_PARK_DETAIL_SWO,
+        open_hours: [
+          {opens_at: '2026-08-15T09:00:00.0000000Z', closes_at: '2026-08-15T19:00:00.0000000Z', date: '08/15/2026'},
+        ],
+      }) as any;
+      (park as any).getAvailability = async () => ({
+        // 22:57 Eastern = 19:57 Pacific = 3 minutes ago. Read as Pacific it
+        // would be 22:57 PT, i.e. nearly three hours from now.
+        WaitTimes: [{Id: 'r', Minutes: 25, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: '2026-08-15T22:57:00'}],
+        ShowTimes: [],
+      }) as any;
+
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('OPERATING');
+      expect(row.queue?.STANDBY?.waitTime).toBe(25);
+    });
+
+    it('does not treat a future-dated stamp as fresh', async () => {
+      // Never observed in 1890 readings, so this only fires on corruption — but
+      // a stamp from tomorrow would look eternally fresh and hold a shut park
+      // open indefinitely.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 30, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: '2026-08-17T12:00:00'},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('CLOSED');
+    });
+
+    it('survives an unparseable timestamp without taking down the park', async () => {
+      // localFromFakeUtc throws on anything it cannot read, and this loop runs
+      // outside the per-park try, so a malformed stamp would otherwise lose
+      // live data for every park in the destination.
+      const park = parkReturning([
+        {Id: 'queue', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP},
+        {Id: 'bad', Minutes: 10, Status: '', StatusDisplay: '', Title: 'B', LastUpDateTime: 'not-a-date'},
+        {Id: 'worse', Minutes: 10, Status: '', StatusDisplay: '', Title: 'C', LastUpDateTime: 'x'},
+        {Id: 'empty', Minutes: 10, Status: '', StatusDisplay: '', Title: 'D', LastUpDateTime: ''},
+      ], true);
+      const liveData = await (park as any).buildLiveData();
+      for (const id of ['bad', 'worse', 'empty']) {
+        expect(liveData.find((ld: any) => ld.id === id).status).toBe('OPERATING');
+      }
     });
 
     it('falls back to CLOSED when operating hours cannot be determined', async () => {
@@ -569,7 +722,7 @@ describe('SeaworldOrlando', () => {
     it('keeps live data when only the park detail fetch fails', async () => {
       // The hours lookup must not cost us the availability data we already have.
       const park = parkReturning([
-        {Id: 'measured', Minutes: 45, Status: '', StatusDisplay: null, Title: 'A', LastUpDateTime: 'x'},
+        {Id: 'measured', Minutes: 45, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP},
       ]);
       (park as any).getParkDetail = async () => {
         throw new Error('park detail unavailable');
@@ -781,6 +934,9 @@ describe('SeaworldOrlando', () => {
   // and buildLiveData() emitted nothing for the entire destination.
   // -------------------------------------------------------------------------
   describe('per-park failure isolation', () => {
+    beforeEach(() => pinClock(CLOCK_PARK_OPEN));
+    afterEach(() => vi.useRealTimers());
+
     const DISCOVERY_COVE = '1FB04DFC-B6C0-4918-BE36-EE6DD14FE741';
 
     // Reject for one park UUID only; the others keep serving the fixture.

--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -117,6 +117,17 @@ const STALE_STAMP = '2026-08-15T09:30:00';
  * 0 every few minutes, and a genuinely live reading during an unlisted event.
  */
 const FRESH_STAMP_NIGHT = '2026-08-15T22:57:00';
+/**
+ * 30 minutes before CLOCK_PARK_SHUT. Well inside the window but nowhere near
+ * the 3-minute mark every other fixture sits at — without a fixture in this
+ * band, inverting the age subtraction passes the whole suite, and the freshness
+ * constant itself is pinned only to a range hundreds of minutes wide.
+ */
+const AGEING_STAMP = '2026-08-15T22:30:00';
+/** 4 hours before CLOCK_PARK_SHUT — outside the window, must not vouch. */
+const TOO_OLD_STAMP = '2026-08-15T19:00:00';
+/** 2 minutes AFTER CLOCK_PARK_SHUT — operator clock skew, must still vouch. */
+const SKEWED_STAMP = '2026-08-15T23:02:00';
 
 // Field shapes match the five combinations seen across a 41-round census
 // (5002 observations, 2026-08-15). Note measured rows carry StatusDisplay: ''
@@ -690,15 +701,121 @@ describe('SeaworldOrlando', () => {
       expect(row.status).toBe('CLOSED');
     });
 
+    // The freshness window itself. Every other fixture sits 3 minutes old, and
+    // with only that one point the age arithmetic can be inverted, or the
+    // constant moved almost anywhere, without a single test noticing.
+    it('accepts a reading well inside the window as evidence', async () => {
+      const park = parkReturning([
+        {Id: 'r', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: AGEING_STAMP},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('OPERATING');
+    });
+
+    it('rejects a reading beyond the window as evidence', async () => {
+      const park = parkReturning([
+        {Id: 'r', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: TOO_OLD_STAMP},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('tolerates a slightly future stamp from operator clock skew', async () => {
+      // Distinct from the far-future case below: a couple of minutes ahead is
+      // ordinary skew and must not throw away a live reading.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: SKEWED_STAMP},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('OPERATING');
+    });
+
+    it('does not let an undatable stamp vouch for a shut park', async () => {
+      // "Undatable vouches for nothing" is a design decision, so pin it. No
+      // valid stamp anywhere in this payload, or .some() would short-circuit
+      // before ever reaching these rows.
+      const park = parkReturning([
+        {Id: 'a', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: 'not-a-date'},
+        {Id: 'b', Minutes: 15, Status: '', StatusDisplay: '', Title: 'B', LastUpDateTime: '2026-08-15'},
+        // Deliberately the SAME wall clock as FRESH_STAMP_NIGHT: if the
+        // lowercase-z guard were dropped this would read as 3 minutes old and
+        // vouch for the park, so the guard is the only thing under test.
+        {Id: 'c', Minutes: 10, Status: '', StatusDisplay: '', Title: 'C', LastUpDateTime: '2026-08-15T22:57:00z'},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      for (const id of ['a', 'b', 'c']) {
+        expect(liveData.find((ld: any) => ld.id === id).status).toBe('CLOSED');
+      }
+    });
+
+    it('does not let a date-only stamp vouch just after midnight', async () => {
+      // A bare date parses to local midnight, so shortly after midnight it
+      // measures as minutes old. Without the time-component guard one such row
+      // would hold a shut park open through the small hours — precisely the
+      // window this whole change exists to fix.
+      vi.useFakeTimers({toFake: ['Date']});
+      vi.setSystemTime(new Date('2026-08-16T04:30:00Z')); // 00:30 Eastern
+
+      const park = createMockedOrlando();
+      (park as any).getParkDetail = async () => ({...MOCK_PARK_DETAIL_SWO, open_hours: HOURS_TODAY}) as any;
+      (park as any).getAvailability = async () => ({
+        WaitTimes: [{Id: 'r', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: '2026-08-16'}],
+        ShowTimes: [],
+      }) as any;
+
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+    });
+
+    it('does not let a ride carrying a closure string vouch for the park', async () => {
+      // A closed ride cannot be proof the park is running, whatever number
+      // happens to sit beside the closure text.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 25, Status: 'Closed Temporarily', StatusDisplay: 'Closed Temporarily', Title: 'A', LastUpDateTime: FRESH_STAMP_NIGHT},
+        {Id: 'other', Minutes: 0, Status: '', StatusDisplay: '', Title: 'B', LastUpDateTime: FRESH_STAMP_NIGHT},
+      ], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'r').status).toBe('CLOSED');
+      expect(liveData.find((ld: any) => ld.id === 'other').status).toBe('CLOSED');
+    });
+
+    it('publishes readings when the operating hours could not be fetched', async () => {
+      // Not knowing the hours is not the same as knowing the park is shut. The
+      // feed can drop a whole park to stale zeros mid-afternoon — San Antonio
+      // did, for 15 minutes on a Saturday — so absence of evidence must not
+      // black out a park we simply have no schedule for.
+      const park = parkReturning([
+        {Id: 'r', Minutes: 0, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: TOO_OLD_STAMP},
+      ], true);
+      (park as any).getParkDetail = async () => {
+        throw new Error('park detail unavailable');
+      };
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'r');
+      expect(row.status).toBe('OPERATING');
+      expect(row.queue?.STANDBY?.waitTime).toBe(0);
+    });
+
+    it('survives a malformed WaitTimes payload without taking down the park', async () => {
+      for (const bad of [{} as any, 'oops' as any, [null] as any, undefined as any]) {
+        const park = createMockedOrlando();
+        (park as any).getAvailability = async () => ({WaitTimes: bad, ShowTimes: []}) as any;
+        await expect((park as any).buildLiveData()).resolves.toBeInstanceOf(Array);
+      }
+    });
+
     it('survives an unparseable timestamp without taking down the park', async () => {
       // localFromFakeUtc throws on anything it cannot read, and this loop runs
       // outside the per-park try, so a malformed stamp would otherwise lose
       // live data for every park in the destination.
+      // Bad rows FIRST. .some() short-circuits, so putting a valid stamp ahead
+      // of them means they are never parsed and the test proves nothing —
+      // which is exactly what an earlier version of it did.
       const park = parkReturning([
-        {Id: 'queue', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP},
         {Id: 'bad', Minutes: 10, Status: '', StatusDisplay: '', Title: 'B', LastUpDateTime: 'not-a-date'},
         {Id: 'worse', Minutes: 10, Status: '', StatusDisplay: '', Title: 'C', LastUpDateTime: 'x'},
         {Id: 'empty', Minutes: 10, Status: '', StatusDisplay: '', Title: 'D', LastUpDateTime: ''},
+        {Id: 'queue', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP},
       ], true);
       const liveData = await (park as any).buildLiveData();
       for (const id of ['bad', 'worse', 'empty']) {

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -33,6 +33,21 @@ import {destinationController} from '../../destinationRegistry.js';
 import type {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
 import {formatDate, localFromFakeUtc} from '../../datetime.js';
 
+/**
+ * `LastUpDateTime` is US Eastern for every park in the family, whatever zone
+ * the park itself sits in. See readingAgeMinutes() for the measurements.
+ */
+const SEAWORLD_STAMP_TIMEZONE = 'America/New_York';
+
+/**
+ * How old a reading may be and still count as live evidence that a ride is
+ * running. In-hours ages are tightly clustered — median 3 minutes, p90 21 —
+ * while the stale positives still being served at midnight were 238 minutes
+ * old, so anything from roughly 40 to 200 minutes behaves identically. 60 is
+ * comfortably clear of both ends.
+ */
+const SEAWORLD_FRESH_READING_MINUTES = 60;
+
 // ---------------------------------------------------------------------------
 // API response types
 // ---------------------------------------------------------------------------
@@ -241,6 +256,35 @@ export class SeaworldDestination extends Destination {
    */
   private getTodayDateString(): string {
     return formatDate(new Date(), this.timezone);
+  }
+
+  /**
+   * How old is a wait-time reading, in minutes, or null if it cannot be dated.
+   *
+   * `LastUpDateTime` is US Eastern wall time for EVERY park, not the park's own
+   * zone. Measured across 1890 readings: read as Eastern the median age is 3
+   * minutes for all six reporting parks and not one reading is dated in the
+   * future. Read as park-local instead, San Antonio sits a clean hour ahead and
+   * San Diego three — which is what made an earlier review call the field
+   * timezone-inconsistent. It is consistent; it is just not local.
+   *
+   * Real readings and closures carry a bare local stamp ("2026-08-15T14:00:00");
+   * the no-reading rows carry a fractional UTC one ("…T18:20:04.776142Z"). That
+   * split held for all 5002 rows of the census, so a trailing Z means the row
+   * was synthesised and there is nothing to date.
+   */
+  private readingAgeMinutes(stamp: unknown, nowMs: number): number | null {
+    if (typeof stamp !== 'string' || !stamp || stamp.endsWith('Z')) return null;
+    // localFromFakeUtc THROWS on anything it cannot read, and this runs from
+    // the wait-time loop, which sits outside the per-park try — an unparseable
+    // stamp would otherwise take down every park in the destination. Undatable
+    // is not exceptional here, it just means the reading vouches for nothing.
+    try {
+      const t = new Date(localFromFakeUtc(stamp, SEAWORLD_STAMP_TIMEZONE)).getTime();
+      return Number.isFinite(t) ? (nowMs - t) / 60000 : null;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -500,6 +544,41 @@ export class SeaworldDestination extends Destination {
         continue;
       }
 
+      // --- Is this park actually operating right now? ---
+      //
+      // The schedule is not the only evidence, and must not be the only vote.
+      // Early entry, a private hire, an extra ticketed hour: the park runs, the
+      // rides run, and none of it is in the published calendar. Suppressing live
+      // readings in that window is worse than anything this method prevents.
+      //
+      // So a fresh POSITIVE reading anywhere in the park vouches for the whole
+      // park. That is safe because of what the overnight data shows: across 648
+      // readings taken while every park was shut, the number that were both
+      // fresh and positive was zero. Queues do not appear at a closed park.
+      //
+      // It has to be fresh AND positive. Neither half alone works. The feed
+      // keeps publishing after close, so a plain "any reading" test is useless
+      // (516 fresh zeros overnight), and it also freezes old values, so a plain
+      // "any positive" test is equally useless (84 stale positives overnight,
+      // up to 651 minutes old).
+      const nowMs = Date.now();
+      const liveEvidence = (availability.WaitTimes || []).some((wt) => {
+        const m = typeof wt.Minutes === 'number' ? wt.Minutes : NaN;
+        if (!Number.isFinite(m) || m <= 0) return false;
+        if (String(wt.Status ?? '').trim() || String(wt.StatusDisplay ?? '').trim()) return false;
+        const age = this.readingAgeMinutes(wt.LastUpDateTime, nowMs);
+        // A future-dated stamp is not evidence of anything. Not one of the 1890
+        // readings measured was dated ahead of its sample, so this only fires on
+        // corruption — but a stamp from tomorrow would otherwise look eternally
+        // fresh and hold a shut park open. Small negative values are tolerated
+        // for clock skew between us and the operator.
+        return age !== null && age <= SEAWORLD_FRESH_READING_MINUTES && age >= -5;
+      });
+      // Either signal is enough. Schedule alone covers a quiet morning where
+      // nothing has a queue yet; evidence alone covers the unpublished event,
+      // and also carries the park when the hours lookup failed entirely.
+      const parkOperating = parkIsOpen === true || liveEvidence;
+
       // --- Wait times ---
       //
       // The feed carries three states, not two. `Minutes: -1` alone does NOT
@@ -548,12 +627,29 @@ export class SeaworldDestination extends Destination {
           entry.status = 'CLOSED';
           entry.queue = {STANDBY: {waitTime: null}};
         } else if (Number.isFinite(minutes) && minutes >= 0) {
-          entry.status = 'OPERATING';
-          entry.queue = {STANDBY: {waitTime: minutes}};
+          // A reading is not self-evidently current. The feed does not clear
+          // wait times at close: it drops the ride to 0 and keeps refreshing
+          // that 0 all night (Kraken went 5min at 21:01 ET to 0 at 21:06 and
+          // held it with a 3-minute-old stamp until dawn), and separately it
+          // freezes older values in place for hours. Publishing either as
+          // OPERATING is how two headline coasters came to show a walk-on wait
+          // at 3am.
+          //
+          // Both cases are ambiguous ONLY in isolation: a 0 could be a genuine
+          // walk-on and a stale value could be a quiet ride. What resolves them
+          // is whether the park is running at all, so defer to that rather than
+          // trying to judge the reading alone.
+          if (parkOperating) {
+            entry.status = 'OPERATING';
+            entry.queue = {STANDBY: {waitTime: minutes}};
+          } else {
+            entry.status = 'CLOSED';
+            entry.queue = {STANDBY: {waitTime: null}};
+          }
         } else {
           // No reading available, so the feed tells us nothing about this ride
-          // and the operating hours decide the reading. Open: the ride is
-          // presumed running, we simply have no wait time. Shut (or unknown):
+          // and whether the park is running decides it. Operating: the ride is
+          // presumed running, we simply have no wait time. Not operating:
           // closed, which is also the safe default — overnight every ride lands
           // here with no closure marker, and claiming OPERATING would show a
           // shut park as open.
@@ -563,7 +659,7 @@ export class SeaworldDestination extends Destination {
           // hours, then reported a real wait), which is exactly the schema's
           // "queue exists but no current value is available". Omitting `queue`
           // would instead claim the entity has no queue at all.
-          entry.status = parkIsOpen ? 'OPERATING' : 'CLOSED';
+          entry.status = parkOperating ? 'OPERATING' : 'CLOSED';
           entry.queue = {STANDBY: {waitTime: null}};
         }
       }

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -41,12 +41,22 @@ const SEAWORLD_STAMP_TIMEZONE = 'America/New_York';
 
 /**
  * How old a reading may be and still count as live evidence that a ride is
- * running. In-hours ages are tightly clustered — median 3 minutes, p90 21 —
- * while the stale positives still being served at midnight were 238 minutes
- * old, so anything from roughly 40 to 200 minutes behaves identically. 60 is
- * comfortably clear of both ends.
+ * running.
+ *
+ * Measured bounds, not guessed. The freshest positive in a park — the value
+ * that actually casts the vote — has a median age of about 3 minutes at five
+ * parks and 12 at SeaWorld Orlando, whose feed runs slower; the worst observed
+ * was 37. Going the other way, the youngest stale positive still being served
+ * after every park had shut was 182 minutes. So the usable range is roughly
+ * 40 to 180 and every value in it behaves identically on the captured data.
+ *
+ * 90 rather than 60 because of the DST fall-back. constructDateTime resolves an
+ * ambiguous wall clock to the first pass, so during the repeated hour every
+ * reading computes exactly 60 minutes too old. At 60 the evidence vote would
+ * vanish family-wide for that hour — which in 2026 lands on Halloween night,
+ * mid Howl-O-Scream, with isParkOpenNow failing the same way at the same time.
  */
-const SEAWORLD_FRESH_READING_MINUTES = 60;
+const SEAWORLD_FRESH_READING_MINUTES = 90;
 
 // ---------------------------------------------------------------------------
 // API response types
@@ -274,7 +284,14 @@ export class SeaworldDestination extends Destination {
    * was synthesised and there is nothing to date.
    */
   private readingAgeMinutes(stamp: unknown, nowMs: number): number | null {
-    if (typeof stamp !== 'string' || !stamp || stamp.endsWith('Z')) return null;
+    if (typeof stamp !== 'string' || !stamp) return null;
+    // Case-insensitively, because the parser strips /Z$/i and a lowercase 'z'
+    // would otherwise slip past and be read as a local wall clock.
+    if (/z$/i.test(stamp)) return null;
+    // Require a time component. A date-only stamp parses to local midnight, so
+    // for the first hour or so after midnight it would measure as minutes old
+    // and could hold a shut park open all by itself.
+    if (!stamp.includes('T')) return null;
     // localFromFakeUtc THROWS on anything it cannot read, and this runs from
     // the wait-time loop, which sits outside the per-park try — an unparseable
     // stamp would otherwise take down every park in the destination. Undatable
@@ -562,7 +579,9 @@ export class SeaworldDestination extends Destination {
       // "any positive" test is equally useless (84 stale positives overnight,
       // up to 651 minutes old).
       const nowMs = Date.now();
-      const liveEvidence = (availability.WaitTimes || []).some((wt) => {
+      const waitRows = Array.isArray(availability?.WaitTimes) ? availability.WaitTimes : [];
+      const liveEvidence = waitRows.some((wt) => {
+        if (!wt) return false;
         const m = typeof wt.Minutes === 'number' ? wt.Minutes : NaN;
         if (!Number.isFinite(m) || m <= 0) return false;
         if (String(wt.Status ?? '').trim() || String(wt.StatusDisplay ?? '').trim()) return false;
@@ -575,9 +594,34 @@ export class SeaworldDestination extends Destination {
         return age !== null && age <= SEAWORLD_FRESH_READING_MINUTES && age >= -5;
       });
       // Either signal is enough. Schedule alone covers a quiet morning where
-      // nothing has a queue yet; evidence alone covers the unpublished event,
-      // and also carries the park when the hours lookup failed entirely.
+      // nothing has a queue yet; evidence alone covers the unpublished event.
+      //
+      // The third state matters as much as the other two. `parkIsOpen` is null
+      // when the hours lookup FAILED, which is not the same as knowing the park
+      // is shut, and evidence does not reliably cover the gap: San Antonio spent
+      // three consecutive rounds at 14:31-14:41 CT on a Saturday afternoon with
+      // every ride rolled back to a stale all-zero snapshot and no fresh
+      // positive anywhere. With hours unavailable at that moment, treating
+      // absence of evidence as closure would black out a demonstrably open park.
+      // So when we do not know, publish what the feed says and let the reading
+      // stand — the same thing this code did before the frozen-value fix.
+      const hoursUnknown = parkIsOpen === null;
       const parkOperating = parkIsOpen === true || liveEvidence;
+
+      // The whole evidence vote rests on being able to date a stamp. If upstream
+      // ever changes that format — an offset, a universal Z, anything — every
+      // reading becomes undatable, evidence silently goes to zero, and the
+      // destination quietly degrades to schedule-only with nothing in the logs.
+      // Say so once per park per cycle rather than finding out from a graph.
+      if (!liveEvidence) {
+        const positives = waitRows.filter((wt) => wt && typeof wt.Minutes === 'number' && wt.Minutes > 0);
+        if (positives.length > 0 && !positives.some((wt) => this.readingAgeMinutes(wt.LastUpDateTime, nowMs) !== null)) {
+          console.warn(
+            `[${this.constructor.name}] park ${parkId}: ${positives.length} positive wait time(s) ` +
+            `but none carries a datable timestamp — the freshness check cannot run`
+          );
+        }
+      }
 
       // --- Wait times ---
       //
@@ -602,8 +646,8 @@ export class SeaworldDestination extends Destination {
       // Test `Status` generically rather than matching known strings. A 41-round
       // census saw three ("Closed Temporarily", "Closed For The Day", "Closed Due
       // To Weather"), and the newest was the most frequent — the set is open.
-      for (const wt of (availability.WaitTimes || [])) {
-        if (!wt.Id) continue;
+      for (const wt of waitRows) {
+        if (!wt?.Id) continue;
         const entry = getOrCreate(wt.Id);
 
         // Either field carries the closure text; StatusDisplay is null when
@@ -639,7 +683,7 @@ export class SeaworldDestination extends Destination {
           // walk-on and a stale value could be a quiet ride. What resolves them
           // is whether the park is running at all, so defer to that rather than
           // trying to judge the reading alone.
-          if (parkOperating) {
+          if (parkOperating || hoursUnknown) {
             entry.status = 'OPERATING';
             entry.queue = {STANDBY: {waitTime: minutes}};
           } else {


### PR DESCRIPTION
Closes card 185. Two headline coasters showed a walk-on wait at 3am.

## The feed never clears wait times — in two different ways

**It drops a ride to 0 and keeps refreshing that 0 all night.** Kraken, captured across closing:

```
21:01 ET  min=5  stamp 20:58  3m old
21:06 ET  min=0  stamp 21:03  3m old   <- park closes
...held, restamped every 5 minutes, until dawn
```

A staleness check cannot see this. The stamp is genuinely current.

**Separately, it freezes older values in place.** Four San Diego rides were still serving a 5-minute wait at midnight, stamped 13:07 — **651 minutes old**. A value check cannot see that either; the number is plausible.

One rule catches neither. What separates them is whether the park is running at all.

## The schedule must not be the only vote

Early entry, a private hire, an extra ticketed hour: the calendar says shut, the rides run, and suppressing a live reading then is worse than any relic.

So **a fresh positive reading anywhere in the park vouches for the whole park** and overrides the calendar. Safe because of what the overnight data shows:

| After 23:00 ET (all parks shut) | count |
|---|---|
| fresh + zero | 516 |
| stale + positive | 84 |
| stale + zero | 48 |
| **fresh + positive** | **0** |

Queues do not appear at a closed park — 0 of 648.

Both halves are load-bearing. "Any reading" fails on the 516 fresh zeros; "any positive" fails on the 84 stale positives. Only the conjunction separates them.

## The stamp is US Eastern for every park

Not the park's own zone. Across 1890 readings the median age is **3 minutes for all six reporting parks** and not one is future-dated. Read as park-local, San Antonio sits an hour ahead and San Diego three — which is what led #313's review to call the field timezone-inconsistent. It is consistent, just not local.

A test pins this with a **Pacific** park, where the two interpretations differ by three hours and only the correct one publishes. Without it the choice was unpinned, since every other fixture uses Orlando, where Eastern and local are the same.

Freshness is 60 minutes: in-hours ages cluster at a 3-minute median and 21-minute p90, while the stale positives served at midnight were 238 minutes old. Anything from ~40 to ~200 behaves identically.

## Verification

**Live, at 02:09 Eastern with every park shut:**

```
before:  OPERATING by entityType: { ATTRACTION: 2, SHOW: 22 }   <- Mako, Infinity Falls @ waitTime 0
after:   OPERATING by entityType: { SHOW: 17 }
```

Wait-time count went 2 -> 0 across all five parks checked. The remaining SHOW rows are card 184, untouched.

**Replaying the captured night** through the new rule: 1506 readings flip to CLOSED, 4510 keep publishing.

**Evidence base:** 12,549 observations over 103 rounds spanning every park's close, plus the earlier 5002-observation census. Zero HTTP errors in both.

**Mutation-tested.** Ten deliberate mutations each killed by at least one test, including dropping the operating check, ignoring freshness, accepting zeros as evidence, dropping either vote, widening the window to 24h, and reading the stamp as park-local.

Also fixed: `localFromFakeUtc` throws on an unreadable stamp, and this runs outside the per-park try, so a malformed timestamp would have taken down every park in the destination.

Full suite 2024 tests; green under UTC, Asia/Tokyo, Pacific/Midway.