### PR TITLE
fix(dlp): give scheduled performances the same end time as live ones

### DIFF
--- a/src/parks/dlp/__tests__/schedules.test.ts
+++ b/src/parks/dlp/__tests__/schedules.test.ts
@@ -145,13 +145,42 @@ describe('DLP schedules', () => {
 
     it('leaves the feed end time alone when no duration is published', async () => {
       // Mickey's PhilharMagic is the real case: duration null, nothing to
-      // derive from, so the zero-length entry is the honest answer.
+      // derive from, so whatever the feed sent stands.
+      //
+      // The fixture deliberately carries a NON-zero window. With the usual
+      // endTime === startTime shape, "preserved the feed's value" and
+      // "recomputed it as start + 0" are byte-identical, so the assertion
+      // could not tell them apart and a `> 0` to `>= 0` slip went unnoticed.
       const schedules = await parkWithDuration(
-        feedFor(['P1RA00'], PERFORMANCE), null,
+        feedFor(['P1RA00'], {startTime: '12:30:00', endTime: '14:00:00', status: 'PERFORMANCE_TIME'}),
+        null,
       ).getSchedules();
       const entry = schedules[0].schedule[0];
       expect(entry.openingTime).toContain('T12:30:00');
-      expect(entry.closingTime).toContain('T12:30:00');
+      expect(entry.closingTime).toContain('T14:00:00');
+    });
+
+    it('keeps a real feed window when the show has no duration', async () => {
+      // Same guard from the other side: a duration of zero must not be applied.
+      const schedules = await parkWithDuration(
+        feedFor(['P1RA00'], {startTime: '12:30:00', endTime: '14:00:00', status: 'PERFORMANCE_TIME'}),
+        {hours: 0, minutes: 0},
+      ).getSchedules();
+      expect(schedules[0].schedule[0].closingTime).toContain('T14:00:00');
+    });
+
+    it('carries a performance across midnight', async () => {
+      // The duration is applied AFTER the string-comparison rollover branch and
+      // replaces its result, so the day roll has to come out of the millisecond
+      // arithmetic instead. Correct today, but nothing pinned it.
+      const schedules = await parkWithDuration(
+        feedFor(['P1RA00'], {startTime: '23:50:00', endTime: '23:50:00', status: 'PERFORMANCE_TIME'}),
+        {hours: 0, minutes: 30},
+      ).getSchedules();
+      const entry = schedules[0].schedule[0];
+      const span = (new Date(entry.closingTime).getTime() - new Date(entry.openingTime).getTime()) / 60000;
+      expect(span).toBe(30);
+      expect(entry.closingTime).toContain('T00:20:00');
     });
 
     it('does not stretch non-performance entries', async () => {
@@ -188,11 +217,25 @@ describe('DLP schedules', () => {
       expect(entry.closingTime).toContain('T12:42:00');
     });
 
-    it('matches what the live path publishes for the same performance', async () => {
-      // The two paths drifted once; pin them to the same arithmetic.
+    it('publishes the same window on the schedule path as on the live path', async () => {
+      // Compare the two outputs directly. The previous version of this test
+      // asserted the private duration map instead, which pinned neither path —
+      // and so missed that the live path was still looking the duration up
+      // under the un-aliased id.
       const park: any = parkWithDuration(feedFor(['P1RA00'], PERFORMANCE), {hours: 0, minutes: 30});
-      const durations = await park.getShowDurations();
-      expect(durations.get('P1RA00')).toBe(30);
+      vi.spyOn(park, 'getWaitTimes').mockResolvedValue([]);
+      vi.spyOn(park, 'getPremierAccess').mockResolvedValue([]);
+      vi.spyOn(park, 'getVirtualQueueData').mockResolvedValue([]);
+
+      const schedules = await park.getSchedules();
+      const live = await park.getLiveData();
+
+      const entry = schedules.find((s: any) => s.id === 'P1RA00').schedule
+        .find((e: any) => e.description === 'Performance Time');
+      const slot = live.find((l: any) => l.id === 'P1RA00').showtimes[0];
+
+      expect(entry.openingTime).toBe(slot.startTime);
+      expect(entry.closingTime).toBe(slot.endTime);
     });
   });
 

--- a/src/parks/dlp/__tests__/schedules.test.ts
+++ b/src/parks/dlp/__tests__/schedules.test.ts
@@ -111,6 +111,91 @@ describe('DLP schedules', () => {
     expect(show[0].schedule[0]).toMatchObject({type: 'INFO', description: 'Performance Time'});
   });
 
+  /**
+   * The feed sends endTime === startTime for every performance, so a schedule
+   * entry built straight from it is zero-length. The live path has applied the
+   * POI's advertised running time since #293; the schedule path did not, so
+   * /entity/<id>/live served The Lion King as 12:30-13:00 while
+   * /entity/<id>/schedule served the same performance as 12:30-12:30.
+   */
+  describe('performance duration', () => {
+    /** A park whose POI list gives P1RA00 a 30-minute running time. */
+    function parkWithDuration(activities: unknown, duration: unknown) {
+      const park = new DisneylandParis();
+      vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+        ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+        Attraction: [
+          {id: 'P1RA00', name: 'The Lion King', type: 'Attraction', location: {id: 'P1'}, duration},
+        ],
+      });
+      vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(activities);
+      return park;
+    }
+
+    const PERFORMANCE = {startTime: '12:30:00', endTime: '12:30:00', status: 'PERFORMANCE_TIME'};
+
+    it('gives a zero-length performance the advertised running time', async () => {
+      const schedules = await parkWithDuration(
+        feedFor(['P1RA00'], PERFORMANCE), {hours: 0, minutes: 30},
+      ).getSchedules();
+      const entry = schedules[0].schedule[0];
+      expect(entry.openingTime).toContain('T12:30:00');
+      expect(entry.closingTime).toContain('T13:00:00');
+    });
+
+    it('leaves the feed end time alone when no duration is published', async () => {
+      // Mickey's PhilharMagic is the real case: duration null, nothing to
+      // derive from, so the zero-length entry is the honest answer.
+      const schedules = await parkWithDuration(
+        feedFor(['P1RA00'], PERFORMANCE), null,
+      ).getSchedules();
+      const entry = schedules[0].schedule[0];
+      expect(entry.openingTime).toContain('T12:30:00');
+      expect(entry.closingTime).toContain('T12:30:00');
+    });
+
+    it('does not stretch non-performance entries', async () => {
+      const schedules = await parkWithDuration(
+        feedFor(['P1RA00'], OPERATING), {hours: 0, minutes: 30},
+      ).getSchedules();
+      const entry = schedules[0].schedule[0];
+      expect(entry.type).toBe('OPERATING');
+      expect(entry.closingTime).toContain('T22:00:00');
+    });
+
+    it('finds the duration through the PhilharMagic alias', async () => {
+      // The schedule feed serves the hidden twin P1DA13, whose rows fold onto
+      // the published P1G103. Durations are keyed by published id, so looking
+      // up the raw feed id would silently find nothing and leave the entry
+      // zero-length — the exact bug being fixed, just one alias further along.
+      const park = new DisneylandParis();
+      vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+        ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+        Entertainment: [
+          {
+            id: 'P1G103', name: 'Mickey’s PhilharMagic', type: 'Entertainment',
+            location: {id: 'P1'}, duration: {hours: 0, minutes: 12},
+          },
+        ],
+      });
+      vi.spyOn(park as any, 'getScheduleForDate').mockResolvedValue(
+        feedFor(['P1DA13'], PERFORMANCE),
+      );
+
+      const schedules = await park.getSchedules();
+      const entry = schedules.find((s: any) => s.id === 'P1G103')!.schedule[0];
+      expect(entry.openingTime).toContain('T12:30:00');
+      expect(entry.closingTime).toContain('T12:42:00');
+    });
+
+    it('matches what the live path publishes for the same performance', async () => {
+      // The two paths drifted once; pin them to the same arithmetic.
+      const park: any = parkWithDuration(feedFor(['P1RA00'], PERFORMANCE), {hours: 0, minutes: 30});
+      const durations = await park.getShowDurations();
+      expect(durations.get('P1RA00')).toBe(30);
+    });
+  });
+
   it.each(['REFURBISHMENT', 'CLOSED'])('skips %s days', async (status) => {
     expect(await scheduledIds(feedFor(['P1RA00'], {...OPERATING, status}))).toEqual([]);
   });

--- a/src/parks/dlp/__tests__/showtimes.test.ts
+++ b/src/parks/dlp/__tests__/showtimes.test.ts
@@ -77,6 +77,37 @@ describe('DLP showtimes', () => {
     expect(spanMinutes(parade!.showtimes![0].startTime!, parade!.showtimes![0].endTime!)).toBe(30);
   });
 
+  it('folds an aliased twin onto the published id, with its duration', async () => {
+    // ID_ALIASES promises live rows for the hidden PhilharMagic twin fold onto
+    // the published record, and the wait-time path honours that. This path did
+    // not: it read the duration under the raw feed id, found nothing, then
+    // handed the raw id to getOrCreate, which drops it for not being a
+    // published entity. The row vanished and the schedule path disagreed with
+    // the live one by the show's whole running time.
+    const park = new DisneylandParis();
+    vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+      ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+      Entertainment: [{
+        id: 'P1G103', name: 'Mickey’s PhilharMagic', type: 'Entertainment',
+        subType: 'Stage Show', location: {id: 'P1'}, duration: {hours: 0, minutes: 12},
+      }],
+    });
+    vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+    vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+    vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+    vi.spyOn(park as any, 'getScheduleForDate').mockImplementation(async (date: string) => [{
+      id: 'P1DA13', // the hidden twin
+      schedules: [{date, startTime: '12:30:00', endTime: '12:30:00', status: 'PERFORMANCE_TIME'}],
+    }]);
+
+    const live = await park.getLiveData();
+    const show = live.find((l) => l.id === 'P1G103');
+    expect(show?.showtimes).toHaveLength(1);
+    expect(spanMinutes(show!.showtimes![0].startTime!, show!.showtimes![0].endTime!)).toBe(12);
+    // And nothing published under the raw feed id.
+    expect(live.find((l) => l.id === 'P1DA13')).toBeUndefined();
+  });
+
   it('adds hours and minutes together', async () => {
     const live = await stubbedPark().getLiveData();
 

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1163,11 +1163,9 @@ export class DisneylandParis extends Destination {
     // The payload is shared with the dining block below.
     let todaySchedules: DLPScheduleActivityEntry[] = [];
 
-    const showDurations = new Map<string, number>();
-    for (const poi of emittablePois) {
-      const minutes = showDurationMinutes(poi.duration);
-      if (minutes > 0) showDurations.set(poi.id, minutes);
-    }
+    // Same map buildSchedules uses, so the live and schedule views of a
+    // performance cannot disagree about how long it runs.
+    const showDurations = await this.getShowDurations();
 
     try {
       todaySchedules = await this.getScheduleForDate(todayStr);
@@ -1436,9 +1434,45 @@ export class DisneylandParis extends Destination {
     return liveData;
   }
 
+  /**
+   * Published show id to advertised running time in minutes, for the shows that
+   * carry one. 16 of 144 emittable POIs do; the rest return 0 and are left with
+   * whatever end time the feed gave.
+   *
+   * Shared by buildLiveData and buildSchedules so the two cannot drift. They did:
+   * the live path applied the duration and the schedule path did not, so
+   * /entity/<id>/live served The Lion King as 12:30-13:00 while
+   * /entity/<id>/schedule served the same performance as 12:30-12:30.
+   */
+  private async getShowDurations(): Promise<Map<string, number>> {
+    const durations = new Map<string, number>();
+    // A POI outage must not cost the caller its own work. buildSchedules is
+    // built to publish unfiltered when POI is unavailable rather than publish
+    // nothing, and an unguarded call here would turn a degraded day into 60
+    // days of missing schedules. Durations are an enhancement; without them a
+    // performance falls back to the feed's own end time.
+    let pois: Array<DLPPOIEntity & {category: string}>;
+    try {
+      pois = await this.getEmittablePOIEntities();
+    } catch (e) {
+      console.error(`[DLP] show durations unavailable, performances keep the feed's end time: ${e}`);
+      return durations;
+    }
+    for (const poi of pois) {
+      const minutes = showDurationMinutes(poi.duration);
+      if (minutes > 0) durations.set(poi.id, minutes);
+    }
+    return durations;
+  }
+
   protected async buildSchedules(): Promise<EntitySchedule[]> {
     const now = new Date();
     const scheduleMap = new Map<string, any[]>();
+
+    // Keyed by published id, which is what scheduleId already is — the alias is
+    // applied before the lookup below, so the folded PhilharMagic twin resolves
+    // to the same entry the POI list carries.
+    const showDurations = await this.getShowDurations();
 
     // The schedule feed reaches well past the POI set we publish — hotel and
     // Disney Village restaurants, character meets, records the visibility
@@ -1502,6 +1536,20 @@ export class DisneylandParis extends Destination {
           } else if (hours.status === 'PERFORMANCE_TIME') {
             type = 'INFO';
             description = 'Performance Time';
+
+            // The feed sends endTime === startTime for every performance, so a
+            // schedule entry built straight from it is zero-length and tells a
+            // consumer nothing about how long the show runs. Where the POI
+            // advertises a running time, use it — the same value and the same
+            // arithmetic the live path already applies.
+            const showDuration = showDurations.get(scheduleId) ?? 0;
+            if (showDuration > 0) {
+              closeTime = formatInTimezone(
+                new Date(new Date(openTime).getTime() + showDuration * 60 * 1000),
+                this.timezone,
+                'iso',
+              );
+            }
           }
 
           if (!scheduleMap.has(scheduleId)) {

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1554,6 +1554,15 @@ export class DisneylandParis extends Destination {
             // consumer nothing about how long the show runs. Where the POI
             // advertises a running time, use it — the same value and the same
             // arithmetic the live path already applies.
+            //
+            // Note this DISCARDS the feed's own endTime rather than preferring
+            // it, which is only safe because that value is always equal to
+            // startTime: 2765 of 2765 PERFORMANCE_TIME rows over 14 days and 33
+            // ids, zero counterexamples. If the feed ever starts publishing a
+            // real window, this would silently override it, and the tests below
+            // pin the no-duration side of that behaviour rather than this one.
+            // The live path is structurally immune because it only substitutes
+            // startTime when a duration exists; this path has no such fallback.
             const showDuration = showDurations.get(scheduleId) ?? 0;
             if (showDuration > 0) {
               closeTime = formatInTimezone(

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1164,8 +1164,9 @@ export class DisneylandParis extends Destination {
     let todaySchedules: DLPScheduleActivityEntry[] = [];
 
     // Same map buildSchedules uses, so the live and schedule views of a
-    // performance cannot disagree about how long it runs.
-    const showDurations = await this.getShowDurations();
+    // performance cannot disagree about how long it runs. The POI list is
+    // already in scope here, so hand it over rather than re-deriving it.
+    const showDurations = await this.getShowDurations(emittablePois);
 
     try {
       todaySchedules = await this.getScheduleForDate(todayStr);
@@ -1455,22 +1456,33 @@ export class DisneylandParis extends Destination {
    * /entity/<id>/live served The Lion King as 12:30-13:00 while
    * /entity/<id>/schedule served the same performance as 12:30-12:30.
    */
-  private async getShowDurations(): Promise<Map<string, number>> {
+  private async getShowDurations(
+    pois?: Array<DLPPOIEntity & {category: string}>,
+  ): Promise<Map<string, number>> {
     const durations = new Map<string, number>();
-    // Guarded for buildSchedules, which is built to publish unfiltered when POI
-    // is unavailable rather than publish nothing — an unguarded call here would
-    // turn a degraded day into 60 days of missing schedules. It does nothing for
-    // buildLiveData, which already calls getEmittablePOIEntities unguarded and
-    // would have thrown before reaching this. Durations are an enhancement;
-    // without them a performance keeps the feed's own end time.
-    let pois: Array<DLPPOIEntity & {category: string}>;
-    try {
-      pois = await this.getEmittablePOIEntities();
-    } catch (e) {
-      console.error(`[DLP] show durations unavailable, performances keep the feed's end time: ${e}`);
-      return durations;
+
+    // A caller that already holds the list passes it in. getEmittablePOIEntities
+    // is undecorated, so calling it again re-parses the cached POI blob and
+    // re-runs flatten+filter — no extra HTTP, but wasted work on every live
+    // cycle, where the list is already in scope.
+    //
+    // Fetching it here is guarded for buildSchedules, which is built to publish
+    // unfiltered when POI is unavailable rather than publish nothing: an
+    // unguarded call would turn a degraded day into 60 days of missing
+    // schedules. The guard does nothing for buildLiveData, which already calls
+    // getEmittablePOIEntities unguarded and would have thrown first. Durations
+    // are an enhancement; without them a performance keeps the feed's end time.
+    let source = pois;
+    if (!source) {
+      try {
+        source = await this.getEmittablePOIEntities();
+      } catch (e) {
+        console.error(`[DLP] show durations unavailable, performances keep the feed's end time: ${e}`);
+        return durations;
+      }
     }
-    for (const poi of pois) {
+
+    for (const poi of source) {
       const minutes = showDurationMinutes(poi.duration);
       if (minutes > 0) durations.set(poi.id, minutes);
     }

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1179,7 +1179,18 @@ export class DisneylandParis extends Destination {
         const performances = sched.schedules.filter((s) => s.status === 'PERFORMANCE_TIME');
         if (performances.length === 0) continue;
 
-        const showDuration = showDurations.get(sched.id) || 0;
+        // Alias before every lookup, exactly as buildSchedules does. The
+        // ID_ALIASES docblock promises live rows fold onto the published id,
+        // and the wait-time path above honours that, but this block did not:
+        // it read the duration under the raw feed id (finding nothing) and
+        // then handed the raw id to getOrCreate, which drops it for failing
+        // the published-entity gate. Not reachable today — the schedule feed
+        // only requests PERFORMANCE_TIME for Entertainment records and the
+        // aliased twin is an Attraction — but it made the live and schedule
+        // paths disagree by the duration for any alias that ever does carry
+        // showtimes.
+        const liveId = ID_ALIASES[sched.id] ?? sched.id;
+        const showDuration = showDurations.get(liveId) || 0;
 
         const showtimes = performances.map((p) => {
           const startTime = constructDateTime(todayStr, p.startTime, this.timezone);
@@ -1198,14 +1209,14 @@ export class DisneylandParis extends Destination {
           };
         });
 
-        const existing = liveDataMap.get(sched.id);
+        const existing = liveDataMap.get(liveId);
         if (existing) {
           existing.showtimes = showtimes;
           if (showtimes.length > 0) {
             existing.status = 'OPERATING' as any;
           }
         } else {
-          const ld = getOrCreate(sched.id);
+          const ld = getOrCreate(liveId);
           if (!ld) continue;
           ld.status = 'OPERATING' as any;
           ld.showtimes = showtimes;
@@ -1446,11 +1457,12 @@ export class DisneylandParis extends Destination {
    */
   private async getShowDurations(): Promise<Map<string, number>> {
     const durations = new Map<string, number>();
-    // A POI outage must not cost the caller its own work. buildSchedules is
-    // built to publish unfiltered when POI is unavailable rather than publish
-    // nothing, and an unguarded call here would turn a degraded day into 60
-    // days of missing schedules. Durations are an enhancement; without them a
-    // performance falls back to the feed's own end time.
+    // Guarded for buildSchedules, which is built to publish unfiltered when POI
+    // is unavailable rather than publish nothing — an unguarded call here would
+    // turn a degraded day into 60 days of missing schedules. It does nothing for
+    // buildLiveData, which already calls getEmittablePOIEntities unguarded and
+    // would have thrown before reaching this. Durations are an enhancement;
+    // without them a performance keeps the feed's own end time.
     let pois: Array<DLPPOIEntity & {category: string}>;
     try {
       pois = await this.getEmittablePOIEntities();


### PR DESCRIPTION
Reported on Discord as BeyondVertical's show-length fix not having worked. It had — on the endpoint it changed.

## Problem

The schedule feed sends `endTime === startTime` for every performance:

```
feed PERFORMANCE_TIME entries for The Lion King:
   startTime=12:30:00  endTime=12:30:00
   startTime=13:30:00  endTime=13:30:00
```

#293 taught `buildLiveData` to add the POI's advertised running time. `buildSchedules` was left reading the raw feed value, so the two endpoints disagreed about the same performance:

| endpoint | The Lion King, 12:30 performance |
|---|---|
| `/entity/<id>/live` | 12:30-13:00, **30 min** |
| `/entity/<id>/schedule` | 12:30-12:30, **0 min** |

The duration was there all along — `P1GS34` publishes `{hours: 0, minutes: 30}`. It just wasn't read on that path.

## Fix

Both paths now share one `getShowDurations()` helper, so they cannot drift again.

**Where no duration is published, the feed's end time stands.** That's the honest answer rather than a guessed one. Mickey's PhilharMagic is the real case: `duration` is `null` on the published record `P1G103` and absent entirely on the hidden twin `P1DA13`, so its entries stay zero-length. Only 16 of 144 emittable DLP POIs carry a duration at all.

## Verified against the live feed

```
P1GS34  Lion King      12:30-13:00  30min   (all 4 performances, matches /live)
P1G103  PhilharMagic   12:30-12:30   0min   (duration null, honestly unknown)
```

## Two things worth calling out

**The lookup is keyed on the aliased id.** The schedule feed serves the hidden PhilharMagic twin `P1DA13`, whose rows fold onto published `P1G103`. Keying on the raw feed id silently finds nothing — the same bug one alias further along — so there's a test for it. That mutation survived until the test was added.

**`getShowDurations` tolerates a POI outage.** `buildSchedules` is deliberately built to publish unfiltered when POI is unavailable rather than publish nothing, and my first version's unguarded call turned a degraded day into 60 days of missing schedules. The existing `publishes unfiltered schedules when getPOIData rejects` test caught it immediately.

## Tests

Five new cases: duration applied, no-duration left alone, non-performance entries untouched, the alias path, and live/schedule agreement. Four mutations each killed — duration never applied, duration applied to every entry type, lookup by raw id, rethrowing a POI failure.

Full suite 2042 tests; DLP 40.