### PR TITLE
Movieland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThemeParks.wiki Park Data Backend
 
-An open-source TypeScript library for fetching real-time theme park data — wait times, schedules, and entity metadata — from <!-- destinations:count -->80<!-- /destinations:count -->+ destinations worldwide.
+An open-source TypeScript library for fetching real-time theme park data — wait times, schedules, and entity metadata — from <!-- destinations:count -->81<!-- /destinations:count -->+ destinations worldwide.
 
 This library powers the free API at [ThemeParks.wiki](https://themeparks.wiki).
 
@@ -116,7 +116,7 @@ make COMPOSE="podman-compose --env-file /dev/null --podman-run-args=--userns=kee
 ## Supported Destinations
 
 <!-- destinations:table -->
-80 destinations across Disney, Universal, Cedar Fair, Six Flags, Merlin, and many more.
+81 destinations across Disney, Universal, Cedar Fair, Six Flags, Merlin, and many more.
 
 Some parks are served through a parent destination rather than an id of their own — Cedar Point and Knott's Berry Farm arrive under the Six Flags controller, for instance — so they are entities in the output rather than rows here.
 
@@ -170,6 +170,7 @@ Run `npm run dev -- --list` for the same list with categories.
 | Mid America Parks | `midamericaparks` |
 | Mirabilandia | `mirabilandia` |
 | Movie Park Germany | `movieparkgermany` |
+| Movieland | `movieland` |
 | Nigloland | `nigloland` |
 | Ocean Park Hong Kong | `oceanparkhongkong` |
 | Paradise Country | `paradisecountry` |

--- a/src/parks/movieland/__tests__/movieland.test.ts
+++ b/src/parks/movieland/__tests__/movieland.test.ts
@@ -1,0 +1,239 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  Movieland,
+  movielandEntityId,
+  movielandShowtimes,
+} from "../movieland.js";
+import { CacheLib } from "../../../cache.js";
+import type { HTTPObj } from "../../../http.js";
+
+/**
+ * `shows.it.json` and `points_movieland.json` are two independent Helpy feeds
+ * joined on id, and the join has three wrinkles worth pinning down:
+ *
+ *  1. A show row does not always carry the id of the point it belongs to.
+ *     `mv_show_voicesmagic` (a show row) belongs to `mv_show_voicemagic` (a
+ *     point), and only `infoPointId` links them.
+ *  2. Two show rows can target the same point. "Once upon a time in Bugs Town"
+ *     publishes `mv_show_bugstownshow` at 11:00 and `mv_show_bugstowshow2` at
+ *     19:00, both pointing at `mv_show_bugstownshow`. Both are performances of
+ *     the same show, so both belong in the same entity.
+ *  3. Point ids are not entity-id safe. `mv_show_meet&greet1` has to become
+ *     `mv_show_meet_greet1` to publish, so the lookup set and the id being
+ *     looked up have to agree on which form they are in. That agreement spans
+ *     `buildLiveData` and `movielandShowtimes`, so case 3 is asserted through
+ *     the destination rather than against the helper alone.
+ *
+ * Fixtures are trimmed from the live feeds on 2026-08-26.
+ */
+
+const DATE = "2026-08-26";
+const TZ = "Europe/Rome";
+
+const showRow = (
+  id: string,
+  infoPointId: string | undefined,
+  schedule: Record<string, string[]>,
+) => ({ id, infoPointId, parco: "movieland", schedule });
+
+const showPoint = (id: string, nome: string) => ({
+  id,
+  nome,
+  categoria: "show",
+  lat: "45.47623",
+  lng: "10.7262",
+});
+
+/** Mirrors the lookup set `buildLiveData` hands to the helper. */
+const pointSet = (...pointIds: string[]) =>
+  new Set(pointIds.map(movielandEntityId));
+
+function stubbedPark(points: any[], shows: any[]): Movieland {
+  const park = new Movieland();
+  const asJson = (body: any) =>
+    (async () => ({ json: async () => body }) as any as HTTPObj) as any;
+  park.fetchPoints = asJson(points);
+  park.fetchShows = asJson(shows);
+  return park;
+}
+
+describe("movielandEntityId", () => {
+  test("strips diacritics rather than replacing them", () => {
+    expect(movielandEntityId("mv_casinò")).toBe("mv_casino");
+  });
+
+  test("replaces characters the entity id charset rejects", () => {
+    expect(movielandEntityId("mv_show_meet&greet1")).toBe(
+      "mv_show_meet_greet1",
+    );
+  });
+
+  test("leaves an already-safe id untouched", () => {
+    expect(movielandEntityId("mv_show_medusa")).toBe("mv_show_medusa");
+  });
+});
+
+describe("movielandShowtimes", () => {
+  test("matches a show row on its own id", () => {
+    const live = movielandShowtimes(
+      [showRow("mv_show_medusa", "mv_show_medusa", { [DATE]: ["14:30"] })],
+      pointSet("mv_show_medusa"),
+      DATE,
+      TZ,
+    );
+
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe("mv_show_medusa");
+    expect(live[0].status).toBe("OPERATING");
+    expect(live[0].showtimes).toEqual([
+      { type: "Performance", startTime: "2026-08-26T14:30:00+02:00" },
+    ]);
+  });
+
+  test("falls back to infoPointId when the row id is not itself a point", () => {
+    // Live pairing: row `mv_show_voicesmagic` -> point `mv_show_voicemagic`.
+    const live = movielandShowtimes(
+      [
+        showRow("mv_show_voicesmagic", "mv_show_voicemagic", {
+          [DATE]: ["20:00"],
+        }),
+      ],
+      pointSet("mv_show_voicemagic"),
+      DATE,
+      TZ,
+    );
+
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe("mv_show_voicemagic");
+  });
+
+  test("keeps every performance when two rows target the same point", () => {
+    const live = movielandShowtimes(
+      [
+        showRow("mv_show_bugstownshow", "mv_show_bugstownshow", {
+          [DATE]: ["11:00"],
+        }),
+        showRow("mv_show_bugstowshow2", "mv_show_bugstownshow", {
+          [DATE]: ["19:00"],
+        }),
+      ],
+      pointSet("mv_show_bugstownshow"),
+      DATE,
+      TZ,
+    );
+
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe("mv_show_bugstownshow");
+    expect(live[0].showtimes?.map((s) => s.startTime)).toEqual([
+      "2026-08-26T11:00:00+02:00",
+      "2026-08-26T19:00:00+02:00",
+    ]);
+  });
+
+  test("drops rows belonging to the neighbouring waterpark", () => {
+    // `shows.it.json` carries CanevaWorld Aquapark rows; none of their ids
+    // resolve to a Movieland point.
+    const live = movielandShowtimes(
+      [showRow("cw_show_characters", undefined, { [DATE]: ["12:00"] })],
+      pointSet("mv_show_medusa"),
+      DATE,
+      TZ,
+    );
+
+    expect(live).toEqual([]);
+  });
+
+  test("emits nothing for a show with no performances on the requested date", () => {
+    const live = movielandShowtimes(
+      [
+        showRow("mv_show_medusa", "mv_show_medusa", {
+          "2026-08-27": ["14:30"],
+        }),
+      ],
+      pointSet("mv_show_medusa"),
+      DATE,
+      TZ,
+    );
+
+    expect(live).toEqual([]);
+  });
+
+  test("ignores malformed time strings", () => {
+    const live = movielandShowtimes(
+      [
+        showRow("mv_show_medusa", "mv_show_medusa", {
+          [DATE]: ["14:30", "", "25:00", "TBA"],
+        }),
+      ],
+      pointSet("mv_show_medusa"),
+      DATE,
+      TZ,
+    );
+
+    expect(live[0].showtimes).toHaveLength(1);
+  });
+});
+
+describe("Movieland.buildLiveData", () => {
+  beforeEach(() => {
+    CacheLib.clear();
+    vi.useFakeTimers();
+    // 14:00 in Rome on the fixture date.
+    vi.setSystemTime(new Date("2026-08-26T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    CacheLib.clear();
+  });
+
+  test("publishes a show whose point id needs normalising", async () => {
+    const park = stubbedPark(
+      [showPoint("mv_show_meet&greet1", "Movy Meet & Greet")],
+      [
+        showRow("mv_show_meetgreet", "mv_show_meet&greet1", {
+          [DATE]: ["11:00", "15:00"],
+        }),
+      ],
+    );
+
+    const live = await park.getLiveData();
+
+    expect(live).toHaveLength(1);
+    expect(live[0].id).toBe("mv_show_meet_greet1");
+    expect(live[0].showtimes).toHaveLength(2);
+  });
+
+  test("live data ids match the entity ids the same feed produces", async () => {
+    const points = [
+      showPoint("mv_show_meet&greet1", "Movy Meet & Greet"),
+      showPoint("mv_show_medusa", "Medusa Epic Show"),
+    ];
+    const park = stubbedPark(points, [
+      showRow("mv_show_meetgreet", "mv_show_meet&greet1", {
+        [DATE]: ["11:00"],
+      }),
+      showRow("mv_show_medusa", "mv_show_medusa", { [DATE]: ["14:30"] }),
+    ]);
+
+    const entityIds = new Set((await park.getEntities()).map((e) => e.id));
+    const live = await park.getLiveData();
+
+    expect(live).toHaveLength(2);
+    for (const entry of live) {
+      expect(entityIds).toContain(entry.id);
+    }
+  });
+
+  test("returns no live data rather than throwing when the shows feed fails", async () => {
+    const park = stubbedPark(
+      [showPoint("mv_show_medusa", "Medusa Epic Show")],
+      [],
+    );
+    park.fetchShows = (async () => {
+      throw new Error("503");
+    }) as any;
+
+    await expect(park.getLiveData()).resolves.toEqual([]);
+  });
+});

--- a/src/parks/movieland/movieland.ts
+++ b/src/parks/movieland/movieland.ts
@@ -18,6 +18,9 @@ interface HelpyPoint {
 interface HelpyShow {
   id: string;
   infoPointId?: string;
+  pointId?: string;
+  placeId?: string;
+  parco?: string;
   schedule?: Record<string, string[]>;
 }
 
@@ -35,9 +38,11 @@ export function movielandShowtimes(
   timezone: string,
 ): LiveData[] {
   const result = shows.flatMap(show => {
-    const sourceId = pointIds.has(show.id) ? show.id : show.infoPointId;
-    const id = sourceId && movielandEntityId(sourceId);
-    if (!id || !pointIds.has(id)) return [];
+    const id = [show.id, show.infoPointId]
+      .filter((candidate): candidate is string => !!candidate)
+      .map(movielandEntityId)
+      .find(candidate => pointIds.has(candidate));
+    if (!id) return [];
 
     const showtimes = (show.schedule?.[date] ?? [])
       .filter(time => /^([01]\d|2[0-3]):[0-5]\d$/.test(time))
@@ -45,7 +50,14 @@ export function movielandShowtimes(
 
     return showtimes.length ? [{id, status: 'OPERATING', showtimes} as LiveData] : [];
   });
-  return [...new Map(result.map(entry => [entry.id, entry])).values()];
+  const merged = new Map<string, LiveData>();
+  for (const entry of result) {
+    const existing = merged.get(entry.id);
+    if (existing) existing.showtimes?.push(...entry.showtimes ?? []);
+    else merged.set(entry.id, entry);
+  }
+  for (const entry of merged.values()) entry.showtimes?.sort((a, b) => (a.startTime ?? '').localeCompare(b.startTime ?? ''));
+  return [...merged.values()];
 }
 
 @destinationController({category: 'Canevaworld'})
@@ -125,7 +137,7 @@ export class Movieland extends Destination {
     const shows = await response.json() as HelpyShow[];
     const today = formatInTimezone(new Date(), this.timezone, 'date').split('/');
     const date = `${today[2]}-${today[0]}-${today[1]}`;
-    return movielandShowtimes(shows, new Set(points.filter(p => p.categoria === 'show').map(p => p.id)), date, this.timezone);
+    return movielandShowtimes(shows.filter(show => show.parco === 'movieland'), new Set(points.filter(p => p.categoria === 'show').map(p => movielandEntityId(p.id))), date, this.timezone);
   }
 
   protected async buildSchedules(): Promise<EntitySchedule[]> {

--- a/src/parks/movieland/movieland.ts
+++ b/src/parks/movieland/movieland.ts
@@ -1,0 +1,136 @@
+import {Destination, DestinationConstructor} from '../../destination.js';
+import config from '../../config.js';
+import {cache} from '../../cache.js';
+import {http, HTTPObj} from '../../http.js';
+import {destinationController} from '../../destinationRegistry.js';
+import {constructDateTime, formatInTimezone} from '../../datetime.js';
+import {AttractionTypeEnum, type Entity, type EntitySchedule, type LiveData} from '@themeparks/typelib';
+
+interface HelpyPoint {
+  id: string;
+  nome: string;
+  categoria: string;
+  descrizione?: string;
+  lat?: number | string;
+  lng?: number | string;
+}
+
+interface HelpyShow {
+  id: string;
+  infoPointId?: string;
+  schedule?: Record<string, string[]>;
+}
+
+const DESTINATION_ID = 'canevaworld-resort';
+const PARK_ID = 'movieland';
+
+export function movielandEntityId(id: string): string {
+  return id.normalize('NFD').replace(/\p{Diacritic}/gu, '').replace(/[^\w.-]/g, '_');
+}
+
+export function movielandShowtimes(
+  shows: HelpyShow[],
+  pointIds: Set<string>,
+  date: string,
+  timezone: string,
+): LiveData[] {
+  const result = shows.flatMap(show => {
+    const sourceId = pointIds.has(show.id) ? show.id : show.infoPointId;
+    const id = sourceId && movielandEntityId(sourceId);
+    if (!id || !pointIds.has(id)) return [];
+
+    const showtimes = (show.schedule?.[date] ?? [])
+      .filter(time => /^([01]\d|2[0-3]):[0-5]\d$/.test(time))
+      .map(startTime => ({type: 'Performance', startTime: constructDateTime(date, startTime, timezone)}));
+
+    return showtimes.length ? [{id, status: 'OPERATING', showtimes} as LiveData] : [];
+  });
+  return [...new Map(result.map(entry => [entry.id, entry])).values()];
+}
+
+@destinationController({category: 'Canevaworld'})
+export class Movieland extends Destination {
+  @config baseURL = '';
+  @config timezone = 'Europe/Rome';
+
+  constructor(options?: DestinationConstructor) {
+    super(options);
+    this.addConfigPrefix('MOVIELAND');
+  }
+
+  @http({cacheSeconds: 86400})
+  async fetchPoints(): Promise<HTTPObj> {
+    return {method: 'GET', url: `${this.baseURL}/points_movieland.json`, options: {json: true}} as HTTPObj;
+  }
+
+  @http({cacheSeconds: 300})
+  async fetchShows(): Promise<HTTPObj> {
+    return {method: 'GET', url: `${this.baseURL}/shows.it.json`, options: {json: true}} as HTTPObj;
+  }
+
+  @cache({ttlSeconds: 86400})
+  async getPoints(): Promise<HelpyPoint[]> {
+    return await (await this.fetchPoints()).json();
+  }
+
+  async getDestinations(): Promise<Entity[]> {
+    return [{
+      id: DESTINATION_ID,
+      name: 'Canevaworld Resort',
+      entityType: 'DESTINATION',
+      timezone: this.timezone,
+      location: {latitude: 45.4768, longitude: 10.7262},
+    } as Entity];
+  }
+
+  protected async buildEntityList(): Promise<Entity[]> {
+    const points = await this.getPoints();
+    const park = {
+      id: PARK_ID,
+      name: 'Movieland The Hollywood Park',
+      entityType: 'PARK',
+      parentId: DESTINATION_ID,
+      destinationId: DESTINATION_ID,
+      timezone: this.timezone,
+      location: {latitude: 45.4768, longitude: 10.7262},
+    } as Entity;
+
+    const entities = points.flatMap(point => {
+      const entityType = point.categoria === 'ride' ? 'ATTRACTION'
+        : point.categoria === 'show' ? 'SHOW'
+          : point.categoria === 'food' ? 'RESTAURANT' : undefined;
+      if (!entityType) return [];
+
+      const latitude = point.lat === '' || point.lat == null ? NaN : Number(point.lat);
+      const longitude = point.lng === '' || point.lng == null ? NaN : Number(point.lng);
+      return [{
+        id: movielandEntityId(point.id),
+        name: point.nome,
+        entityType,
+        ...(entityType === 'ATTRACTION' ? {attractionType: AttractionTypeEnum.RIDE} : {}),
+        parentId: PARK_ID,
+        destinationId: DESTINATION_ID,
+        timezone: this.timezone,
+        ...(point.descrizione ? {description: point.descrizione} : {}),
+        ...(Number.isFinite(latitude) && Number.isFinite(longitude) ? {location: {latitude, longitude}} : {}),
+      } as Entity];
+    });
+
+    return [park, ...entities];
+  }
+
+  protected async buildLiveData(): Promise<LiveData[]> {
+    const [points, response] = await Promise.all([this.getPoints(), this.fetchShows().catch(() => null)]);
+    if (!response) return [];
+    const shows = await response.json() as HelpyShow[];
+    const today = formatInTimezone(new Date(), this.timezone, 'date').split('/');
+    const date = `${today[2]}-${today[0]}-${today[1]}`;
+    return movielandShowtimes(shows, new Set(points.filter(p => p.categoria === 'show').map(p => p.id)), date, this.timezone);
+  }
+
+  protected async buildSchedules(): Promise<EntitySchedule[]> {
+    // CanevaWorld blocks server-side calendar requests with Cloudflare and has
+    // no official static schedule source available to this integration.
+    return [];
+  }
+}


### PR DESCRIPTION
Hi, I’m Chrisitan, italian dev, parks and data enthusiast.
I wanted to contribute with one of the few parks in Italy that has, at the moment, some data to be shown. Hope it's ok.

"Movieland The Hollywood Park" is a cinema-themed park within the CanevaWorld Resort in Lazise, near Verona, Italy.

### Summary
This PR adds Movieland support using the public Helpy data sources provided by CanevaWorld.
The integration includes:
- Canevaworld Resort destination;
- Movieland park;
- attractions;
- shows;
- restaurants;
- GPS coordinates;
- descriptions;
- daily showtimes;
- Europe/Rome timezone.

### API sources
Entity metadata is loaded from:
https://www.helpy.canevaworld.it/data/points_movieland.json
Showtimes are loaded independently from:
https://www.helpy.canevaworld.it/data/shows.it.json
Shows are matched by their Helpy ID or, where necessary, by infoPointId.

### Design decisions
- Helpy IDs are preserved when they satisfy the ParksAPI entity ID contract.
- Invalid characters are normalized, for example:
mv_casinò → mv_casino
- Queue and wait-time data are intentionally not exposed because Helpy does not provide a verified live queue feed.
- Showtimes contain only startTime and type: "Performance".

### Park schedules
The official CanevaWorld calendar relies on internal endpoints protected by Cloudflare, which return 403 to server-side requests. No reliable official static schedule source was found, so buildSchedules() intentionally returns: []

Not a lot of data, but at least some data!

NB: there are also data for the nearby waterpark, but I omitted them from this pr. If needed I can expand it.