### PR TITLE
fix(seaworld): stop reporting shows as OPERATING outside park hours

### DIFF
--- a/src/parks/seaworld/__tests__/seaworld.test.ts
+++ b/src/parks/seaworld/__tests__/seaworld.test.ts
@@ -804,6 +804,76 @@ describe('SeaworldOrlando', () => {
       }
     });
 
+    // --- shows ---------------------------------------------------------
+    // A non-empty ShowTimes array means "scheduled today", not "running now":
+    // the feed serves the whole day's list from midnight. Sampled at 03:46
+    // local, SeaWorld Orlando returned 22 slots from 10:45 to 18:30.
+
+    const SHOW_ROW = {
+      Id: 'show-x',
+      ShowTimes: [{
+        StartDateTime: '2026-08-15T22:00:00Z', EndDateTime: '2026-08-15T22:30:00Z',
+        StartTime: '2026-08-15T18:00:00', EndTime: '2026-08-15T18:30:00',
+      }],
+    };
+
+    function parkWithShows(waitTimes: any[], shows: any[], open: boolean) {
+      pinClock(open ? CLOCK_PARK_OPEN : CLOCK_PARK_SHUT);
+      const park = createMockedOrlando();
+      (park as any).getAvailability = async () => ({WaitTimes: waitTimes, ShowTimes: shows}) as any;
+      (park as any).getParkDetail = async () => ({...MOCK_PARK_DETAIL_SWO, open_hours: HOURS_TODAY}) as any;
+      return park;
+    }
+
+    it('reports a show as OPERATING while the park is open', async () => {
+      const park = parkWithShows([], [SHOW_ROW], true);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'show-x');
+      expect(row.status).toBe('OPERATING');
+      expect(row.showtimes).toHaveLength(1);
+    });
+
+    it('reports a show as CLOSED once the park has shut, keeping the schedule', async () => {
+      // This was the last thing still showing a shut park as open after the
+      // wait-time fixes landed.
+      const park = parkWithShows([], [SHOW_ROW], false);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'show-x');
+      expect(row.status).toBe('CLOSED');
+      // The times are still published — a closed park should still show today's
+      // line-up rather than going blank.
+      expect(row.showtimes).toHaveLength(1);
+    });
+
+    it('carries shows through an unlisted event on the same evidence as rides', async () => {
+      // Schedule says shut, a ride reports a live queue, so the park is running
+      // and its shows are running with it.
+      const park = parkWithShows(
+        [{Id: 'r', Minutes: 20, Status: '', StatusDisplay: '', Title: 'A', LastUpDateTime: FRESH_STAMP_NIGHT}],
+        [SHOW_ROW], false);
+      const liveData = await (park as any).buildLiveData();
+      expect(liveData.find((ld: any) => ld.id === 'show-x').status).toBe('OPERATING');
+    });
+
+    it('does not let a schedule overwrite an explicit ride closure', async () => {
+      // No id appears in both arrays today, but if one ever does, the operator
+      // saying "Closed For The Day" must outrank "had performances listed".
+      const park = parkWithShows(
+        [{Id: 'show-x', Minutes: -1, Status: 'Closed For The Day', StatusDisplay: 'Closed For The Day', Title: 'A', LastUpDateTime: FRESH_STAMP}],
+        [SHOW_ROW], true);
+      const liveData = await (park as any).buildLiveData();
+      const row = liveData.find((ld: any) => ld.id === 'show-x');
+      expect(row.status).toBe('CLOSED');
+      expect(row.showtimes).toHaveLength(1);
+    });
+
+    it('survives a malformed ShowTimes payload', async () => {
+      for (const bad of [{} as any, 'oops' as any, [null] as any, undefined as any]) {
+        const park = parkWithShows([], bad, true);
+        await expect((park as any).buildLiveData()).resolves.toBeInstanceOf(Array);
+      }
+    });
+
     it('survives an unparseable timestamp without taking down the park', async () => {
       // localFromFakeUtc throws on anything it cannot read, and this loop runs
       // outside the per-park try, so a malformed stamp would otherwise lose

--- a/src/parks/seaworld/seaworld.ts
+++ b/src/parks/seaworld/seaworld.ts
@@ -516,6 +516,10 @@ export class SeaworldDestination extends Destination {
     // wait-time branch below assigns a status explicitly, so a ride can never
     // fall through to this default — do not rely on `continue` to leave a ride
     // unset, as that silently republishes it as CLOSED.
+    // Ids the operator explicitly closed this cycle. The show loop must not
+    // overwrite a real closure with a schedule.
+    const closedByStatus = new Set<string>();
+
     const getOrCreate = (id: string): LiveData => {
       let entry = liveDataMap.get(id);
       if (!entry) {
@@ -670,6 +674,7 @@ export class SeaworldDestination extends Destination {
         if (closureText) {
           entry.status = 'CLOSED';
           entry.queue = {STANDBY: {waitTime: null}};
+          closedByStatus.add(wt.Id);
         } else if (Number.isFinite(minutes) && minutes >= 0) {
           // A reading is not self-evidently current. The feed does not clear
           // wait times at close: it drops the ride to 0 and keeps refreshing
@@ -709,12 +714,34 @@ export class SeaworldDestination extends Destination {
       }
 
       // --- Show times ---
-      for (const st of (availability.ShowTimes || [])) {
-        if (!st.Id) continue;
+      //
+      // A non-empty ShowTimes array means "has performances scheduled today",
+      // NOT "running now". The feed publishes the whole day's list from
+      // midnight: sampled at 03:46 local, SeaWorld Orlando returned 22 slots
+      // running 10:45 to 18:30, every one still hours away. Reading that as
+      // OPERATING is the same category error the wait-time branch just stopped
+      // making, and after that fix these were the only rows left showing a shut
+      // park as open.
+      //
+      // So the status follows the park, exactly as a ride's does. Note this is
+      // deliberately not "is a performance on stage right now" — that would
+      // flap several times a day as each show starts and ends, and the
+      // showtimes array already carries that detail for anyone who wants it.
+      // The schedule is published either way, so a closed park still shows
+      // today's line-up.
+      const showRows = Array.isArray(availability?.ShowTimes) ? availability.ShowTimes : [];
+      for (const st of showRows) {
+        if (!st?.Id) continue;
         const entry = getOrCreate(st.Id);
 
         if (st.ShowTimes && st.ShowTimes.length > 0) {
-          entry.status = 'OPERATING';
+          // An explicit closure outranks a schedule. No id currently appears in
+          // both arrays (checked across five parks), but if one ever does, the
+          // operator saying "Closed For The Day" must not be overwritten by the
+          // fact that performances were listed this morning.
+          if (!closedByStatus.has(st.Id)) {
+            entry.status = parkOperating ? 'OPERATING' : 'CLOSED';
+          }
           entry.showtimes = st.ShowTimes.map((time) => {
             // StartTime/EndTime are local datetime strings without a timezone
             // suffix (e.g. "2026-04-01T12:00:00").  Use constructDateTime to


### PR DESCRIPTION
Closes card 184, the last source of overnight-open rows after #313 and #316.

## Problem

A non-empty `ShowTimes` array means **"has performances scheduled today"**, not "running now". The feed serves the whole day's list from midnight. Sampled at **03:46 local**:

```
SeaWorld Orlando, searchDate = today
  22 slots, 10:45 -> 18:30, every one still hours away
```

Reading that as OPERATING is the same category error the wait-time branch was making. Once #316 fixed the rides, these were the only rows left showing a shut park as open — 17 at Orlando alone.

## Fix

Show status follows the park, on exactly the signal a ride uses: schedule says open, **or** a fresh positive reading somewhere in the park says so regardless of the schedule. So an unlisted event carries the shows along with the rides.

**Deliberately not "is a performance on stage right now."** That flaps several times a day as each show starts and ends, and `showtimes` already carries that detail for anyone who wants it. The schedule is published either way, so a closed park still shows today's line-up rather than going blank.

## Also

**An explicit ride closure now outranks a schedule.** No id appears in both arrays today (checked across five parks: SWO, BGT, BGW, Sesame Philadelphia, Sesame San Diego — all zero overlap), but the show loop runs second and would otherwise overwrite a `Closed For The Day` with "had performances listed this morning".

**Malformed `ShowTimes` guarded** — a non-array threw out of `buildLiveData` and lost live data for every park in the destination, the same hazard the wait-time loop was hardened against in #316.

## Verification

Live at 03:48 Eastern, every park shut:

```
before:  OPERATING rows by entityType: { SHOW: 17 }
after:   OPERATING rows by entityType: {}
```

All seven destinations report fully closed via the harness, 4/4 each.

Five mutations of the new logic, each killed by at least one test:

| Mutant | Result |
|---|---|
| shows always OPERATING (old behaviour) | 1 test fails |
| shows always CLOSED | 3 fail |
| closure guard dropped, schedule wins | 1 fails |
| showtimes dropped when park shut | 1 fails |
| ShowTimes array guard removed | 1 fails |

Full suite 2037 tests; 92 seaworld; green under UTC and Pacific/Kiritimati.

## Note for later

DLP does the same thing (`disneylandparis.ts:1203-1213` — showtimes present, status OPERATING, no clock check), so this pattern is library-wide rather than SeaWorld-specific. Out of scope here, but worth a card if the same 3am rows show up there.