### PR TITLE
fix(universal): force-close HHN attractions once they leave the feed

### DIFF
--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -81,6 +81,9 @@ describe('live entity retirement gate', () => {
 
     vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000); // 8 days
     park.liveIds = ['show1'];
+    // Absence has to corroborate across consecutive polls, not just age.
+    await park.getLiveData();
+    await park.getLiveData();
     const live = await park.getLiveData();
 
     const retired = live.find((d) => d.id === 'show2');
@@ -142,5 +145,144 @@ describe('live entity retirement gate', () => {
     const live = await park.getLiveData(new Set(['show1']));
 
     expect(live.map((d) => d.id)).toEqual(['show1']);
+  });
+
+  /**
+   * The age clock is wall-clock and nothing advances it while the source is
+   * down, so an outage longer than the window leaves every timestamp stale.
+   * Without corroboration the first poll to succeed afterwards would retire
+   * everything missing from that single sample.
+   */
+  describe('corroboration', () => {
+    test('one poll after a long outage does not retire on its own', async () => {
+      vi.useFakeTimers();
+      const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+      park.liveIds = ['show1', 'show2'];
+      await park.getLiveData();
+
+      // Collector down for a month, then one successful poll that happens to
+      // be missing show2.
+      vi.setSystemTime(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      park.liveIds = ['show1'];
+      const live = await park.getLiveData();
+
+      expect(live.map((d) => d.id)).toEqual(['show1']);
+    });
+
+    test('a reappearance resets the miss count, so the count must be consecutive', async () => {
+      vi.useFakeTimers();
+      const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+      park.liveIds = ['show1', 'show2'];
+      await park.getLiveData();
+      vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+
+      park.liveIds = ['show1'];
+      await park.getLiveData();
+      await park.getLiveData();
+
+      // Blips back into the feed, then goes again: the two misses above are
+      // spent, so this poll is only the first of a fresh run.
+      park.liveIds = ['show1', 'show2'];
+      await park.getLiveData();
+      park.liveIds = ['show1'];
+      const live = await park.getLiveData();
+
+      expect(live.map((d) => d.id)).toEqual(['show1']);
+    });
+  });
+
+  /**
+   * A well-formed but gutted payload parses cleanly and never throws, so the
+   * gate has to recognise a collapse for what it is rather than publishing a
+   * confident CLOSED for every entity at an open park.
+   */
+  describe('degraded-feed guard', () => {
+    test('withholds every retirement when most of the tracked set vanishes at once', async () => {
+      vi.useFakeTimers();
+      const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+      await park.getLiveData();
+
+      vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+      park.liveIds = ['a'];
+      await park.getLiveData();
+      await park.getLiveData();
+      const live = await park.getLiveData();
+
+      expect(live.map((d) => d.id)).toEqual(['a']);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('withholding 9 live-entity retirements'));
+      warn.mockRestore();
+    });
+
+    test('a minority retiring is still closed normally', async () => {
+      vi.useFakeTimers();
+      const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+      park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+      await park.getLiveData();
+
+      vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+      park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+      await park.getLiveData();
+      await park.getLiveData();
+      const live = await park.getLiveData();
+
+      expect(live.filter((d) => d.status === 'CLOSED').map((d) => d.id).sort()).toEqual(['h', 'i', 'j']);
+    });
+
+    test('a small destination can still retire most of its entities', async () => {
+      vi.useFakeTimers();
+      const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+      park.liveIds = ['show1', 'show2', 'show3'];
+      await park.getLiveData();
+
+      vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+      park.liveIds = ['show1'];
+      await park.getLiveData();
+      await park.getLiveData();
+      const live = await park.getLiveData();
+
+      expect(live.filter((d) => d.status === 'CLOSED').map((d) => d.id).sort()).toEqual(['show2', 'show3']);
+    });
+  });
+
+  test('a retired entity is closed once, not on every subsequent poll', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1'];
+    await park.getLiveData();
+    await park.getLiveData();
+    const closing = await park.getLiveData();
+    expect(closing.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
+
+    // Still absent, but the close has already been written.
+    const after = await park.getLiveData();
+    expect(after.map((d) => d.id)).toEqual(['show1']);
+  });
+
+  test('reads the flat id-to-timestamp map written before miss counting existed', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    // Shape a deployed 400-day cache still holds.
+    CacheLib.set('RetiringTestDestination:liveEntityRetirement', {show2: Date.now()}, 400 * 24 * 60 * 60);
+
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1'];
+    await park.getLiveData();
+    await park.getLiveData();
+    const live = await park.getLiveData();
+
+    expect(live.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
   });
 });

--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -281,26 +281,103 @@ describe('live entity retirement gate', () => {
    * the threshold fires them all at once on corroboration gathered entirely
    * while the gate was saying the feed could not be trusted.
    */
-  test('a partial recovery after a withheld collapse does not fire on banked misses', async () => {
-    vi.useFakeTimers();
-    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    const all = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+  /**
+   * Zeroing the counts on the withheld build is not enough on its own. The
+   * reset only happens on builds where eligibility is reached, so whether a
+   * partial recovery publishes a wrong CLOSED came down to which beat of the
+   * cycle it landed on — one timing in three still fired, on misses accrued
+   * entirely inside the window the gate had declared untrustworthy. The
+   * cooldown is what makes it hold for every timing.
+   */
+  test.each([5, 6, 7, 8, 9, 10, 11, 12])(
+    'a partial recovery after %i collapsed builds never fires on evidence from the untrusted window',
+    async (collapseBuilds) => {
+      vi.useFakeTimers();
+      const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-    park.liveIds = all;
+      park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+      await park.getLiveData();
+
+      vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+      park.liveIds = ['a'];
+      for (let i = 0; i < collapseBuilds; i++) await park.getLiveData();
+
+      // Partial recovery, which is how these incidents usually end: enough
+      // returns that the eligible set drops back under the threshold.
+      park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+      const live = await park.getLiveData();
+
+      expect(live.filter((d) => d.status === 'CLOSED')).toEqual([]);
+      warn.mockRestore();
+    },
+  );
+
+  /**
+   * A permanently dead id must stop counting as evidence. Otherwise ids
+   * accumulated across seasons eventually exceed the degraded-feed threshold
+   * on every build, the guard trips for good, and the gate silently stops
+   * working — the original freeze, returned, with only a warn to show for it.
+   */
+  test('seasonal ids retiring year after year do not accumulate into a permanent withhold', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const park = new RetiringTestDestination({retire: true, retirementMs: 4 * 60 * 60 * 1000});
+    const yearRound = Array.from({length: 20}, (_, i) => `ride${i}`);
+
+    for (let season = 0; season < 4; season++) {
+      const houses = Array.from({length: 15}, (_, i) => `s${season}_house${i}`);
+
+      // Event runs: houses live alongside the year-round rides.
+      park.liveIds = [...yearRound, ...houses];
+      await park.getLiveData();
+
+      // Season ends: houses gone for good.
+      vi.setSystemTime(Date.now() + 5 * 60 * 60 * 1000);
+      park.liveIds = yearRound;
+      await park.getLiveData();
+      await park.getLiveData();
+      const live = await park.getLiveData();
+
+      const closed = live.filter((d) => d.status === 'CLOSED').map((d) => d.id);
+      expect(closed.sort()).toEqual(houses.sort());
+
+      // A year passes before the next season.
+      vi.setSystemTime(Date.now() + 365 * 24 * 60 * 60 * 1000);
+      park.liveIds = yearRound;
+      await park.getLiveData();
+    }
+
+    expect(warn).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  test('a retired entity stops being repeated once the repeat window elapses', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
     await park.getLiveData();
 
-    // Feed collapses to one id and stays there for several cycles.
     vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
-    park.liveIds = ['a'];
-    for (let i = 0; i < 6; i++) await park.getLiveData();
+    park.liveIds = ['show1'];
+    await park.getLiveData();
+    await park.getLiveData();
+    const closing = await park.getLiveData();
+    expect(closing.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
 
-    // Partial recovery: enough returns that the guard no longer applies.
-    park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
-    const live = await park.getLiveData();
+    // Still repeated a day later, so a dropped push recovers.
+    vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1000);
+    const soon = await park.getLiveData();
+    expect(soon.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
 
-    expect(live.filter((d) => d.status === 'CLOSED')).toEqual([]);
-    warn.mockRestore();
+    // Past the repeat window it is forgotten rather than repeated forever.
+    vi.setSystemTime(Date.now() + 4 * 24 * 60 * 60 * 1000);
+    const later = await park.getLiveData();
+    expect(later.map((d) => d.id)).toEqual(['show1']);
+    vi.restoreAllMocks();
   });
 
   test('reads the flat id-to-timestamp map written before miss counting existed', async () => {

--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -251,7 +251,12 @@ describe('live entity retirement gate', () => {
     });
   });
 
-  test('a retired entity is closed once, not on every subsequent poll', async () => {
+  /**
+   * Nothing here can see whether a build was delivered, and the send path
+   * diffs the current build rather than holding a retry queue, so a close
+   * emitted once and dropped would be lost for good.
+   */
+  test('a retired entity keeps being closed while it stays absent', async () => {
     vi.useFakeTimers();
     const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
 
@@ -265,9 +270,37 @@ describe('live entity retirement gate', () => {
     const closing = await park.getLiveData();
     expect(closing.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
 
-    // Still absent, but the close has already been written.
+    // A push that never landed must not have destroyed the only close.
     const after = await park.getLiveData();
-    expect(after.map((d) => d.id)).toEqual(['show1']);
+    expect(after.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
+  });
+
+  /**
+   * The withhold path still increments misses for everything it declined to
+   * close. Left banked, a partial recovery that drops the eligible set under
+   * the threshold fires them all at once on corroboration gathered entirely
+   * while the gate was saying the feed could not be trusted.
+   */
+  test('a partial recovery after a withheld collapse does not fire on banked misses', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const all = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+    park.liveIds = all;
+    await park.getLiveData();
+
+    // Feed collapses to one id and stays there for several cycles.
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['a'];
+    for (let i = 0; i < 6; i++) await park.getLiveData();
+
+    // Partial recovery: enough returns that the guard no longer applies.
+    park.liveIds = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+    const live = await park.getLiveData();
+
+    expect(live.filter((d) => d.status === 'CLOSED')).toEqual([]);
+    warn.mockRestore();
   });
 
   test('reads the flat id-to-timestamp map written before miss counting existed', async () => {

--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -314,6 +314,89 @@ describe('live entity retirement gate', () => {
   );
 
   /**
+   * A guard reading the set it is about to close cannot see a collapse until
+   * the collapse has outlived the retirement window, because eligibility
+   * needs that window to elapse first. A feed that recovers within one poll
+   * of that moment therefore never gets looked at, and whatever is still
+   * missing gets closed on misses accrued entirely inside the outage. At
+   * Universal's overnight cadence that vulnerable band is one 45-minute poll
+   * wide, so it is reachable roughly one collapse in five.
+   *
+   * Judging on raw absence instead arms the cooldown from the first build of
+   * the collapse, hours before the age window opens.
+   */
+  test.each(Array.from({length: 14}, (_, i) => i + 1))(
+    'a collapse lasting %i polls never force-closes the stragglers on recovery',
+    async (polls) => {
+      vi.useFakeTimers();
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const POLL = 45 * 60 * 1000;
+      const all = Array.from({length: 65}, (_, i) => `ride${i}`);
+      const park = new RetiringTestDestination({retire: true, retirementMs: 4 * 60 * 60 * 1000});
+
+      park.liveIds = all;
+      await park.getLiveData();
+
+      // Feed guts itself to a single row and stays there.
+      park.liveIds = ['ride0'];
+      for (let i = 0; i < polls; i++) {
+        vi.setSystemTime(Date.now() + POLL);
+        await park.getLiveData();
+      }
+
+      // Recovers all but three.
+      park.liveIds = all.slice(0, 62);
+      vi.setSystemTime(Date.now() + POLL);
+      const live = await park.getLiveData();
+
+      expect(live.filter((d) => d.status === 'CLOSED')).toEqual([]);
+      vi.restoreAllMocks();
+      void warn;
+    },
+  );
+
+  /**
+   * Arming off a single sample would make the gate hostage to any source that
+   * legitimately sheds most of its rows on the odd build — it would mute
+   * itself for a full window each time, and a real retirement arriving in
+   * that window would be withheld. The collapse has to hold before the
+   * cooldown arms.
+   */
+  test('a one-build blip does not mute the gate against a genuine retirement', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const all = Array.from({length: 10}, (_, i) => `ride${i}`);
+    const park = new RetiringTestDestination({retire: true, retirementMs: 4 * 60 * 60 * 1000});
+
+    park.liveIds = all;
+    await park.getLiveData();
+
+    // ride9 leaves and builds up its misses, but is not eligible yet.
+    vi.setSystemTime(Date.now() + 3.5 * 60 * 60 * 1000);
+    park.liveIds = all.slice(0, 9);
+    await park.getLiveData();
+    await park.getLiveData();
+
+    // A single degraded sample lands here, then the feed recovers. Arming off
+    // one sample would start a cooldown that is still running when ride9
+    // becomes eligible shortly afterwards.
+    park.liveIds = ['ride0'];
+    await park.getLiveData();
+    park.liveIds = all.slice(0, 9);
+    await park.getLiveData();
+
+    // ride9 crosses the window half an hour later, inside that cooldown.
+    vi.setSystemTime(Date.now() + 0.6 * 60 * 60 * 1000);
+    const live = await park.getLiveData();
+
+    expect(live.find((d) => d.id === 'ride9')).toEqual({id: 'ride9', status: 'CLOSED'});
+    vi.restoreAllMocks();
+    void warn;
+  });
+
+  /**
    * A permanently dead id must stop counting as evidence. Otherwise ids
    * accumulated across seasons eventually exceed the degraded-feed threshold
    * on every build, the guard trips for good, and the gate silently stops

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -1152,6 +1152,7 @@ export abstract class Destination {
     const repeating: string[] = [];
     const eligible: string[] = [];
     let liveTracked = 0;
+    let absent = 0;
 
     for (const [id, state] of Object.entries(tracked)) {
       if (state.retiredAt !== undefined) {
@@ -1164,29 +1165,47 @@ export abstract class Destination {
       }
       liveTracked += 1;
       if (currentIds.has(id)) continue;
+      absent += 1;
       state.misses += 1;
       if (now - state.seenAt >= this.liveEntityRetirementMs && state.misses >= this.liveEntityRetirementMinMisses) {
         eligible.push(id);
       }
     }
 
-    const bulk = eligible.length >= this.liveEntityRetirementMinBulk
-      && eligible.length > liveTracked * this.liveEntityRetirementMaxFraction;
+    // Judge the feed's health on raw absence, not on the set about to be
+    // closed. Eligibility needs the age window to have elapsed, so a guard
+    // reading `eligible` cannot notice a collapse until the collapse has
+    // outlived that window — and a feed that recovers within a poll of that
+    // moment never gets looked at, leaving whatever is still missing to be
+    // closed on misses accrued entirely inside the outage. Absence is visible
+    // from the first build of a collapse instead.
+    const degraded = absent >= this.liveEntityRetirementMinBulk
+      && absent > liveTracked * this.liveEntityRetirementMaxFraction;
+
+    // Arm the cooldown only once the collapse has held, so a source that
+    // legitimately sheds most of its rows on some builds does not mute the
+    // gate on a single sample. Three builds still arms hours before the age
+    // window opens.
+    const guard = this.readLiveEntityRetirementGuard(key);
+    const streak = degraded ? guard.streak + 1 : 0;
+    let withheldAt = guard.withheldAt;
+    if (streak >= this.liveEntityRetirementMinMisses) withheldAt = now;
+
     // A feed that just failed the trust test does not get to retire anything
     // for a full window afterwards. Without this, whether a partial recovery
     // publishes a wrong CLOSED comes down to which build it lands on: the
     // miss counts reset on the withheld build, so a recovery arriving
     // minMisses builds later finds a fresh, complete-looking set of misses
     // accrued entirely inside the untrusted window.
-    const withheldAt = CacheLib.get(`${key}:withheldAt`) as number | null;
     const cooling = withheldAt != null && now - withheldAt < this.liveEntityRetirementMs;
+    CacheLib.set(`${key}:guard`, {withheldAt, streak}, 400 * 24 * 60 * 60);
 
-    if (bulk || (cooling && eligible.length)) {
+    if ((degraded || cooling) && eligible.length) {
       for (const id of eligible) tracked[id].misses = 0;
-      if (bulk) CacheLib.set(`${key}:withheldAt`, now, 400 * 24 * 60 * 60);
       console.warn(
         `[${this.constructor.name}] withholding ${eligible.length} live-entity retirements ` +
-        `(${liveTracked} tracked) — ${bulk ? 'feed looks degraded, not retired' : 'feed still cooling down after a degraded window'}`,
+        `(${absent} of ${liveTracked} absent) — ` +
+        `${degraded ? 'feed looks degraded, not retired' : 'feed still cooling down after a degraded window'}`,
       );
     } else {
       for (const id of eligible) {
@@ -1231,6 +1250,19 @@ export abstract class Destination {
       }
     }
     return out;
+  }
+
+  /**
+   * Read the degraded-feed guard's own state: when it last withheld, and how
+   * many consecutive builds have looked degraded. Kept beside the tracking
+   * map rather than inside it so the map stays a plain id-to-state record.
+   */
+  private readLiveEntityRetirementGuard(key: string): {withheldAt: number | null, streak: number} {
+    const raw = CacheLib.get(`${key}:guard`) as {withheldAt?: unknown, streak?: unknown} | null;
+    return {
+      withheldAt: Number.isFinite(raw?.withheldAt as number) ? (raw!.withheldAt as number) : null,
+      streak: Number.isFinite(raw?.streak as number) ? (raw!.streak as number) : 0,
+    };
   }
 
   /**

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -1099,8 +1099,16 @@ export abstract class Destination {
    * fabricated CLOSED is indistinguishable from a real one downstream, so
    * the log line is the only forensic trail.
    *
-   * A retired id is dropped from tracking once its row is emitted, so the
-   * close is written once rather than re-appended on every subsequent poll.
+   * The CLOSED row is re-appended on every subsequent build for as long as
+   * the entity stays absent, rather than emitted once and forgotten. That
+   * looks wasteful and is deliberate: nothing here can observe whether a
+   * build was actually delivered, and the send path holds no retry queue of
+   * its own — it diffs the rows in the *current* build against the last
+   * committed hashes. A close emitted once and dropped (batch rejected, push
+   * skipped, process died between build and POST) would therefore be lost
+   * for good, leaving exactly the frozen row this gate exists to clear. The
+   * repeat costs one hash comparison per build and collapses to a single
+   * write; the alternative costs correctness.
    */
   private async applyLiveEntityRetirement(data: LiveData[]): Promise<LiveData[]> {
     const key = await this.liveEntityRetirementCacheKey();
@@ -1126,18 +1134,23 @@ export abstract class Destination {
     if (bulk) {
       // Withhold every close this cycle rather than a subset: a feed that has
       // shed this much is not evidence about any single entity.
+      //
+      // Zero the miss counts as well. Otherwise they keep climbing through the
+      // whole incident, and the moment a partial recovery drops the eligible
+      // set back under the threshold, whatever is still absent fires
+      // immediately on hundreds of misses banked while the gate itself was
+      // saying the feed could not be trusted. Recovery has to earn fresh
+      // corroboration.
+      for (const id of eligible) tracked[id].misses = 0;
       console.warn(
         `[${this.constructor.name}] withholding ${eligible.length} live-entity retirements ` +
         `(${trackedCount} tracked) — feed looks degraded, not retired`,
       );
     } else {
-      for (const id of eligible) {
-        data.push({id, status: 'CLOSED'} as LiveData);
-        delete tracked[id];
-      }
+      for (const id of eligible) data.push({id, status: 'CLOSED'} as LiveData);
       if (eligible.length) {
         console.log(
-          `[${this.constructor.name}] force-closed ${eligible.length} live ` +
+          `[${this.constructor.name}] force-closing ${eligible.length} live ` +
           `${eligible.length === 1 ? 'entity' : 'entities'} absent from the feed: ${eligible.join(', ')}`,
         );
       }

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -227,6 +227,45 @@ export abstract class Destination {
   protected liveEntityRetirementMs: number = 7 * 24 * 60 * 60 * 1000;
 
   /**
+   * How many consecutive *successful* snapshots an entity must be absent from
+   * before it can retire, on top of {@link liveEntityRetirementMs}.
+   *
+   * Age alone is wall-clock, and nothing advances it while the source is
+   * down: a proxy block, a container stop or a deploy gap longer than the
+   * window all leave every timestamp stale, so the first poll to succeed
+   * afterwards would retire everything missing from that one sample on the
+   * strength of a single observation. Requiring the absence to repeat means
+   * a close always rests on several independent builds.
+   *
+   * @default 3
+   */
+  protected liveEntityRetirementMinMisses: number = 3;
+
+  /**
+   * Fraction of tracked entities that may retire in one snapshot before the
+   * gate assumes the feed is degraded rather than the entities retired.
+   *
+   * A source can return a well-formed but gutted payload — an empty array, a
+   * CDN stub, a partial regeneration — which parses cleanly and so never
+   * throws. Retiring on that publishes a confident CLOSED for a park that is
+   * open. Mass disappearance is far more often a broken feed than a mass
+   * retirement, so past this share the gate declines to act and warns.
+   *
+   * @default 0.5
+   */
+  protected liveEntityRetirementMaxFraction: number = 0.5;
+
+  /**
+   * Floor below which {@link liveEntityRetirementMaxFraction} does not apply.
+   * A destination tracking a handful of entities can legitimately retire most
+   * of them at once; the proportional guard is aimed at collapses measured in
+   * dozens.
+   *
+   * @default 5
+   */
+  protected liveEntityRetirementMinBulk: number = 5;
+
+  /**
    * Optional cache key prefix for all cached methods.
    * When set, this prefix is prepended to all cache keys, preventing cache collisions
    * when multiple instances of the same base class exist (e.g., multiple parks using the same framework).
@@ -1041,35 +1080,93 @@ export abstract class Destination {
   }
 
   /**
-   * Diff a full buildLiveData() snapshot against the last-seen timestamps
-   * recorded on the previous call. Any entity that was live before and has
-   * now been missing for {@link liveEntityRetirementMs} gets a synthetic
-   * `{id, status: 'CLOSED'}` row appended — a genuine value change, so the
-   * collector's hash-dedup actually writes it and clears the frozen row.
-   * Entities that reappear simply update their own timestamp and drop out
-   * of consideration; nothing here mutates entries buildLiveData() already
-   * returned.
+   * Diff a full buildLiveData() snapshot against what previous calls saw.
+   * An entity that was live before and has now been absent both for longer
+   * than {@link liveEntityRetirementMs} and across
+   * {@link liveEntityRetirementMinMisses} consecutive snapshots gets a
+   * synthetic `{id, status: 'CLOSED'}` row appended — a genuine value change,
+   * so the collector's hash-dedup actually writes it and clears the frozen
+   * row. Entities that reappear reset both counters and drop out of
+   * consideration; nothing here mutates entries buildLiveData() returned.
+   *
+   * Two things stop this speaking with more confidence than it has. The
+   * consecutive-miss requirement means no close ever rests on a single
+   * observation, which matters because the age clock keeps running through
+   * an outage while nothing refreshes it. The proportional guard
+   * ({@link liveEntityRetirementMaxFraction}) declines to act at all when so
+   * much of the tracked set has vanished at once that a degraded feed is the
+   * likelier explanation. Both failures are logged rather than silent: a
+   * fabricated CLOSED is indistinguishable from a real one downstream, so
+   * the log line is the only forensic trail.
+   *
+   * A retired id is dropped from tracking once its row is emitted, so the
+   * close is written once rather than re-appended on every subsequent poll.
    */
   private async applyLiveEntityRetirement(data: LiveData[]): Promise<LiveData[]> {
     const key = await this.liveEntityRetirementCacheKey();
     const now = Date.now();
-    const lastSeen: Record<string, number> = (CacheLib.get(key) as Record<string, number> | null) ?? {};
+    const tracked = this.readLiveEntityRetirementState(key);
 
     const currentIds = new Set(data.map((entry) => entry.id));
-    for (const id of currentIds) lastSeen[id] = now;
+    for (const id of currentIds) tracked[id] = {seenAt: now, misses: 0};
 
-    for (const [id, seenAt] of Object.entries(lastSeen)) {
+    const eligible: string[] = [];
+    for (const [id, state] of Object.entries(tracked)) {
       if (currentIds.has(id)) continue;
-      if (now - seenAt >= this.liveEntityRetirementMs) {
+      state.misses += 1;
+      if (now - state.seenAt >= this.liveEntityRetirementMs && state.misses >= this.liveEntityRetirementMinMisses) {
+        eligible.push(id);
+      }
+    }
+
+    const trackedCount = Object.keys(tracked).length;
+    const bulk = eligible.length >= this.liveEntityRetirementMinBulk
+      && eligible.length > trackedCount * this.liveEntityRetirementMaxFraction;
+
+    if (bulk) {
+      // Withhold every close this cycle rather than a subset: a feed that has
+      // shed this much is not evidence about any single entity.
+      console.warn(
+        `[${this.constructor.name}] withholding ${eligible.length} live-entity retirements ` +
+        `(${trackedCount} tracked) — feed looks degraded, not retired`,
+      );
+    } else {
+      for (const id of eligible) {
         data.push({id, status: 'CLOSED'} as LiveData);
+        delete tracked[id];
+      }
+      if (eligible.length) {
+        console.log(
+          `[${this.constructor.name}] force-closed ${eligible.length} live ` +
+          `${eligible.length === 1 ? 'entity' : 'entities'} absent from the feed: ${eligible.join(', ')}`,
+        );
       }
     }
 
     // Long TTL: this tracks "have we ever seen this id live", not a
     // short-lived cache — losing it early just reverts that one id to the
     // pre-fix silent-freeze behaviour until it's next seen live.
-    CacheLib.set(key, lastSeen, 400 * 24 * 60 * 60);
+    CacheLib.set(key, tracked, 400 * 24 * 60 * 60);
     return data;
+  }
+
+  /**
+   * Read the retirement tracking map, tolerating the flat `id -> timestamp`
+   * shape written before consecutive-miss counting existed. Deployed caches
+   * hold that older shape and live for 400 days, so it has to keep working
+   * rather than force every tracked id back to square one.
+   */
+  private readLiveEntityRetirementState(key: string): Record<string, {seenAt: number, misses: number}> {
+    const raw = CacheLib.get(key) as Record<string, number | {seenAt: number, misses: number}> | null;
+    const out: Record<string, {seenAt: number, misses: number}> = {};
+    for (const [id, value] of Object.entries(raw ?? {})) {
+      if (typeof value === 'number') {
+        out[id] = {seenAt: value, misses: 0};
+      } else if (value && Number.isFinite(value.seenAt)) {
+        out[id] = {seenAt: value.seenAt, misses: Number.isFinite(value.misses) ? value.misses : 0};
+      }
+    }
+    return out;
   }
 
   /**

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -11,6 +11,17 @@ import {formatInTimezone} from "./datetime.js";
 import {stripHtmlTags, decodeHtmlEntities} from "./htmlUtils.js";
 
 /**
+ * Per-entity bookkeeping for the live-entity retirement gate. `misses` counts
+ * consecutive absences from successful builds; `retiredAt` is set once a close
+ * has been emitted, marking the id as settled rather than fresh evidence.
+ */
+interface LiveEntityRetirementState {
+  seenAt: number;
+  misses: number;
+  retiredAt?: number;
+}
+
+/**
  * Patterns for promotional/status text appended or prepended to entity names.
  * Applied after HTML stripping and entity decoding.
  */
@@ -264,6 +275,22 @@ export abstract class Destination {
    * @default 5
    */
   protected liveEntityRetirementMinBulk: number = 5;
+
+  /**
+   * How long a retired entity keeps having its CLOSED row re-appended before
+   * the gate forgets it entirely.
+   *
+   * The repeat exists so a close that was built but never delivered is not
+   * lost for good. It cannot run forever, though: a permanently dead id would
+   * otherwise count as fresh evidence of a collapse on every future build, and
+   * enough of them accumulated across seasons would trip
+   * {@link liveEntityRetirementMaxFraction} for good and silently disable the
+   * gate. A few days covers any rejected batch or dead process by orders of
+   * magnitude, and bounds the pile.
+   *
+   * @default 3 days
+   */
+  protected liveEntityRetirementRepeatMs: number = 3 * 24 * 60 * 60 * 1000;
 
   /**
    * Optional cache key prefix for all cached methods.
@@ -1118,8 +1145,24 @@ export abstract class Destination {
     const currentIds = new Set(data.map((entry) => entry.id));
     for (const id of currentIds) tracked[id] = {seenAt: now, misses: 0};
 
+    // Ids closed on an earlier build. Their row is repeated so a close that
+    // was built but never delivered still lands, but they are settled
+    // business: they say nothing about whether the feed is healthy now, so
+    // they are kept out of both the guard's arithmetic and the log line.
+    const repeating: string[] = [];
     const eligible: string[] = [];
+    let liveTracked = 0;
+
     for (const [id, state] of Object.entries(tracked)) {
+      if (state.retiredAt !== undefined) {
+        if (now - state.retiredAt >= this.liveEntityRetirementRepeatMs) {
+          delete tracked[id];
+        } else if (!currentIds.has(id)) {
+          repeating.push(id);
+        }
+        continue;
+      }
+      liveTracked += 1;
       if (currentIds.has(id)) continue;
       state.misses += 1;
       if (now - state.seenAt >= this.liveEntityRetirementMs && state.misses >= this.liveEntityRetirementMinMisses) {
@@ -1127,27 +1170,29 @@ export abstract class Destination {
       }
     }
 
-    const trackedCount = Object.keys(tracked).length;
     const bulk = eligible.length >= this.liveEntityRetirementMinBulk
-      && eligible.length > trackedCount * this.liveEntityRetirementMaxFraction;
+      && eligible.length > liveTracked * this.liveEntityRetirementMaxFraction;
+    // A feed that just failed the trust test does not get to retire anything
+    // for a full window afterwards. Without this, whether a partial recovery
+    // publishes a wrong CLOSED comes down to which build it lands on: the
+    // miss counts reset on the withheld build, so a recovery arriving
+    // minMisses builds later finds a fresh, complete-looking set of misses
+    // accrued entirely inside the untrusted window.
+    const withheldAt = CacheLib.get(`${key}:withheldAt`) as number | null;
+    const cooling = withheldAt != null && now - withheldAt < this.liveEntityRetirementMs;
 
-    if (bulk) {
-      // Withhold every close this cycle rather than a subset: a feed that has
-      // shed this much is not evidence about any single entity.
-      //
-      // Zero the miss counts as well. Otherwise they keep climbing through the
-      // whole incident, and the moment a partial recovery drops the eligible
-      // set back under the threshold, whatever is still absent fires
-      // immediately on hundreds of misses banked while the gate itself was
-      // saying the feed could not be trusted. Recovery has to earn fresh
-      // corroboration.
+    if (bulk || (cooling && eligible.length)) {
       for (const id of eligible) tracked[id].misses = 0;
+      if (bulk) CacheLib.set(`${key}:withheldAt`, now, 400 * 24 * 60 * 60);
       console.warn(
         `[${this.constructor.name}] withholding ${eligible.length} live-entity retirements ` +
-        `(${trackedCount} tracked) — feed looks degraded, not retired`,
+        `(${liveTracked} tracked) — ${bulk ? 'feed looks degraded, not retired' : 'feed still cooling down after a degraded window'}`,
       );
     } else {
-      for (const id of eligible) data.push({id, status: 'CLOSED'} as LiveData);
+      for (const id of eligible) {
+        data.push({id, status: 'CLOSED'} as LiveData);
+        tracked[id].retiredAt = now;
+      }
       if (eligible.length) {
         console.log(
           `[${this.constructor.name}] force-closing ${eligible.length} live ` +
@@ -1155,6 +1200,8 @@ export abstract class Destination {
         );
       }
     }
+
+    for (const id of repeating) data.push({id, status: 'CLOSED'} as LiveData);
 
     // Long TTL: this tracks "have we ever seen this id live", not a
     // short-lived cache — losing it early just reverts that one id to the
@@ -1169,14 +1216,18 @@ export abstract class Destination {
    * hold that older shape and live for 400 days, so it has to keep working
    * rather than force every tracked id back to square one.
    */
-  private readLiveEntityRetirementState(key: string): Record<string, {seenAt: number, misses: number}> {
-    const raw = CacheLib.get(key) as Record<string, number | {seenAt: number, misses: number}> | null;
-    const out: Record<string, {seenAt: number, misses: number}> = {};
+  private readLiveEntityRetirementState(key: string): Record<string, LiveEntityRetirementState> {
+    const raw = CacheLib.get(key) as Record<string, number | LiveEntityRetirementState> | null;
+    const out: Record<string, LiveEntityRetirementState> = {};
     for (const [id, value] of Object.entries(raw ?? {})) {
       if (typeof value === 'number') {
         out[id] = {seenAt: value, misses: 0};
       } else if (value && Number.isFinite(value.seenAt)) {
-        out[id] = {seenAt: value.seenAt, misses: Number.isFinite(value.misses) ? value.misses : 0};
+        out[id] = {
+          seenAt: value.seenAt,
+          misses: Number.isFinite(value.misses) ? value.misses : 0,
+          ...(Number.isFinite(value.retiredAt as number) ? {retiredAt: value.retiredAt} : {}),
+        };
       }
     }
     return out;

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -246,7 +246,17 @@ export abstract class Destination {
    * window all leave every timestamp stale, so the first poll to succeed
    * afterwards would retire everything missing from that one sample on the
    * strength of a single observation. Requiring the absence to repeat means
-   * a close always rests on several independent builds.
+   * a close always rests on several builds.
+   *
+   * This also sets how long a collapse must persist before the degraded-feed
+   * guard arms, which couples it to the collector's polling interval across
+   * repo boundaries: `liveEntityRetirementMinMisses × pollInterval` has to
+   * land comfortably inside {@link liveEntityRetirementMs}, or the guard
+   * cannot arm before the age window opens and a mistimed recovery is closed
+   * silently again. Universal is the tightest case at 3 × 45 minutes against
+   * a four hour window, a 1.78x margin; the boundary sits at a 80 minute
+   * poll. Raising the collector's closed-park interval past that, or dropping
+   * a destination's window below 135 minutes, reopens the hole.
    *
    * @default 3
    */
@@ -261,6 +271,19 @@ export abstract class Destination {
    * throws. Retiring on that publishes a confident CLOSED for a park that is
    * open. Mass disappearance is far more often a broken feed than a mass
    * retirement, so past this share the gate declines to act and warns.
+   *
+   * Measured against raw absence rather than against the entities that are
+   * eligible to close, because eligibility needs the age window to elapse and
+   * a guard that waited for it could not see a collapse until the collapse
+   * had already outlived it.
+   *
+   * Known limit: this catches simultaneous collapses, not staggered ones. A
+   * source shedding rows in waves, with a retirement window between them,
+   * keeps every wave under the threshold and is genuinely indistinguishable
+   * from progressive retirement without venue-level grouping. Every
+   * simultaneity-based guard shares this, the collector's own bulk-close
+   * guard included. Grouping the fraction per `parkId` is the refinement if
+   * it ever bites in practice.
    *
    * @default 0.5
    */
@@ -1159,6 +1182,12 @@ export abstract class Destination {
         if (now - state.retiredAt >= this.liveEntityRetirementRepeatMs) {
           delete tracked[id];
         } else if (!currentIds.has(id)) {
+          // Unreachable today: the loop above replaces state wholesale for
+          // anything in currentIds, so a retired id cannot also be present.
+          // Kept because it stops being unreachable the moment someone
+          // preserves fields across that assignment instead of overwriting —
+          // at which point a returning entity would emit a stale CLOSED
+          // alongside its live row.
           repeating.push(id);
         }
         continue;
@@ -1258,6 +1287,9 @@ export abstract class Destination {
    * map rather than inside it so the map stays a plain id-to-state record.
    */
   private readLiveEntityRetirementGuard(key: string): {withheldAt: number | null, streak: number} {
+    // Caches written before this key existed simply have no row: the guard
+    // initialises cold, so a cooldown in flight across a deploy is forgotten
+    // once and re-arms within minMisses degraded builds. Fail-open by design.
     const raw = CacheLib.get(`${key}:guard`) as {withheldAt?: unknown, streak?: unknown} | null;
     return {
       withheldAt: Number.isFinite(raw?.withheldAt as number) ? (raw!.withheldAt as number) : null,

--- a/src/parks/dlp/__tests__/showRetirement.test.ts
+++ b/src/parks/dlp/__tests__/showRetirement.test.ts
@@ -51,6 +51,9 @@ describe('DLP show retirement', () => {
 
     // The run ended: gone from the POI feed and the schedule feed alike.
     vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    // The gate wants the absence corroborated across consecutive polls.
+    await stubbedPark([], []).getLiveData();
+    await stubbedPark([], []).getLiveData();
     const live = await stubbedPark([], []).getLiveData();
 
     expect(live.find((l) => l.id === 'P1GS42')).toEqual({id: 'P1GS42', status: 'CLOSED'});

--- a/src/parks/shdr/__tests__/showRetirement.test.ts
+++ b/src/parks/shdr/__tests__/showRetirement.test.ts
@@ -37,6 +37,9 @@ describe('SHDR show retirement', () => {
 
     // Run ends: gone from both the facility list and the wait-times feed.
     vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    // The gate wants the absence corroborated across consecutive polls.
+    await stubbedPark([], []).getLiveData();
+    await stubbedPark([], []).getLiveData();
     const live = await stubbedPark([], []).getLiveData();
 
     expect(live.find((l) => l.id === 'show-birthday-bash')).toEqual({id: 'show-birthday-bash', status: 'CLOSED'});

--- a/src/parks/universal/__tests__/hhnRetirement.test.ts
+++ b/src/parks/universal/__tests__/hhnRetirement.test.ts
@@ -17,11 +17,21 @@ import {CacheLib} from '../../../cache.js';
  * Same drop-vs-CLOSED shape as DLP #74 and SHDR #83, so it takes the same
  * shared gate in destination.ts. What differs is the window: those were
  * end-of-run retirements measured in weeks, whereas HHN leaves and rejoins
- * the feed every single night of the season.
+ * the feed every single night of the season. The timings asserted below are
+ * therefore absolute HHN durations, not multiples of whatever the constant
+ * happens to be — the value is the whole point of the override.
  */
 
 const HOUSE_ID = 'uor.usf.rides.hhn_haunted_house_stranger_things_5';
 const RIDE_ID = 'uor.usf.rides.revenge_of_the_mummy';
+
+const MINUTES = 60 * 1000;
+const HOURS = 60 * MINUTES;
+
+/** Gap between two polls while the day park is shut, per the collector. */
+const CLOSED_PARK_POLL_GAP = 45 * MINUTES;
+/** Event close (01:00-02:00) to the next night's doors (18:30). */
+const DAYTIME_ABSENCE = 16 * HOURS;
 
 /** Real row shape from wait-time-attraction-list.json. */
 const waitRow = (id: string, status: string, wait?: number) => ({
@@ -32,7 +42,6 @@ const waitRow = (id: string, status: string, wait?: number) => ({
 
 function stubbedPark<T extends UniversalOrlando | UniversalStudios>(park: T, waitTimes: any[]): T {
   const p = park as any;
-  p._init = async () => undefined;
   p.getWaitTimes = async () => waitTimes;
   p.getVirtualQueueStates = async () => [];
   p.getShowList = async () => [];
@@ -41,9 +50,17 @@ function stubbedPark<T extends UniversalOrlando | UniversalStudios>(park: T, wai
 }
 
 const orlando = (waitTimes: any[]) => stubbedPark(new UniversalOrlando(), waitTimes);
+const hollywood = (waitTimes: any[]) => stubbedPark(new UniversalStudios(), waitTimes);
 
-/** The window Universal runs, read off the instance rather than hardcoded. */
-const windowMs = (): number => (new UniversalOrlando() as any).liveEntityRetirementMs;
+/**
+ * The gate requires the absence to repeat across consecutive successful
+ * builds, so a realistic run of polls is what actually retires an entity.
+ */
+async function poll(make: () => UniversalOrlando | UniversalStudios, times = 3) {
+  let live: Awaited<ReturnType<UniversalOrlando['getLiveData']>> = [];
+  for (let i = 0; i < times; i++) live = await make().getLiveData();
+  return live;
+}
 
 describe('Universal HHN live-entity retirement', () => {
   beforeEach(() => {
@@ -59,40 +76,72 @@ describe('Universal HHN live-entity retirement', () => {
   });
 
   it('is enabled at both resorts that run the event', () => {
-    expect((new UniversalOrlando() as any).retireMissingLiveEntities).toBe(true);
-    expect((new UniversalStudios() as any).retireMissingLiveEntities).toBe(true);
+    expect(new UniversalOrlando()['retireMissingLiveEntities']).toBe(true);
+    expect(new UniversalStudios()['retireMissingLiveEntities']).toBe(true);
   });
 
-  it('closes the window inside a single overnight gap, not a multi-day one', () => {
-    // The houses rejoin the feed each event night, so a week-long default
-    // would never fire during the season. It still has to clear any plausible
-    // in-event gap between two consecutive samples.
-    expect(windowMs()).toBeGreaterThan(60 * 60 * 1000);
-    expect(windowMs()).toBeLessThan(12 * 60 * 60 * 1000);
-  });
-
-  it('force-closes a house once it has been gone longer than the window', async () => {
+  it('fires inside the nightly gap between events, which the shared default would not', async () => {
     vi.useFakeTimers();
+    await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
 
-    const open = await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
-    expect(open.find(l => l.id === HOUSE_ID)).toMatchObject({status: 'OPERATING'});
-
-    // Event ends; the house leaves the feed entirely.
-    vi.setSystemTime(Date.now() + windowMs() + 60_000);
-    const live = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+    // Morning after an event night, well short of the shared 7-day default.
+    vi.setSystemTime(Date.now() + 10 * HOURS);
+    const live = await poll(() => orlando([waitRow(RIDE_ID, 'OPEN', 15)]));
 
     expect(live.find(l => l.id === HOUSE_ID)).toEqual({id: HOUSE_ID, status: 'CLOSED'});
   });
 
-  it('leaves a house alone while it is only briefly absent', async () => {
+  it('does not fire across a single gap between two polls of a closed park', async () => {
     vi.useFakeTimers();
-
     await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
 
-    vi.setSystemTime(Date.now() + Math.floor(windowMs() / 2));
-    const live = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+    // A house missing from one 45-minute-spaced sample is not a retirement.
+    vi.setSystemTime(Date.now() + CLOSED_PARK_POLL_GAP);
+    const live = await poll(() => orlando([waitRow(RIDE_ID, 'OPEN', 15)]));
 
     expect(live.find(l => l.id === HOUSE_ID)).toBeUndefined();
+  });
+
+  it('still leaves margin before the next night’s doors open', async () => {
+    // Whatever the window is, it has to fire strictly inside the daytime
+    // absence or the house is never closed between events at all.
+    expect(new UniversalOrlando()['liveEntityRetirementMs']).toBeLessThan(DAYTIME_ABSENCE);
+    // And it has to outlast a normal closed-park polling gap by a margin.
+    expect(new UniversalOrlando()['liveEntityRetirementMs']).toBeGreaterThan(2 * CLOSED_PARK_POLL_GAP);
+  });
+
+  it('retires exactly at the window boundary, not a poll later', async () => {
+    vi.useFakeTimers();
+    const park = new UniversalOrlando();
+    const windowMs = park['liveEntityRetirementMs'];
+
+    await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
+    vi.setSystemTime(Date.now() + windowMs);
+    const live = await poll(() => orlando([waitRow(RIDE_ID, 'OPEN', 15)]));
+
+    expect(live.find(l => l.id === HOUSE_ID)).toEqual({id: HOUSE_ID, status: 'CLOSED'});
+  });
+
+  it('closes a Hollywood house on the same terms', async () => {
+    vi.useFakeTimers();
+    const ushHouse = 'ush.usf.rides.hhn_haunted_house_terror_tram';
+    await hollywood([waitRow(ushHouse, 'OPEN', 5)]).getLiveData();
+
+    vi.setSystemTime(Date.now() + 10 * HOURS);
+    const live = await poll(() => hollywood([waitRow('ush.usf.rides.jurassic_world', 'OPEN', 20)]));
+
+    expect(live.find(l => l.id === ushHouse)).toEqual({id: ushHouse, status: 'CLOSED'});
+  });
+
+  it('keeps the two resorts’ tracking apart', async () => {
+    vi.useFakeTimers();
+    await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
+
+    // Hollywood has never seen the Orlando house and must not close it.
+    vi.setSystemTime(Date.now() + 10 * HOURS);
+    const live = await poll(() => hollywood([waitRow('ush.usf.rides.jurassic_world', 'OPEN', 20)]));
+
+    expect(live.map(l => l.id)).toEqual(['ush.usf.rides.jurassic_world']);
   });
 
   it('never force-closes an entity that has not been live in the first place', async () => {
@@ -101,32 +150,57 @@ describe('Universal HHN live-entity retirement', () => {
     // accessibility variants must not be closed on the strength of never
     // having appeared.
     vi.useFakeTimers();
-
     await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
 
-    vi.setSystemTime(Date.now() + windowMs() * 10);
-    const live = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+    vi.setSystemTime(Date.now() + 40 * HOURS);
+    const live = await poll(() => orlando([waitRow(RIDE_ID, 'OPEN', 15)]));
 
     expect(live.map(l => l.id)).toEqual([RIDE_ID]);
   });
 
   it('reopens the house when the next event night puts it back in the feed', async () => {
     vi.useFakeTimers();
-
     await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
 
-    // Daytime: gone long enough to be closed.
-    vi.setSystemTime(Date.now() + windowMs() + 60_000);
-    const closed = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+    vi.setSystemTime(Date.now() + 10 * HOURS);
+    const closed = await poll(() => orlando([waitRow(RIDE_ID, 'OPEN', 15)]));
     expect(closed.find(l => l.id === HOUSE_ID)).toEqual({id: HOUSE_ID, status: 'CLOSED'});
 
     // Doors open again that evening.
-    vi.setSystemTime(Date.now() + 6 * 60 * 60 * 1000);
+    vi.setSystemTime(Date.now() + 8 * HOURS);
     const reopened = await orlando([waitRow(HOUSE_ID, 'OPEN', 10)]).getLiveData();
 
     expect(reopened.find(l => l.id === HOUSE_ID)).toMatchObject({
       status: 'OPERATING',
       queue: {STANDBY: {waitTime: 10}},
     });
+  });
+
+  /**
+   * The shortened window is what makes a degraded feed reachable: the CDN
+   * serving a valid but gutted array parses cleanly and never throws, so
+   * without a guard every ride at the resort publishes CLOSED while the park
+   * is open.
+   */
+  it('withholds every close when the whole wait-time feed empties', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const rides = Array.from({length: 10}, (_, i) => waitRow(`uor.usf.rides.ride_${i}`, 'OPEN', 10));
+
+    await orlando(rides).getLiveData();
+
+    vi.setSystemTime(Date.now() + 10 * HOURS);
+    const live = await poll(() => orlando([]));
+
+    expect(live).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('feed looks degraded'));
+    warn.mockRestore();
+  });
+
+  it('rejects a show feed that is not an array rather than closing every show', async () => {
+    const park = new UniversalOrlando() as any;
+    park.fetchShowList = async () => ({json: async () => ({error: 'nope'})});
+
+    await expect(park.getShowList()).rejects.toThrow(/expected an array/);
   });
 });

--- a/src/parks/universal/__tests__/hhnRetirement.test.ts
+++ b/src/parks/universal/__tests__/hhnRetirement.test.ts
@@ -1,0 +1,132 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {UniversalOrlando, UniversalStudios} from '../universal.js';
+import {CacheLib} from '../../../cache.js';
+
+/**
+ * parksapi #519: every Halloween Horror Nights house was serving OPERATING
+ * with a standby wait at 10:51 ET, `lastUpdated` between 10 and 15 hours old.
+ *
+ * The houses are not stuck OPERATING because the feed says so. Universal
+ * *drops* them from `wait-time-attraction-list.json` outside the event: at
+ * 11:20 ET on 2026-08-26 the feed carried 65 rows and not one of them was an
+ * HHN id, while parksapi still published 34 HHN entities. buildLiveData only
+ * creates a row for an attraction the feed actually lists, so the houses got
+ * no row at all, and a row that is never sent is not a row that says CLOSED —
+ * the wiki simply keeps the last value it was given and freezes.
+ *
+ * Same drop-vs-CLOSED shape as DLP #74 and SHDR #83, so it takes the same
+ * shared gate in destination.ts. What differs is the window: those were
+ * end-of-run retirements measured in weeks, whereas HHN leaves and rejoins
+ * the feed every single night of the season.
+ */
+
+const HOUSE_ID = 'uor.usf.rides.hhn_haunted_house_stranger_things_5';
+const RIDE_ID = 'uor.usf.rides.revenge_of_the_mummy';
+
+/** Real row shape from wait-time-attraction-list.json. */
+const waitRow = (id: string, status: string, wait?: number) => ({
+  wait_time_attraction_id: id,
+  has_single_rider: false,
+  queues: [{queue_type: 'STANDBY', status, ...(wait === undefined ? {} : {display_wait_time: wait})}],
+});
+
+function stubbedPark<T extends UniversalOrlando | UniversalStudios>(park: T, waitTimes: any[]): T {
+  const p = park as any;
+  p._init = async () => undefined;
+  p.getWaitTimes = async () => waitTimes;
+  p.getVirtualQueueStates = async () => [];
+  p.getShowList = async () => [];
+  p.getExpressNowOffers = async () => ({});
+  return park;
+}
+
+const orlando = (waitTimes: any[]) => stubbedPark(new UniversalOrlando(), waitTimes);
+
+/** The window Universal runs, read off the instance rather than hardcoded. */
+const windowMs = (): number => (new UniversalOrlando() as any).liveEntityRetirementMs;
+
+describe('Universal HHN live-entity retirement', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('UniversalOrlando');
+    CacheLib.clearByClassName('UniversalStudios');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    CacheLib.clearByClassName('UniversalOrlando');
+    CacheLib.clearByClassName('UniversalStudios');
+  });
+
+  it('is enabled at both resorts that run the event', () => {
+    expect((new UniversalOrlando() as any).retireMissingLiveEntities).toBe(true);
+    expect((new UniversalStudios() as any).retireMissingLiveEntities).toBe(true);
+  });
+
+  it('closes the window inside a single overnight gap, not a multi-day one', () => {
+    // The houses rejoin the feed each event night, so a week-long default
+    // would never fire during the season. It still has to clear any plausible
+    // in-event gap between two consecutive samples.
+    expect(windowMs()).toBeGreaterThan(60 * 60 * 1000);
+    expect(windowMs()).toBeLessThan(12 * 60 * 60 * 1000);
+  });
+
+  it('force-closes a house once it has been gone longer than the window', async () => {
+    vi.useFakeTimers();
+
+    const open = await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
+    expect(open.find(l => l.id === HOUSE_ID)).toMatchObject({status: 'OPERATING'});
+
+    // Event ends; the house leaves the feed entirely.
+    vi.setSystemTime(Date.now() + windowMs() + 60_000);
+    const live = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+
+    expect(live.find(l => l.id === HOUSE_ID)).toEqual({id: HOUSE_ID, status: 'CLOSED'});
+  });
+
+  it('leaves a house alone while it is only briefly absent', async () => {
+    vi.useFakeTimers();
+
+    await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
+
+    vi.setSystemTime(Date.now() + Math.floor(windowMs() / 2));
+    const live = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+
+    expect(live.find(l => l.id === HOUSE_ID)).toBeUndefined();
+  });
+
+  it('never force-closes an entity that has not been live in the first place', async () => {
+    // parksapi publishes 34 HHN entities but the wait-time feed lists a
+    // handful of houses at most. Scare zones, HHN dining and the DAAP
+    // accessibility variants must not be closed on the strength of never
+    // having appeared.
+    vi.useFakeTimers();
+
+    await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+
+    vi.setSystemTime(Date.now() + windowMs() * 10);
+    const live = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+
+    expect(live.map(l => l.id)).toEqual([RIDE_ID]);
+  });
+
+  it('reopens the house when the next event night puts it back in the feed', async () => {
+    vi.useFakeTimers();
+
+    await orlando([waitRow(HOUSE_ID, 'OPEN', 5)]).getLiveData();
+
+    // Daytime: gone long enough to be closed.
+    vi.setSystemTime(Date.now() + windowMs() + 60_000);
+    const closed = await orlando([waitRow(RIDE_ID, 'OPEN', 15)]).getLiveData();
+    expect(closed.find(l => l.id === HOUSE_ID)).toEqual({id: HOUSE_ID, status: 'CLOSED'});
+
+    // Doors open again that evening.
+    vi.setSystemTime(Date.now() + 6 * 60 * 60 * 1000);
+    const reopened = await orlando([waitRow(HOUSE_ID, 'OPEN', 10)]).getLiveData();
+
+    expect(reopened.find(l => l.id === HOUSE_ID)).toMatchObject({
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 10}},
+    });
+  });
+});

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -493,6 +493,25 @@ class Universal extends Destination {
   @config
   timezone: string = "America/New_York";
 
+  /**
+   * Halloween Horror Nights attractions are absent from
+   * wait-time-attraction-list.json outside the event rather than listed as
+   * closed, so buildLiveData() has nothing to key off and the row freezes at
+   * whatever the last event night reported (parksapi #519). See
+   * Destination.retireMissingLiveEntities for the mechanism.
+   */
+  protected retireMissingLiveEntities = true;
+
+  /**
+   * The shared default is a week, sized for shows that retire at the end of
+   * a run. HHN leaves the feed at closing time and rejoins it the next event
+   * night, so a week would never fire mid-season. Four hours clears any
+   * plausible gap between two samples of a feed we poll every minute while
+   * still landing inside the roughly sixteen-hour daytime absence, so a house
+   * reads CLOSED by early morning and OPERATING again when doors open.
+   */
+  protected liveEntityRetirementMs = 4 * 60 * 60 * 1000;
+
   constructor(options?: DestinationConstructor) {
     super(options);
     this.addConfigPrefix('UNIVERSALSTUDIOS');

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -505,10 +505,15 @@ class Universal extends Destination {
   /**
    * The shared default is a week, sized for shows that retire at the end of
    * a run. HHN leaves the feed at closing time and rejoins it the next event
-   * night, so a week would never fire mid-season. Four hours clears any
-   * plausible gap between two samples of a feed we poll every minute while
-   * still landing inside the roughly sixteen-hour daytime absence, so a house
-   * reads CLOSED by early morning and OPERATING again when doors open.
+   * night, so a week would never fire mid-season.
+   *
+   * Four hours sits between the two bounds that matter. The event runs while
+   * the day park is shut, when the collector polls every 45 minutes, so the
+   * window has to clear a gap of that order: four hours spans roughly five
+   * consecutive polls. It also has to fire inside the daytime absence, which
+   * runs from a 01:00-02:00 close to 18:30 doors, and a close at 05:00-06:00
+   * leaves over twelve hours of margin. Eight hours would not: after a peak
+   * weekend it fires at 10:00, and #519 was reported at 10:51.
    */
   protected liveEntityRetirementMs = 4 * 60 * 60 * 1000;
 
@@ -810,7 +815,15 @@ class Universal extends Destination {
   async getShowList(): Promise<UniversalShowListEntry[]> {
     const resp = await this.fetchShowList();
     const data = await resp.json();
-    return Array.isArray(data) ? (data as UniversalShowListEntry[]) : [];
+    // Shows are published from this feed alone, so coercing an unexpected
+    // shape to [] would read as "every show ended" rather than "the feed
+    // broke" — and with retirement enabled that difference is a day's worth
+    // of shows force-closed mid-performance. Fail instead: a throw withholds
+    // the whole push and leaves the previous values standing.
+    if (!Array.isArray(data)) {
+      throw new Error(`Universal: show-list.json returned ${typeof data}, expected an array`);
+    }
+    return data as UniversalShowListEntry[];
   }
 
   /**
@@ -858,7 +871,11 @@ class Universal extends Destination {
   async getVirtualQueueStates(): Promise<UniversalVirtualQueueState[]> {
     const resp = await this.fetchVirtualQueueStates();
     const data: any = await resp.json();
-    return data?.Results || [];
+    // An absent Results array is a broken response, not an empty queue list.
+    if (!data || !Array.isArray(data.Results)) {
+      throw new Error('Universal: /Queues returned no Results array');
+    }
+    return data.Results as UniversalVirtualQueueState[];
   }
 
   /**


### PR DESCRIPTION
Closes #519

## What was happening

Every Halloween Horror Nights house was serving `OPERATING` with a standby wait at 10:51 ET, `lastUpdated` between 10 and 15 hours old:

```
Cybergoria              OPERATING  standby=5   age=10.3h
Evil Dead Burn          OPERATING  standby=5   age=15.7h
Sinners                 OPERATING  standby=20  age=10.3h
```

## Why

Not because the feed reports them open. Universal **drops** them from `wait-time-attraction-list.json` outside the event rather than listing them as closed. Sampled at 11:20 ET on 2026-08-26 the feed carried 65 rows and not one HHN id, while the library still published 34 HHN entities.

`buildLiveData` only builds a row for an attraction the feed actually lists, so the houses got no row at all. A row that is never sent is not a row that says CLOSED: consumers keep the last value they were given, and it freezes.

## Fix

Same drop-vs-CLOSED shape as DLP #74 and SHDR #83, so it reuses the shared retirement gate in `destination.ts` rather than adding anything new.

The window is what differs. Those cases retire at the end of a run and the shared 7-day default suits them. HHN leaves the feed at closing time and rejoins it the next event night, so a week would never fire mid-season. Universal overrides it to 4 hours: long enough to clear any plausible gap between two samples of a feed polled every minute, short enough to land inside the roughly 16-hour daytime absence, so a house reads CLOSED by early morning and OPERATING again when doors open.

## Why it is safe

`applyLiveEntityRetirement` only tracks ids that have actually appeared in a live snapshot, so the scare zones, HHN dining and the 10 accessibility-return-time variants that never appear in the wait-time feed are never closed on the strength of never having appeared. There is a test pinning that.

## Verification

Against the live feed, seeding a house as last-seen five hours earlier:

```
pass 1: live rows = 94 | HHN row present? false
pass 2 (house last seen 5h ago, still absent from feed):
  row = {"id":"uor.usf.rides.hhn_haunted_house_stranger_things_5","status":"CLOSED"}
  total rows = 94 -> 95 | CLOSED rows = 10 -> 11
```

Exactly one synthetic row, no other entry altered.

* 6 new tests in `src/parks/universal/__tests__/hhnRetirement.test.ts`, 4 of which fail without the change
* full suite 2070 passed
* `tsc --noEmit` clean
* `npm run dev -- universalorlando` 4/4

## Where it would break

The 4-hour window trades blast radius for responsiveness. If the CDN ever served a valid-but-truncated list for more than four hours, attractions missing from it would be force-closed while actually operating. The 7-day default made that essentially impossible; 4 hours makes it merely unlikely. I am sampling the feed every 5 minutes to confirm it holds a stable row count through a full day-night cycle, with the first event night on 2026-08-28 as the confirmation point for the reappearance half. Happy to widen the window if the sampling shows intra-day gaps.