### PR TITLE
fix(dlp,shdr): force-close a live entity once it retires from the feed

### DIFF
--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Drop-vs-CLOSED retirement gate (parksapi #83 / #74).
+ *
+ * The collector is upsert-only with no delete path: dropping an entity from
+ * buildLiveData() output changes nothing, so a show that leaves the upstream
+ * feed permanently freezes at its last live value forever. Confirmed
+ * independently on DLP and SHDR. This is the shared, opt-in fix — a
+ * destination that sets `retireMissingLiveEntities = true` gets a synthetic
+ * CLOSED row written once a previously-live entity has been missing from a
+ * full buildLiveData() snapshot for longer than `liveEntityRetirementMs`.
+ */
+
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
+import {Destination} from '../destination.js';
+import config from '../config.js';
+import {CacheLib} from '../cache.js';
+import {Entity, LiveData} from '@themeparks/typelib';
+
+@config
+class RetiringTestDestination extends Destination {
+  public liveIds: string[] = ['show1', 'show2'];
+  public streamScope: ReadonlySet<string> | undefined = undefined;
+
+  constructor(opts?: {retire?: boolean; retirementMs?: number}) {
+    super();
+    if (opts?.retire !== undefined) this.retireMissingLiveEntities = opts.retire;
+    if (opts?.retirementMs !== undefined) this.liveEntityRetirementMs = opts.retirementMs;
+  }
+
+  protected async buildEntityList(): Promise<Entity[]> {
+    return [];
+  }
+
+  protected async buildLiveData(scope?: ReadonlySet<string>): Promise<LiveData[]> {
+    void scope;
+    return this.liveIds.map((id) => ({id, status: 'OPERATING'} as LiveData));
+  }
+}
+
+describe('live entity retirement gate', () => {
+  beforeEach(() => {
+    CacheLib.clearByClassName('RetiringTestDestination');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('defaults to off: a missing entity is silently dropped, not force-closed', async () => {
+    const park = new RetiringTestDestination();
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    park.liveIds = ['show1'];
+    const live = await park.getLiveData();
+
+    expect(live.map((d) => d.id)).toEqual(['show1']);
+  });
+
+  test('an entity missing for less than the retirement window stays silently dropped', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    vi.setSystemTime(Date.now() + 3 * 24 * 60 * 60 * 1000); // 3 days
+    park.liveIds = ['show1'];
+    const live = await park.getLiveData();
+
+    expect(live.map((d) => d.id)).toEqual(['show1']);
+  });
+
+  test('an entity missing past the retirement window is force-closed', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000); // 8 days
+    park.liveIds = ['show1'];
+    const live = await park.getLiveData();
+
+    const retired = live.find((d) => d.id === 'show2');
+    expect(retired).toEqual({id: 'show2', status: 'CLOSED'});
+    // show1 is untouched
+    expect(live.find((d) => d.id === 'show1')).toEqual({id: 'show1', status: 'OPERATING'});
+  });
+
+  test('an entity that reappears before retiring is emitted normally, no synthetic row', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    vi.setSystemTime(Date.now() + 3 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1'];
+    await park.getLiveData();
+
+    vi.setSystemTime(Date.now() + 3 * 24 * 60 * 60 * 1000); // 6 days total, still under threshold
+    park.liveIds = ['show1', 'show2'];
+    const live = await park.getLiveData();
+
+    expect(live).toEqual([
+      {id: 'show1', status: 'OPERATING'},
+      {id: 'show2', status: 'OPERATING'},
+    ]);
+  });
+
+  test('retirement clock resets after a reappearance', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    // show2 reappears at day 6, resetting its clock
+    vi.setSystemTime(Date.now() + 6 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    // 5 more days missing (11 total from first sighting, but only 5 since reappearance)
+    vi.setSystemTime(Date.now() + 5 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1'];
+    const live = await park.getLiveData();
+
+    expect(live.map((d) => d.id)).toEqual(['show1']);
+  });
+
+  test('a partial (scoped) build is never subject to retirement, even past the window', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    vi.setSystemTime(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1'];
+    const live = await park.getLiveData(new Set(['show1']));
+
+    expect(live.map((d) => d.id)).toEqual(['show1']);
+  });
+});

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -4,7 +4,7 @@ import {reusable} from "./promiseReuse.js";
 import {loadProxyConfig, hasProxyConfig, type ProxyConfig} from "./proxy.js";
 import {inject} from "./injector.js";
 import {type HTTPObj, HttpQueue, http} from "./http.js";
-import {cache} from "./cache.js";
+import {cache, CacheLib} from "./cache.js";
 import {VQueueBuilder} from "./virtualQueue/builder.js";
 import {calculateReturnWindow} from "./virtualQueue/timeWindows.js";
 import {formatInTimezone} from "./datetime.js";
@@ -188,6 +188,43 @@ export abstract class Destination {
    * @default false
    */
   hasLiveStream: boolean = false;
+
+  /**
+   * Opt-in: force-close a previously-live entity once it has been absent
+   * from a full buildLiveData() snapshot for longer than
+   * {@link liveEntityRetirementMs}.
+   *
+   * The collector is upsert-only with no delete path, so simply omitting a
+   * retired entity from buildLiveData() output achieves nothing — the last
+   * value sits there indefinitely (see nigloland.ts RIDE_RETIREMENT_MS for
+   * the same trap on a wait-time signal). Confirmed independently on two
+   * park modules: a seasonal show run ends, the entity leaves the upstream
+   * feed entirely, and its live row freezes mid-run — 50+ days OPERATING on
+   * one, 17+ days on another (parksapi #74, #83).
+   *
+   * Off by default. A destination whose buildLiveData() legitimately omits
+   * entities for unrelated reasons (a genuinely partial feed, a bug) would
+   * have them wrongly force-closed, so this only applies where the pattern
+   * has actually been confirmed. Only ever applied to a full snapshot
+   * (`scope` undefined) — a partial/streaming build's absentees carry no
+   * meaning and are never gated.
+   *
+   * @default false
+   */
+  protected retireMissingLiveEntities: boolean = false;
+
+  /**
+   * How long an entity may be missing from a full buildLiveData() snapshot
+   * before {@link retireMissingLiveEntities} presumes it retired and
+   * force-closes it. Conservative default: the confirmed real-world cases
+   * were stale 17 and 50+ days, so a week already improves on both by an
+   * order of magnitude while tolerating a normal multi-day show hiatus.
+   * Override per-destination if evidence supports a tighter or looser
+   * window.
+   *
+   * @default 7 days
+   */
+  protected liveEntityRetirementMs: number = 7 * 24 * 60 * 60 * 1000;
 
   /**
    * Optional cache key prefix for all cached methods.
@@ -963,7 +1000,10 @@ export abstract class Destination {
   @trace()
   async getLiveData(scope?: ReadonlySet<string>): Promise<LiveData[]> {
     await this.init();
-    const data = await this.buildLiveData(scope);
+    let data = await this.buildLiveData(scope);
+    if (this.retireMissingLiveEntities && scope === undefined) {
+      data = await this.applyLiveEntityRetirement(data);
+    }
     // Sanitise waitTime values — must be a finite number or null/undefined.
     // Catches bugs like waitTime:"" which crash downstream integer columns.
     for (const entry of data) {
@@ -980,6 +1020,55 @@ export abstract class Destination {
       }
     }
     for (const entry of data) stripUndefinedDeep(entry);
+    return data;
+  }
+
+  /**
+   * Cache key for this destination's {@link retireMissingLiveEntities}
+   * last-seen tracking. Reuses the same prefix resolution the `@cache`
+   * decorator applies, so it lands in the same namespace
+   * `CacheLib.clearByClassName()` already sweeps for this destination.
+   */
+  private async liveEntityRetirementCacheKey(): Promise<string> {
+    let prefix: string;
+    if (typeof this.getCacheKeyPrefix === 'function') {
+      const result = this.getCacheKeyPrefix();
+      prefix = result instanceof Promise ? await result : result;
+    } else {
+      prefix = this.cacheKeyPrefix || this.constructor.name;
+    }
+    return `${prefix}:liveEntityRetirement`;
+  }
+
+  /**
+   * Diff a full buildLiveData() snapshot against the last-seen timestamps
+   * recorded on the previous call. Any entity that was live before and has
+   * now been missing for {@link liveEntityRetirementMs} gets a synthetic
+   * `{id, status: 'CLOSED'}` row appended — a genuine value change, so the
+   * collector's hash-dedup actually writes it and clears the frozen row.
+   * Entities that reappear simply update their own timestamp and drop out
+   * of consideration; nothing here mutates entries buildLiveData() already
+   * returned.
+   */
+  private async applyLiveEntityRetirement(data: LiveData[]): Promise<LiveData[]> {
+    const key = await this.liveEntityRetirementCacheKey();
+    const now = Date.now();
+    const lastSeen: Record<string, number> = (CacheLib.get(key) as Record<string, number> | null) ?? {};
+
+    const currentIds = new Set(data.map((entry) => entry.id));
+    for (const id of currentIds) lastSeen[id] = now;
+
+    for (const [id, seenAt] of Object.entries(lastSeen)) {
+      if (currentIds.has(id)) continue;
+      if (now - seenAt >= this.liveEntityRetirementMs) {
+        data.push({id, status: 'CLOSED'} as LiveData);
+      }
+    }
+
+    // Long TTL: this tracks "have we ever seen this id live", not a
+    // short-lived cache — losing it early just reverts that one id to the
+    // pre-fix silent-freeze behaviour until it's next seen live.
+    CacheLib.set(key, lastSeen, 400 * 24 * 60 * 60);
     return data;
   }
 

--- a/src/parks/dlp/__tests__/showRetirement.test.ts
+++ b/src/parks/dlp/__tests__/showRetirement.test.ts
@@ -1,0 +1,72 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {DisneylandParis} from '../disneylandparis.js';
+import {CacheLib} from '../../../cache.js';
+
+/**
+ * parksapi #74: a DLP show ("Angel's Pop Star Party") ran its last
+ * performance, left the POI/schedule feeds entirely, and its live row froze
+ * OPERATING with a 7-week-old showtime — dropping a row achieves nothing,
+ * the collector is upsert-only. DLP opts into the shared retirement gate
+ * (destination.ts) to force-close a show once it's been gone this long.
+ */
+function stubbedPark(entertainment: Array<Record<string, unknown>>, schedule: unknown[]): DisneylandParis {
+  const park = new DisneylandParis();
+
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({
+    ThemePark: [{id: 'P1', name: 'Disneyland Park', type: 'ThemePark'}],
+    Entertainment: entertainment,
+  });
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getPremierAccess').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getVirtualQueueData').mockResolvedValue([]);
+  vi.spyOn(park as any, 'getScheduleForDate').mockImplementation(async () => schedule);
+
+  return park;
+}
+
+const SHOW = {
+  id: 'P1GS42', name: "Angel's Pop Star Party", type: 'Entertainment',
+  subType: 'Stage Show', location: {id: 'P1'},
+};
+
+describe('DLP show retirement', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('DisneylandParis');
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('is enabled', () => {
+    expect(new DisneylandParis()['retireMissingLiveEntities']).toBe(true);
+  });
+
+  it('force-closes a show that has been gone from the feed past the retirement window', async () => {
+    vi.useFakeTimers();
+
+    await stubbedPark(
+      [SHOW],
+      [{id: 'P1GS42', schedules: [{date: '2026-06-28', startTime: '11:00:00', endTime: '11:00:00', status: 'PERFORMANCE_TIME'}]}],
+    ).getLiveData();
+
+    // The run ended: gone from the POI feed and the schedule feed alike.
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    const live = await stubbedPark([], []).getLiveData();
+
+    expect(live.find((l) => l.id === 'P1GS42')).toEqual({id: 'P1GS42', status: 'CLOSED'});
+  });
+
+  it('does not force-close a show missing for only a few days', async () => {
+    vi.useFakeTimers();
+
+    await stubbedPark(
+      [SHOW],
+      [{id: 'P1GS42', schedules: [{date: '2026-06-28', startTime: '11:00:00', endTime: '11:00:00', status: 'PERFORMANCE_TIME'}]}],
+    ).getLiveData();
+
+    vi.setSystemTime(Date.now() + 2 * 24 * 60 * 60 * 1000);
+    const live = await stubbedPark([], []).getLiveData();
+
+    expect(live.find((l) => l.id === 'P1GS42')).toBeUndefined();
+  });
+});

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -324,6 +324,14 @@ export class DisneylandParis extends Destination {
   @config
   timezone: string = 'Europe/Paris';
 
+  /**
+   * A seasonal show's POI and schedule entries disappear entirely once its
+   * run ends — buildLiveData() has nothing to key off, so the row would
+   * otherwise freeze at its last live value forever (parksapi #74). See
+   * Destination.retireMissingLiveEntities for the mechanism.
+   */
+  protected retireMissingLiveEntities = true;
+
   constructor(options?: DestinationConstructor) {
     super(options);
     this.addConfigPrefix('DLP');

--- a/src/parks/shdr/__tests__/showRetirement.test.ts
+++ b/src/parks/shdr/__tests__/showRetirement.test.ts
@@ -1,0 +1,55 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {ShanghaiDisneylandResort} from '../shanghaidisneyresort.js';
+import {CacheLib} from '../../../cache.js';
+
+/**
+ * parksapi #83: 4 SHDR shows were found frozen (one 17 days stale, still
+ * OPERATING) after their run ended and they left the wait-times/facility
+ * feeds entirely. Sibling of DLP #74 — same drop-vs-CLOSED pattern, fixed
+ * the same way via the shared retirement gate in destination.ts.
+ */
+function stubbedPark(facilities: Array<Record<string, unknown>>, waitTimes: Array<Record<string, unknown>>): ShanghaiDisneylandResort {
+  const park = new ShanghaiDisneylandResort();
+  vi.spyOn(park as any, 'getFacilities').mockResolvedValue(facilities);
+  vi.spyOn(park as any, 'getWaitTimes').mockResolvedValue(waitTimes);
+  return park;
+}
+
+const SHOW = {id: 'show-birthday-bash', name: '10th Birthday Bash: Summer Beats Celebration', type: 'Entertainment'};
+const showWaitEntry = {id: 'show-birthday-bash', waitTime: {status: 'Operating'}};
+
+describe('SHDR show retirement', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('ShanghaiDisneylandResort');
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('is enabled', () => {
+    expect(new ShanghaiDisneylandResort()['retireMissingLiveEntities']).toBe(true);
+  });
+
+  it('force-closes a show that has been gone from the feed past the retirement window', async () => {
+    vi.useFakeTimers();
+
+    await stubbedPark([SHOW], [showWaitEntry]).getLiveData();
+
+    // Run ends: gone from both the facility list and the wait-times feed.
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    const live = await stubbedPark([], []).getLiveData();
+
+    expect(live.find((l) => l.id === 'show-birthday-bash')).toEqual({id: 'show-birthday-bash', status: 'CLOSED'});
+  });
+
+  it('does not force-close a show missing for only a few days', async () => {
+    vi.useFakeTimers();
+
+    await stubbedPark([SHOW], [showWaitEntry]).getLiveData();
+
+    vi.setSystemTime(Date.now() + 2 * 24 * 60 * 60 * 1000);
+    const live = await stubbedPark([], []).getLiveData();
+
+    expect(live.find((l) => l.id === 'show-birthday-bash')).toBeUndefined();
+  });
+});

--- a/src/parks/shdr/shanghaidisneyresort.ts
+++ b/src/parks/shdr/shanghaidisneyresort.ts
@@ -106,6 +106,14 @@ export class ShanghaiDisneylandResort extends Destination {
   @config
   appVersion: string = '';
 
+  /**
+   * A show's facility record and wait-times row disappear entirely once its
+   * run ends — buildLiveData() has nothing to key off, so the row would
+   * otherwise freeze at its last live value forever (parksapi #83). See
+   * Destination.retireMissingLiveEntities for the mechanism.
+   */
+  protected retireMissingLiveEntities = true;
+
   constructor(options?: DestinationConstructor) {
     super(options);
     this.addConfigPrefix('SHDR');

--- a/src/tools/liveDataRetirement/__tests__/capture.test.ts
+++ b/src/tools/liveDataRetirement/__tests__/capture.test.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect} from 'vitest';
+import {buildCaptureRows} from '../capture.js';
+
+/**
+ * Pure formatting logic for the retirement-gate calibration capture
+ * (parksapi #74 / #83). One JSONL row per live-data entity per poll, so a
+ * gap analysis can later ask "how long was id X actually missing before it
+ * either came back or got force-closed".
+ */
+describe('buildCaptureRows', () => {
+  it('emits one row per live entity with id, status and showtime count', () => {
+    const rows = buildCaptureRows(
+      'disneylandparis',
+      [
+        {id: 'P1GS42', status: 'OPERATING', showtimes: [{startTime: 'a', endTime: 'b', type: 'Performance Time'}]},
+        {id: 'P1RA00', status: 'CLOSED'},
+      ] as any,
+      '2026-08-19T09:00:00.000Z',
+    );
+
+    expect(rows).toEqual([
+      {ts: '2026-08-19T09:00:00.000Z', parksApiId: 'disneylandparis', id: 'P1GS42', status: 'OPERATING', showtimeCount: 1},
+      {ts: '2026-08-19T09:00:00.000Z', parksApiId: 'disneylandparis', id: 'P1RA00', status: 'CLOSED', showtimeCount: 0},
+    ]);
+  });
+
+  it('treats a missing status as null rather than omitting the field', () => {
+    const rows = buildCaptureRows('shanghaidisneylandresort', [{id: 'x'}] as any, '2026-08-19T09:00:00.000Z');
+    expect(rows[0].status).toBeNull();
+  });
+});

--- a/src/tools/liveDataRetirement/capture.ts
+++ b/src/tools/liveDataRetirement/capture.ts
@@ -1,0 +1,85 @@
+/**
+ * Show-retirement calibration capture (parksapi #74 / #83).
+ *
+ * Polls local buildLiveData() output for one or more destinations and
+ * appends one JSONL row per live entity, so the actual absence pattern
+ * (how long a show genuinely disappears from the feed before it comes back
+ * vs. before it's truly gone) can be measured over days rather than
+ * guessed. Feeds calibration of Destination.liveEntityRetirementMs — see
+ * destination.ts and the DLP/SHDR opt-ins.
+ *
+ * Deliberately dumb: no aggregation, no judgement calls, just id/status/
+ * showtime-count/timestamp per poll. Analysis happens later, over the
+ * accumulated file.
+ *
+ * Usage:
+ *   tsx --env-file=.env src/tools/liveDataRetirement/capture.ts \
+ *     --only=disneylandparis,shanghaidisneylandresort \
+ *     --out=/home/cube/monitoring/parksapi-show-retirement/capture.jsonl
+ */
+import {appendFileSync, mkdirSync} from 'node:fs';
+import {dirname} from 'node:path';
+import {getDestinationById} from '../../destinationRegistry.js';
+import {stopHttpQueue} from '../../http.js';
+import {LiveData} from '@themeparks/typelib';
+
+export interface CaptureRow {
+  ts: string;
+  parksApiId: string;
+  id: string;
+  status: string | null;
+  showtimeCount: number;
+}
+
+/** Pure: turn one destination's live-data snapshot into capture rows. */
+export function buildCaptureRows(parksApiId: string, liveData: LiveData[], ts: string): CaptureRow[] {
+  return liveData.map((entry) => ({
+    ts,
+    parksApiId,
+    id: entry.id,
+    status: entry.status ?? null,
+    showtimeCount: entry.showtimes?.length ?? 0,
+  }));
+}
+
+function parseArgs(): {only: string[]; out: string} {
+  const args = process.argv.slice(2);
+  const onlyArg = args.find((a) => a.startsWith('--only='))?.split('=')[1];
+  const outArg = args.find((a) => a.startsWith('--out='))?.split('=')[1];
+  if (!onlyArg) throw new Error('--only=<parksApiId,...> is required');
+  if (!outArg) throw new Error('--out=<path> is required');
+  return {only: onlyArg.split(',').map((s) => s.trim()).filter(Boolean), out: outArg};
+}
+
+async function main() {
+  const {only, out} = parseArgs();
+  mkdirSync(dirname(out), {recursive: true});
+
+  const ts = new Date().toISOString();
+  let rowCount = 0;
+
+  for (const parksApiId of only) {
+    try {
+      const entry = await getDestinationById(parksApiId);
+      if (!entry) {
+        console.error(`[capture] registry miss: ${parksApiId}`);
+        continue;
+      }
+      const inst: any = new entry.DestinationClass();
+      const liveData: LiveData[] = await inst.getLiveData();
+      const rows = buildCaptureRows(parksApiId, liveData, ts);
+      const lines = rows.map((r) => JSON.stringify(r)).join('\n') + '\n';
+      appendFileSync(out, lines);
+      rowCount += rows.length;
+    } catch (e: any) {
+      console.error(`[capture] ${parksApiId} failed: ${e.message}`);
+    }
+  }
+
+  console.log(`[capture] ${ts} wrote ${rowCount} row(s) to ${out}`);
+}
+
+main().catch((err) => {
+  console.error('[capture] fatal:', err);
+  process.exitCode = 1;
+}).finally(() => stopHttpQueue());


### PR DESCRIPTION
## Summary

A seasonal show's run ends and it leaves the upstream feed entirely — no
POI/facility entry, no wait-times row, nothing for `buildLiveData()` to key
off. Dropping the row from the build achieves nothing: the collector is
upsert-only with no delete path, so the last live value (often `OPERATING`)
just sits there forever. Confirmed independently on two park modules: DLP's
"Angel's Pop Star Party" frozen 50+ days, four SHDR shows frozen up to 17
days.

## Fix

Adds an opt-in retirement gate to `Destination.getLiveData()`: once a
previously-live entity has been missing from a **full** `buildLiveData()`
snapshot for longer than `liveEntityRetirementMs` (7 days by default), emit
a synthetic `{id, status: 'CLOSED'}` row — a genuine value change the
collector will actually write, clearing the frozen state.

- Off by default. Only ever applies to full snapshots (`scope === undefined`)
  — a partial/streaming build's absentees carry no meaning.
- Enabled explicitly on `DisneylandParis` and `ShanghaiDisneylandResort`,
  the two destinations where the pattern is confirmed. Not defaulted on
  library-wide: a destination whose `buildLiveData()` legitimately omits
  entities for unrelated reasons would get them wrongly force-closed.
- 7-day default is conservative on purpose. Both confirmed real cases were
  stale far longer (17 and 50+ days), so a week already improves on both by
  an order of magnitude while tolerating a normal multi-day show hiatus.

## Calibration data

Added `src/tools/liveDataRetirement/capture.ts` — polls local live data for
DLP/SHDR and logs `id`/`status`/`showtime-count` per entity per poll. Now
running hourly via cron so the 7-day default can be checked against a real
absence-pattern dataset rather than guessed twice.

## Testing

- `src/__tests__/liveEntityRetirement.test.ts` — the shared mechanism in
  isolation (default-off, under-threshold, over-threshold, reappearance
  resets the clock, scoped builds are never gated).
- `src/parks/dlp/__tests__/showRetirement.test.ts` and
  `src/parks/shdr/__tests__/showRetirement.test.ts` — real park classes
  wired up, reproducing the exact frozen-show shape from each issue.
- `src/tools/liveDataRetirement/__tests__/capture.test.ts` — pure
  row-formatting logic.
- Full suite green (2059 tests), `tsc --noEmit` clean, `npm run build`
  clean.
- Sanity-checked against real upstream data for both destinations
  (`npm run dev -- disneylandparis` / `shanghaidisneylandresort`) — live
  data path unaffected, no crashes. (SHDR's `getEntities()` fails on a
  pre-existing, unrelated bug — a `theme-park` ancestor id with unescaped
  `;` characters reaching an entity id — confirmed present on `main` before
  this branch; filed separately.)

## Test plan

- [x] Full test suite passes
- [x] Typecheck and build pass
- [x] Real upstream sanity check for DLP and SHDR
- [ ] Watch the DLP/SHDR staleness dashboard over the next 1-2 weeks to
      confirm the known frozen rows (Angel's Pop Star Party, SHDR 10th
      Birthday Bash) actually clear once the retirement window elapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)