### PR TITLE
fix(energylandia): stop publishing Energy Pass entrance pins as rides

### DIFF
--- a/src/parks/energylandia/__tests__/energylandia.test.ts
+++ b/src/parks/energylandia/__tests__/energylandia.test.ts
@@ -15,6 +15,7 @@ import {
   buildShowtimes,
   showStatusFromShowtimes,
   resolveShowVenueId,
+  isEnergyPassEntrance,
   WEEKDAYS,
 } from '../energylandia.js';
 import {CacheLib} from '../../../cache.js';
@@ -342,6 +343,76 @@ describe('Energylandia — live data', () => {
     expect(rows[0].date).toBe('2026-08-09');
     expect(rows[0].openingTime).toContain('2026-08-09T10:00:00');
     expect(rows[0].closingTime).toContain('2026-08-09T20:00:00');
+  });
+});
+
+/**
+ * "Energy Pass" is the park's paid skip-the-line product. In August 2026 the
+ * CMS grew 14 `type: 'attraction'` documents named "Wejście Energy Pass -
+ * <ride>" — map pins for the paid-queue entrances, tagged
+ * `filterTags: ['energyPass']`, with empty descriptions and no queue counter.
+ * Left in, every pin published as a real ATTRACTION reporting OPERATING all
+ * day. They are recognised by NAME, deliberately not by tag: tagging the
+ * *rides* the pass covers is a plausible future CMS edit, and a tag-based
+ * filter would then delete 14 real coasters from the published entity list.
+ */
+describe('Energy Pass entrance pins are not rides', () => {
+  const epTag = {arrayValue: {values: [{stringValue: 'energyPass'}]}};
+
+  test('recognises a pin by name in any locale', () => {
+    expect(isEnergyPassEntrance(doc('ep1', {
+      name: nameMap({PL: 'Wejście Energy Pass - Anaconda'}), filterTags: epTag,
+    }))).toBe(true);
+    // Name alone is enough — the tag is corroborating, not required.
+    expect(isEnergyPassEntrance(doc('ep2', {
+      name: nameMap({EN: 'Wejście Energy Pass - HYPERION'}),
+    }))).toBe(true);
+  });
+
+  test('a real ride is never a pin, even if the park tags it energyPass', () => {
+    expect(isEnergyPassEntrance(doc('a1', {
+      name: nameMap({PL: '141. Pepsi Hyperion'}), filterTags: epTag,
+    }))).toBe(false);
+    expect(isEnergyPassEntrance(doc('a2', {
+      name: nameMap({PL: '97. Anaconda'}),
+    }))).toBe(false);
+    // A ride whose name merely contains "Energy" is not the product's name.
+    expect(isEnergyPassEntrance(doc('a3', {
+      name: nameMap({PL: '23. Śmiejżelki Energuś'}),
+    }))).toBe(false);
+    expect(isEnergyPassEntrance(doc('x', {}))).toBe(false);
+  });
+
+  test('pins are excluded from entities and live data together', async () => {
+    const p: any = new Energylandia({config: {...BLANK_CONFIG, waitTimesUrl: 'https://feed.example/'}});
+    p.getShowDocs = async () => [];
+    p.getAttractionDocs = async () => [
+      doc('ride', {active: bool(true), type: str('attraction'), open: bool(true),
+        name: nameMap({PL: '97. Anaconda'}), queueTimeId: int(196)}),
+      doc('pin', {active: bool(true), type: str('attraction'), open: bool(true),
+        name: nameMap({PL: 'Wejście Energy Pass - Anaconda'}), queueTimeId: str(''),
+        filterTags: epTag}),
+    ];
+    p.fetchWaitTimes = async () => ({text: async () => JSON.stringify([
+      {ID_ATRAKCJI: 196, ATRAKCJA: '97 ANACONDA', CZAS_OCZEKIWANIA: 25},
+    ])});
+    p.getCalendarPeriods = async () => [{openFrom: '10:00', openTo: '20:00', days: ['2026-08-09']}];
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-08-09T10:00:00Z')); // 12:00 in Warsaw
+
+      const entities = await p.getEntities();
+      expect(entities.map((e: any) => e.id)).toContain('energylandia-ride');
+      expect(entities.map((e: any) => e.id)).not.toContain('energylandia-pin');
+
+      // The live side must agree, or the pin ships an orphan row on every poll.
+      const live = await p.getLiveData();
+      expect(live.map((l: any) => l.id)).toEqual(['energylandia-ride']);
+      expect(live[0].queue.STANDBY.waitTime).toBe(25);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/parks/energylandia/energylandia.ts
+++ b/src/parks/energylandia/energylandia.ts
@@ -1196,6 +1196,15 @@ export class Energylandia extends Destination {
    * that is how the ~26 operator-only counter rows in the feed (queue counters,
    * FAST-PASS lanes, spares) are excluded without needing a blocklist: they
    * have no Firestore attraction to attach to, and drop out of the join.
+   *
+   * The FAST-PASS counter rows are NOT a paid-queue signal, so nothing here
+   * publishes PAID_STANDBY. Verified 2026-08-26 by sampling the feed every 10
+   * minutes from before opening through peak midday: every FAST-PASS counter
+   * read exactly 0 for the whole window while the standby counters beside them
+   * climbed to 30-50 minutes, so the counters exist in the operator system but
+   * are not wired to anything. Publishing them would report a permanent
+   * zero-minute paid queue that the park never measured. Revisit only if one
+   * of those rows is ever observed non-zero.
    */
   protected async buildLiveData(): Promise<LiveData[]> {
     const [attractions, shows, waits, periods] = await Promise.all([

--- a/src/parks/energylandia/energylandia.ts
+++ b/src/parks/energylandia/energylandia.ts
@@ -507,6 +507,33 @@ export function resolveShowVenueId(slots: ShowSlot[]): string | undefined {
 }
 
 /**
+ * Is this document an Energy Pass entrance marker rather than a real ride?
+ *
+ * "Energy Pass" is the park's paid skip-the-line product: a one-time
+ * fast-track entry per ride, sold separately from admission and valid on 14
+ * named rides. In August 2026 the CMS grew 14 `type: 'attraction'` documents
+ * named "Wejście Energy Pass - <ride>" ("Wejście" = entrance) — map pins
+ * marking the paid-queue entrances, tagged `filterTags: ['energyPass']` for
+ * the app map's Energy Pass filter. They are not rides: descriptions are
+ * empty, `queueTimeId` is the empty string on all 14, and `number` is a
+ * shared 1000 placeholder. Left in, each published as an ATTRACTION entity
+ * reporting OPERATING all day.
+ *
+ * Matched on the NAME, not the filter tag. The tag means "related to Energy
+ * Pass", and the day the park tags the rides the pass covers — a plausible
+ * CMS edit — a tag-based filter would silently drop 14 real coasters from
+ * the entity list, which downstream is a deletion. No real ride will ever
+ * carry the product's own name, so a name match can only catch the pins.
+ * Every locale is checked because `displayNameFor` picks one locale, and the
+ * pin must be recognised regardless of which the collector is running in.
+ */
+export function isEnergyPassEntrance(doc: FsDoc): boolean {
+  const names = fsLocalised(doc.fields?.name);
+  if (!names) return false;
+  return Object.values(names).some((n) => /energy\s*pass/i.test(n));
+}
+
+/**
  * Is the park inside its published operating window right now?
  *
  * Returns undefined when the date is absent from the calendar, which is
@@ -976,7 +1003,12 @@ export class Energylandia extends Destination {
     const docs = await this.getAttractionDocs();
     return docs.filter((d) => {
       const f = d.fields || {};
-      return fsBool(f.active) === true && fsString(f.type) === type;
+      return fsBool(f.active) === true
+        && fsString(f.type) === type
+        // Energy Pass entrance pins are typed 'attraction' but are map
+        // markers for the paid queue, not rides — see isEnergyPassEntrance.
+        // Filtered here so the entity list and live data agree automatically.
+        && !isEnergyPassEntrance(d);
     });
   }
 


### PR DESCRIPTION
The park's CMS added 14 `Wejście Energy Pass - <ride>` attraction documents. These are map pins marking the entrances to the paid skip-the-line queues ("Energy Pass" is the park's paid one-shot fast-track product, sold separately from admission and valid on 14 named rides). They are not rides: empty descriptions, no queue counter id, a shared placeholder catalogue number, and a `filterTags: ['energyPass']` marker driving the app map's filter. Each one was publishing as a real ATTRACTION entity reporting OPERATING all day.

This recognises the pins by name and keeps them out of both the entity list and live data, through the shared document filter so the two cannot disagree.

Matched on the name rather than the `energyPass` filter tag deliberately: tagging the real rides the pass covers is a plausible future CMS edit, and a tag-based filter would then silently drop 14 real coasters from the published entity list, which downstream is a deletion. No real ride will ever carry the product's own name.

Live verification: 103 raw active attraction documents → 14 pins stripped → 89 rides emitted, zero `Energy Pass` strings anywhere in the output, harness 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)