### PR TITLE
fix(dlp): guard the two remaining midnight-crossing sites against host TZ

### DIFF
--- a/src/parks/dlp/__tests__/dining.test.ts
+++ b/src/parks/dlp/__tests__/dining.test.ts
@@ -151,6 +151,27 @@ describe('DLP dining hours', () => {
     expect(await statusAt('13:00:00', hours)).toBe('CLOSED');
   });
 
+  it('rolls the midnight crossing forward whatever timezone the host runs in', async () => {
+    // `new Date(`${todayStr}T00:00:00`)` parses in the host's zone, so
+    // "add a day, reformat in Europe/Paris" silently fails to advance on
+    // any host east of Paris — Pacific/Kiritimati (UTC+14) is the sharpest
+    // case. shiftDateString (already used a few lines up for the
+    // walkthrough path) anchors at noon UTC instead, so no offset can push
+    // it across a date boundary.
+    const hours = {startTime: '19:00:00', endTime: '01:00:00', status: 'OPERATING'};
+    const original = process.env.TZ;
+    try {
+      for (const tz of ['UTC', 'Pacific/Kiritimati', 'Pacific/Auckland', 'Asia/Tokyo', 'America/Los_Angeles']) {
+        process.env.TZ = tz;
+        expect(await statusAt('23:30:00', hours), tz).toBe('OPERATING');
+        expect(await statusAt('13:00:00', hours), tz).toBe('CLOSED');
+      }
+    } finally {
+      if (original === undefined) delete process.env.TZ;
+      else process.env.TZ = original;
+    }
+  });
+
   it('ignores hours published for another day', async () => {
     const date = parkToday();
     vi.setSystemTime(new Date(`${date}T13:00:00${tzOffset(date)}`));

--- a/src/parks/dlp/__tests__/schedules.test.ts
+++ b/src/parks/dlp/__tests__/schedules.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {DisneylandParis} from '../disneylandparis.js';
+import {formatInTimezone, shiftDateString} from '../../../datetime.js';
 
 /**
  * The schedule feed covers far more than the POI set the park publishes —
@@ -190,6 +191,32 @@ describe('DLP schedules', () => {
       const entry = schedules[0].schedule[0];
       expect(entry.type).toBe('OPERATING');
       expect(entry.closingTime).toContain('T22:00:00');
+    });
+
+    it('rolls a genuinely-published midnight crossing forward whatever timezone the host runs in', async () => {
+      // A real published window (not the duration-derived rollover covered
+      // above) that closes earlier than it opens — e.g. a late-night
+      // attraction open 19:00-01:00. `new Date(`${dateString}T00:00:00`)`
+      // parses in the host's zone, so "add a day, reformat in Europe/Paris"
+      // silently fails to advance on any host east of Paris.
+      const [mm, dd, yyyy] = formatInTimezone(new Date(), 'Europe/Paris', 'date').split('/');
+      const todayStr = `${yyyy}-${mm}-${dd}`;
+      const tomorrowStr = shiftDateString(todayStr, 1);
+
+      const original = process.env.TZ;
+      try {
+        for (const tz of ['UTC', 'Pacific/Kiritimati', 'Pacific/Auckland', 'Asia/Tokyo', 'America/Los_Angeles']) {
+          process.env.TZ = tz;
+          const schedules = await stubbedPark(
+            feedFor(['P1RA00'], {startTime: '19:00:00', endTime: '01:00:00', status: 'OPERATING'}),
+          ).getSchedules();
+          const entry = schedules.find((s) => s.id === 'P1RA00')?.schedule[0];
+          expect(entry?.closingTime, tz).toContain(`${tomorrowStr}T01:00:00`);
+        }
+      } finally {
+        if (original === undefined) delete process.env.TZ;
+        else process.env.TZ = original;
+      }
     });
 
     it('finds the duration through the PhilharMagic alias', async () => {

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -1426,11 +1426,11 @@ export class DisneylandParis extends Destination {
 
       const startTime = constructDateTime(todayStr, hours.startTime.slice(0, 5), this.timezone);
       let endTime = constructDateTime(todayStr, hours.endTime.slice(0, 5), this.timezone);
-      // Midnight crossing, mirroring buildSchedules.
+      // Midnight crossing, mirroring buildSchedules. shiftDateString anchors
+      // at noon UTC; stepping via `new Date(dateStr)` parses in the host's
+      // zone and silently fails to advance on any host east of Paris.
       if (hours.endTime.slice(0, 5) < hours.startTime.slice(0, 5)) {
-        const nextDay = addDays(new Date(`${todayStr}T00:00:00`), 1);
-        const [nmm, ndd, nyyyy] = formatInTimezone(nextDay, this.timezone, 'date').split('/');
-        endTime = constructDateTime(`${nyyyy}-${nmm}-${ndd}`, hours.endTime.slice(0, 5), this.timezone);
+        endTime = constructDateTime(shiftDateString(todayStr, 1), hours.endTime.slice(0, 5), this.timezone);
       }
 
       // Only an explicit OPERATING opens the row; any new status token reads
@@ -1542,13 +1542,11 @@ export class DisneylandParis extends Destination {
 
           // Handle midnight crossing: if close < open, add 1 day to close.
           // Compared on HH:MM so a mixed HH:MM / HH:MM:SS pair can't
-          // fabricate a rollover.
+          // fabricate a rollover. shiftDateString anchors at noon UTC;
+          // stepping via `new Date(dateStr)` parses in the host's zone and
+          // silently fails to advance on any host east of Paris.
           if (hours.endTime.slice(0, 5) < hours.startTime.slice(0, 5)) {
-            const nextDay = addDays(new Date(`${dateString}T00:00:00`), 1);
-            const nextDayStr = formatInTimezone(nextDay, this.timezone, 'date');
-            const [nmm, ndd, nyyyy] = nextDayStr.split('/');
-            const nextDayString = `${nyyyy}-${nmm}-${ndd}`;
-            closeTime = constructDateTime(nextDayString, hours.endTime, this.timezone);
+            closeTime = constructDateTime(shiftDateString(dateString, 1), hours.endTime, this.timezone);
           }
 
           let type: string = 'OPERATING';


### PR DESCRIPTION
## Summary

parksapi #77: `dining.test.ts`'s "rolls a past-midnight close into the
next day" test fails under `TZ=Pacific/Kiritimati` (UTC+14), green under
UTC, America/New_York, Europe/Paris, Asia/Tokyo.

Root cause turned out to be a real production bug, not a test artifact.
Two call sites in `disneylandparis.ts` — the dining-hours block in
`buildLiveData()`, and the equivalent block in `buildSchedules()` — advance
a midnight-crossing close time via:

```ts
const nextDay = addDays(new Date(`${dateStr}T00:00:00`), 1);
```

That bare Date string parses in the **host's local zone**, not the park's.
On any host east of Paris, "add a day" can silently fail to cross the date
boundary before the result gets reformatted into `Europe/Paris`.

A third call site in the same file (the walkthrough-hours window check)
already carries the fix and an explicit warning comment about this exact
trap, landed under #63 ("Guard against the UTC-date-as-local-day trap
library-wide"). These two were simply missed by that sweep.

## Fix

Route both remaining sites through `shiftDateString()` (already imported
in this file, already used at the walkthrough site) instead of the bare
`new Date()` + `addDays` + `formatInTimezone` roundtrip. It anchors at noon
UTC, so no offset or DST shift can push it across a date boundary.

## Testing

- Added a TZ-parameterised regression test at each site (`UTC`,
  `Pacific/Kiritimati`, `Pacific/Auckland`, `Asia/Tokyo`,
  `America/Los_Angeles`) — the same `process.env.TZ` loop pattern already
  used for `shiftDateString`'s own regression test in `datetime.test.ts`.
  Self-contained: catches a regression on `npm test` from any host, no
  external `TZ` override needed.
- Full suite (2047 tests) green under `TZ=Pacific/Kiritimati`,
  `TZ=Pacific/Midway`, and the default host TZ — swept the whole suite,
  not just DLP, per the issue's suggestion. No other host-TZ-dependent
  flakes found.
- `tsc --noEmit` and `npm run build` clean.

Note: "#77" above refers to the ThemeParks/programme tracking issue, not a
parksapi-repo issue — no `Closes` keyword used here since that issue lives
in a different repo and GitHub's auto-close only works within the same
repo. Tracked and closed manually on the programme board.

## Test plan

- [x] Full suite passes under three different TZ values
- [x] Typecheck and build pass
- [x] Confirmed the exact originally-reported failure now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)