### PR TITLE
feat(universal): publish Halloween Horror Nights as ticketed-event hours

### DIFF
--- a/src/parks/universal/__tests__/fixtures/hhnEventCalendar.json
+++ b/src/parks/universal/__tests__/fixtures/hhnEventCalendar.json
@@ -1,0 +1,1854 @@
+{
+ "Id": "tcm:58-158059-64",
+ "Title": "100 GDS HHN - About",
+ "Filename": "index",
+ "ComponentPresentations": [
+  {
+   "Component": {
+    "LastPublishedDate": "0001-01-01T00:00:00",
+    "RevisionDate": "2026-07-23T20:45:39.085Z",
+    "Schema": {
+     "Folder": {
+      "PublicationId": "tcm:0-58-1",
+      "Id": "tcm:58-18711-2",
+      "Title": "Calendar"
+     },
+     "RootElementName": "GDSCalendar",
+     "Publication": {
+      "Id": "tcm:0-58-1",
+      "Title": "060 UO.com Website (EN-US)"
+     },
+     "Id": "tcm:58-151587-8",
+     "Title": "GDS - Calendar"
+    },
+    "Fields": {
+     "start_date": {
+      "Name": "start_date",
+      "Values": [
+       "8/1/2026 6:30:00 PM"
+      ],
+      "DateTimeValues": [
+       "2026-08-01T18:30:00"
+      ],
+      "FieldType": 9,
+      "KeywordValues": []
+     },
+     "end_date": {
+      "Name": "end_date",
+      "Values": [
+       "11/30/2026 12:00:00 AM"
+      ],
+      "DateTimeValues": [
+       "2026-11-30T00:00:00"
+      ],
+      "FieldType": 9,
+      "KeywordValues": []
+     },
+     "calendarData": {
+      "Name": "calendarData",
+      "Values": [
+       "tcm:58-346637"
+      ],
+      "LinkedComponentValues": [
+       {
+        "LastPublishedDate": "0001-01-01T00:00:00",
+        "RevisionDate": "2026-07-23T20:49:29.914Z",
+        "Schema": {
+         "Folder": {
+          "PublicationId": "tcm:0-58-1",
+          "Id": "tcm:58-18711-2",
+          "Title": "Calendar"
+         },
+         "RootElementName": "GDSCalendarConfiguration",
+         "Publication": {
+          "Id": "tcm:0-58-1",
+          "Title": "060 UO.com Website (EN-US)"
+         },
+         "Id": "tcm:58-151578-8",
+         "Title": "GDS - Calendar Configuration"
+        },
+        "Fields": {
+         "calendarConfig": {
+          "Name": "calendarConfig",
+          "Values": [],
+          "EmbeddedValues": [
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Style 1 (Default)"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Style 1 (Default)",
+               "Key": "style-1",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151582-1024",
+               "Title": "Style 1 (Default)"
+              }
+             ]
+            },
+            "eventDates": {
+             "Name": "eventDates",
+             "Values": [
+              "8/27/2026 2:36:10 PM",
+              "10/19/2026 11:18:02 AM"
+             ],
+             "DateTimeValues": [
+              "2026-08-27T14:36:10",
+              "2026-10-19T11:18:02.455"
+             ],
+             "FieldType": 9,
+             "KeywordValues": []
+            },
+            "blockData": {
+             "Name": "blockData",
+             "Values": [
+              "tcm:58-279946"
+             ],
+             "LinkedComponentValues": [
+              {
+               "LastPublishedDate": "0001-01-01T00:00:00",
+               "RevisionDate": "2025-06-03T18:36:52.773Z",
+               "Schema": {
+                "Folder": {
+                 "PublicationId": "tcm:0-58-1",
+                 "Id": "tcm:58-18711-2",
+                 "Title": "Calendar"
+                },
+                "RootElementName": "GDSCalendarBlockContainer",
+                "Publication": {
+                 "Id": "tcm:0-58-1",
+                 "Title": "060 UO.com Website (EN-US)"
+                },
+                "Id": "tcm:58-151576-8",
+                "Title": "GDS - Calendar Block Container"
+               },
+               "Fields": {
+                "heading": {
+                 "Name": "heading",
+                 "Values": [
+                  "##LongDateFormat##"
+                 ],
+                 "FieldType": 2,
+                 "KeywordValues": []
+                },
+                "blocksData": {
+                 "Name": "blocksData",
+                 "Values": [
+                  "tcm:58-279945"
+                 ],
+                 "LinkedComponentValues": [
+                  {
+                   "LastPublishedDate": "0001-01-01T00:00:00",
+                   "RevisionDate": "2026-07-28T20:52:39.178Z",
+                   "Schema": {
+                    "Folder": {
+                     "PublicationId": "tcm:0-58-1",
+                     "Id": "tcm:58-18711-2",
+                     "Title": "Calendar"
+                    },
+                    "RootElementName": "GDSCalendarBlock",
+                    "Publication": {
+                     "Id": "tcm:0-58-1",
+                     "Title": "060 UO.com Website (EN-US)"
+                    },
+                    "Id": "tcm:58-151575-8",
+                    "Title": "GDS - Calendar Block"
+                   },
+                   "Fields": {
+                    "iconImage": {
+                     "Name": "iconImage",
+                     "Values": [
+                      "tcm:58-151600"
+                     ],
+                     "LinkedComponentValues": [
+                      {
+                       "LastPublishedDate": "0001-01-01T00:00:00",
+                       "RevisionDate": "2022-05-26T18:22:48.16Z",
+                       "Schema": {
+                        "Folder": {
+                         "PublicationId": "tcm:0-58-1",
+                         "Id": "tcm:58-58-2",
+                         "Title": "Multimedia Schemas"
+                        },
+                        "RootElementName": "undefined",
+                        "Publication": {
+                         "Id": "tcm:0-58-1",
+                         "Title": "060 UO.com Website (EN-US)"
+                        },
+                        "Id": "tcm:58-400-8",
+                        "Title": "Image - Global"
+                       },
+                       "Fields": {},
+                       "MetadataFields": {},
+                       "ComponentType": 0,
+                       "Multimedia": {
+                        "Url": "/uor/en/us/files/Images/pumpkin.png",
+                        "MimeType": "image/png",
+                        "FileName": "pumpkin.png",
+                        "FileExtension": "png",
+                        "Size": 62575,
+                        "Width": 0,
+                        "Height": 0
+                       },
+                       "Version": 1,
+                       "Id": "tcm:58-151600",
+                       "Title": "pumpkin-vergd"
+                      }
+                     ],
+                     "FieldType": 5
+                    },
+                    "eyebrow": {
+                     "Name": "eyebrow",
+                     "Values": [
+                      "6:30 PM \u2013 2:00 AM"
+                     ],
+                     "FieldType": 0,
+                     "KeywordValues": []
+                    },
+                    "heading": {
+                     "Name": "heading",
+                     "Values": [
+                      "Halloween Horror Nights Premium Scream Night"
+                     ],
+                     "FieldType": 0,
+                     "KeywordValues": []
+                    },
+                    "description": {
+                     "Name": "description",
+                     "Values": [
+                      "Be one of the first to scream at Halloween Horror Nights. This exclusive event features shorter wait times and all-you-care-to-enjoy select food and non-alcoholic drinks."
+                     ],
+                     "FieldType": 2,
+                     "KeywordValues": []
+                    },
+                    "ctaButton": {
+                     "Name": "ctaButton",
+                     "Values": [],
+                     "EmbeddedValues": [
+                      {
+                       "label": {
+                        "Name": "label",
+                        "Values": [
+                         "Get Tickets"
+                        ],
+                        "FieldType": 0,
+                        "KeywordValues": []
+                       },
+                       "link": {
+                        "Name": "link",
+                        "Values": [],
+                        "EmbeddedValues": [
+                         {
+                          "External": {
+                           "Name": "External",
+                           "Values": [
+                            "https://store.universalorlando.com/en/us/store/c/uo_ice_default_pb_extras/HHN_PREM_NIGHT_ICE?config=true"
+                           ],
+                           "FieldType": 0,
+                           "KeywordValues": []
+                          }
+                         }
+                        ],
+                        "FieldType": 4,
+                        "KeywordValues": []
+                       },
+                       "type": {
+                        "Name": "type",
+                        "Values": [
+                         "tertiary-small"
+                        ],
+                        "FieldType": 3,
+                        "CategoryName": "GDS - Button Types",
+                        "CategoryId": "tcm:58-6718-512",
+                        "KeywordValues": [
+                         {
+                          "IsRoot": false,
+                          "IsAbstract": false,
+                          "Description": "tertiary-small",
+                          "Key": "tertiary-small",
+                          "ParentKeywords": [],
+                          "MetadataFields": {},
+                          "Id": "tcm:58-137829-1024",
+                          "Title": "tertiary-small"
+                         }
+                        ]
+                       },
+                       "target": {
+                        "Name": "target",
+                        "Values": [
+                         "self"
+                        ],
+                        "FieldType": 3,
+                        "CategoryName": "GDS - Button Target",
+                        "CategoryId": "tcm:58-6719-512",
+                        "KeywordValues": [
+                         {
+                          "IsRoot": false,
+                          "IsAbstract": false,
+                          "Description": "self",
+                          "Key": "self",
+                          "ParentKeywords": [],
+                          "MetadataFields": {},
+                          "Id": "tcm:58-73858-1024",
+                          "Title": "self"
+                         }
+                        ]
+                       }
+                      }
+                     ],
+                     "FieldType": 4,
+                     "KeywordValues": []
+                    }
+                   },
+                   "MetadataFields": {
+                    "contentId": {
+                     "Name": "contentId",
+                     "Values": [
+                      "gds-hhn-2025-premium-scream-night-calendar-block-data"
+                     ],
+                     "NumericValues": [],
+                     "DateTimeValues": [],
+                     "LinkedComponentValues": [],
+                     "FieldType": 0,
+                     "XPath": "tcm:Metadata/custom:Metadata/custom:contentId",
+                     "KeywordValues": []
+                    }
+                   },
+                   "ComponentType": 1,
+                   "Version": 8,
+                   "Id": "tcm:58-279945",
+                   "Title": "GDS - HHN - SHARED - Calendar Block Data - Event - Premium Scream Night"
+                  }
+                 ],
+                 "FieldType": 6
+                }
+               },
+               "MetadataFields": {},
+               "ComponentType": 1,
+               "Version": 5,
+               "Id": "tcm:58-279946",
+               "Title": "GDS - HHN - SHARED - Calendar Block Data Container - Event - Premium Scream Night"
+              }
+             ],
+             "FieldType": 6
+            }
+           },
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Style 1 (Default)"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Style 1 (Default)",
+               "Key": "style-1",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151582-1024",
+               "Title": "Style 1 (Default)"
+              }
+             ]
+            },
+            "eventDates": {
+             "Name": "eventDates",
+             "Values": [
+              "8/28/2026 1:19:17 PM",
+              "8/29/2026 1:19:17 PM",
+              "8/30/2026 1:19:17 PM",
+              "9/2/2026 1:19:17 PM",
+              "9/3/2026 1:19:17 PM",
+              "9/4/2026 1:19:17 PM",
+              "9/5/2026 1:19:17 PM",
+              "9/6/2026 1:19:17 PM",
+              "9/9/2026 1:19:17 PM",
+              "9/10/2026 1:19:17 PM",
+              "9/11/2026 1:19:17 PM",
+              "9/12/2026 1:19:17 PM",
+              "9/13/2026 1:19:17 PM",
+              "9/16/2026 1:19:17 PM",
+              "9/17/2026 1:19:17 PM",
+              "9/18/2026 1:19:17 PM",
+              "9/19/2026 1:19:17 PM",
+              "9/20/2026 1:19:17 PM",
+              "9/23/2026 1:19:17 PM",
+              "9/24/2026 1:19:17 PM",
+              "9/25/2026 1:19:17 PM",
+              "9/26/2026 1:19:17 PM",
+              "9/27/2026 1:19:17 PM",
+              "9/30/2026 1:19:17 PM",
+              "10/1/2026 1:19:17 PM",
+              "10/2/2026 1:19:17 PM",
+              "10/3/2026 1:19:17 PM",
+              "10/4/2026 1:19:17 PM",
+              "10/7/2026 1:19:17 PM",
+              "10/8/2026 1:19:17 PM",
+              "10/9/2026 1:19:17 PM",
+              "10/10/2026 1:19:17 PM",
+              "10/11/2026 1:19:17 PM",
+              "10/14/2026 1:19:17 PM",
+              "10/15/2026 1:19:17 PM",
+              "10/16/2026 1:19:17 PM",
+              "10/17/2026 1:19:17 PM",
+              "10/18/2026 1:19:17 PM",
+              "10/21/2026 1:19:17 PM",
+              "10/22/2026 1:19:17 PM",
+              "10/23/2026 1:19:17 PM",
+              "10/24/2026 1:19:17 PM",
+              "10/25/2026 1:19:17 PM",
+              "10/28/2026 1:19:17 PM",
+              "10/29/2026 1:19:17 PM",
+              "10/30/2026 1:19:17 PM",
+              "10/31/2026 1:19:17 PM",
+              "11/1/2026 1:19:17 PM",
+              "10/12/2026 12:00:00 AM"
+             ],
+             "DateTimeValues": [
+              "2026-08-28T13:19:17.126",
+              "2026-08-29T13:19:17.126",
+              "2026-08-30T13:19:17.126",
+              "2026-09-02T13:19:17.126",
+              "2026-09-03T13:19:17.126",
+              "2026-09-04T13:19:17.126",
+              "2026-09-05T13:19:17.126",
+              "2026-09-06T13:19:17.126",
+              "2026-09-09T13:19:17.126",
+              "2026-09-10T13:19:17.126",
+              "2026-09-11T13:19:17.126",
+              "2026-09-12T13:19:17.126",
+              "2026-09-13T13:19:17.126",
+              "2026-09-16T13:19:17.126",
+              "2026-09-17T13:19:17.126",
+              "2026-09-18T13:19:17.126",
+              "2026-09-19T13:19:17.126",
+              "2026-09-20T13:19:17.126",
+              "2026-09-23T13:19:17.126",
+              "2026-09-24T13:19:17.126",
+              "2026-09-25T13:19:17.126",
+              "2026-09-26T13:19:17.126",
+              "2026-09-27T13:19:17.126",
+              "2026-09-30T13:19:17.126",
+              "2026-10-01T13:19:17.126",
+              "2026-10-02T13:19:17.126",
+              "2026-10-03T13:19:17.126",
+              "2026-10-04T13:19:17.126",
+              "2026-10-07T13:19:17.126",
+              "2026-10-08T13:19:17.126",
+              "2026-10-09T13:19:17.126",
+              "2026-10-10T13:19:17.126",
+              "2026-10-11T13:19:17.126",
+              "2026-10-14T13:19:17.126",
+              "2026-10-15T13:19:17.126",
+              "2026-10-16T13:19:17.126",
+              "2026-10-17T13:19:17.126",
+              "2026-10-18T13:19:17.126",
+              "2026-10-21T13:19:17.126",
+              "2026-10-22T13:19:17.126",
+              "2026-10-23T13:19:17.126",
+              "2026-10-24T13:19:17.126",
+              "2026-10-25T13:19:17.126",
+              "2026-10-28T13:19:17.126",
+              "2026-10-29T13:19:17.126",
+              "2026-10-30T13:19:17.126",
+              "2026-10-31T13:19:17.126",
+              "2026-11-01T13:19:17.126",
+              "2026-10-12T00:00:00"
+             ],
+             "FieldType": 9,
+             "KeywordValues": []
+            },
+            "blockData": {
+             "Name": "blockData",
+             "Values": [
+              "tcm:58-346640"
+             ],
+             "LinkedComponentValues": [
+              {
+               "LastPublishedDate": "0001-01-01T00:00:00",
+               "RevisionDate": "2026-07-23T20:48:21.732Z",
+               "Schema": {
+                "Folder": {
+                 "PublicationId": "tcm:0-58-1",
+                 "Id": "tcm:58-18711-2",
+                 "Title": "Calendar"
+                },
+                "RootElementName": "GDSCalendarBlockContainer",
+                "Publication": {
+                 "Id": "tcm:0-58-1",
+                 "Title": "060 UO.com Website (EN-US)"
+                },
+                "Id": "tcm:58-151576-8",
+                "Title": "GDS - Calendar Block Container"
+               },
+               "Fields": {
+                "heading": {
+                 "Name": "heading",
+                 "Values": [
+                  "##LongDateFormat##"
+                 ],
+                 "FieldType": 2,
+                 "KeywordValues": []
+                },
+                "blocksData": {
+                 "Name": "blocksData",
+                 "Values": [
+                  "tcm:58-346641"
+                 ],
+                 "LinkedComponentValues": [
+                  {
+                   "LastPublishedDate": "0001-01-01T00:00:00",
+                   "RevisionDate": "2026-07-23T20:47:55.74Z",
+                   "Schema": {
+                    "Folder": {
+                     "PublicationId": "tcm:0-58-1",
+                     "Id": "tcm:58-18711-2",
+                     "Title": "Calendar"
+                    },
+                    "RootElementName": "GDSCalendarBlock",
+                    "Publication": {
+                     "Id": "tcm:0-58-1",
+                     "Title": "060 UO.com Website (EN-US)"
+                    },
+                    "Id": "tcm:58-151575-8",
+                    "Title": "GDS - Calendar Block"
+                   },
+                   "Fields": {
+                    "iconImage": {
+                     "Name": "iconImage",
+                     "Values": [
+                      "tcm:58-151600"
+                     ],
+                     "LinkedComponentValues": [
+                      {
+                       "LastPublishedDate": "0001-01-01T00:00:00",
+                       "RevisionDate": "2022-05-26T18:22:48.16Z",
+                       "Schema": {
+                        "Folder": {
+                         "PublicationId": "tcm:0-58-1",
+                         "Id": "tcm:58-58-2",
+                         "Title": "Multimedia Schemas"
+                        },
+                        "RootElementName": "undefined",
+                        "Publication": {
+                         "Id": "tcm:0-58-1",
+                         "Title": "060 UO.com Website (EN-US)"
+                        },
+                        "Id": "tcm:58-400-8",
+                        "Title": "Image - Global"
+                       },
+                       "Fields": {},
+                       "MetadataFields": {},
+                       "ComponentType": 0,
+                       "Multimedia": {
+                        "Url": "/uor/en/us/files/Images/pumpkin.png",
+                        "MimeType": "image/png",
+                        "FileName": "pumpkin.png",
+                        "FileExtension": "png",
+                        "Size": 62575,
+                        "Width": 0,
+                        "Height": 0
+                       },
+                       "Version": 1,
+                       "Id": "tcm:58-151600",
+                       "Title": "pumpkin-vergd"
+                      }
+                     ],
+                     "FieldType": 5
+                    },
+                    "eyebrow": {
+                     "Name": "eyebrow",
+                     "Values": [
+                      "Halloween Horror Nights"
+                     ],
+                     "FieldType": 0,
+                     "KeywordValues": []
+                    },
+                    "heading": {
+                     "Name": "heading",
+                     "Values": [
+                      "6:30 PM - 2:00 AM"
+                     ],
+                     "FieldType": 0,
+                     "KeywordValues": []
+                    },
+                    "ctaButton": {
+                     "Name": "ctaButton",
+                     "Values": [],
+                     "EmbeddedValues": [
+                      {
+                       "label": {
+                        "Name": "label",
+                        "Values": [
+                         "Get Tickets "
+                        ],
+                        "FieldType": 0,
+                        "KeywordValues": []
+                       },
+                       "link": {
+                        "Name": "link",
+                        "Values": [],
+                        "EmbeddedValues": [
+                         {
+                          "External": {
+                           "Name": "External",
+                           "Values": [
+                            "https://store.universalorlando.com/en/us/store/c/uo_ice_default_pb_extras?query=:recommended:allCategories:uo_ice_default_pb_extras:Recommended%20Extras%20Sort:fvHHN"
+                           ],
+                           "FieldType": 0,
+                           "KeywordValues": []
+                          }
+                         }
+                        ],
+                        "FieldType": 4,
+                        "KeywordValues": []
+                       },
+                       "type": {
+                        "Name": "type",
+                        "Values": [
+                         "tertiary-small"
+                        ],
+                        "FieldType": 3,
+                        "CategoryName": "GDS - Button Types",
+                        "CategoryId": "tcm:58-6718-512",
+                        "KeywordValues": [
+                         {
+                          "IsRoot": false,
+                          "IsAbstract": false,
+                          "Description": "tertiary-small",
+                          "Key": "tertiary-small",
+                          "ParentKeywords": [],
+                          "MetadataFields": {},
+                          "Id": "tcm:58-137829-1024",
+                          "Title": "tertiary-small"
+                         }
+                        ]
+                       },
+                       "target": {
+                        "Name": "target",
+                        "Values": [
+                         "self"
+                        ],
+                        "FieldType": 3,
+                        "CategoryName": "GDS - Button Target",
+                        "CategoryId": "tcm:58-6719-512",
+                        "KeywordValues": [
+                         {
+                          "IsRoot": false,
+                          "IsAbstract": false,
+                          "Description": "self",
+                          "Key": "self",
+                          "ParentKeywords": [],
+                          "MetadataFields": {},
+                          "Id": "tcm:58-73858-1024",
+                          "Title": "self"
+                         }
+                        ]
+                       }
+                      }
+                     ],
+                     "FieldType": 4,
+                     "KeywordValues": []
+                    }
+                   },
+                   "MetadataFields": {
+                    "contentId": {
+                     "Name": "contentId",
+                     "Values": [
+                      "hhn-calendar-data-block-event-about"
+                     ],
+                     "NumericValues": [],
+                     "DateTimeValues": [],
+                     "LinkedComponentValues": [],
+                     "FieldType": 0,
+                     "XPath": "tcm:Metadata/custom:Metadata/custom:contentId",
+                     "KeywordValues": []
+                    }
+                   },
+                   "ComponentType": 1,
+                   "Version": 2,
+                   "Id": "tcm:58-346641",
+                   "Title": "GDS - HHN - About - Calendar Block Data - Event"
+                  }
+                 ],
+                 "FieldType": 6
+                }
+               },
+               "MetadataFields": {},
+               "ComponentType": 1,
+               "Version": 3,
+               "Id": "tcm:58-346640",
+               "Title": "GDS - HHN - About - Calendar Block Data Container - with valid event data"
+              }
+             ],
+             "FieldType": 6
+            }
+           },
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Style 2"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Style 2",
+               "Key": "style-2",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151581-1024",
+               "Title": "Style 2"
+              }
+             ]
+            },
+            "eventDates": {
+             "Name": "eventDates",
+             "Values": [
+              "8/31/2026 1:19:17 PM",
+              "9/1/2026 1:19:17 PM",
+              "9/7/2026 1:19:17 PM",
+              "9/8/2026 1:19:17 PM",
+              "9/14/2026 1:19:17 PM",
+              "9/15/2026 1:19:17 PM",
+              "9/21/2026 1:19:17 PM",
+              "9/22/2026 1:19:17 PM",
+              "9/28/2026 1:19:17 PM",
+              "9/29/2026 1:19:17 PM",
+              "10/5/2026 1:19:17 PM",
+              "10/6/2026 1:19:17 PM",
+              "10/13/2026 1:19:17 PM",
+              "10/20/2026 1:19:17 PM",
+              "10/26/2026 1:19:17 PM",
+              "10/27/2026 1:19:17 PM"
+             ],
+             "DateTimeValues": [
+              "2026-08-31T13:19:17.126",
+              "2026-09-01T13:19:17.126",
+              "2026-09-07T13:19:17.126",
+              "2026-09-08T13:19:17.126",
+              "2026-09-14T13:19:17.126",
+              "2026-09-15T13:19:17.126",
+              "2026-09-21T13:19:17.126",
+              "2026-09-22T13:19:17.126",
+              "2026-09-28T13:19:17.126",
+              "2026-09-29T13:19:17.126",
+              "2026-10-05T13:19:17.126",
+              "2026-10-06T13:19:17.126",
+              "2026-10-13T13:19:17.126",
+              "2026-10-20T13:19:17.126",
+              "2026-10-26T13:19:17.126",
+              "2026-10-27T13:19:17.126"
+             ],
+             "FieldType": 9,
+             "KeywordValues": []
+            },
+            "blockData": {
+             "Name": "blockData",
+             "Values": [
+              "tcm:58-157869"
+             ],
+             "LinkedComponentValues": [
+              {
+               "LastPublishedDate": "0001-01-01T00:00:00",
+               "RevisionDate": "2022-08-15T21:09:59.01Z",
+               "Schema": {
+                "Folder": {
+                 "PublicationId": "tcm:0-58-1",
+                 "Id": "tcm:58-18711-2",
+                 "Title": "Calendar"
+                },
+                "RootElementName": "GDSCalendarBlockContainer",
+                "Publication": {
+                 "Id": "tcm:0-58-1",
+                 "Title": "060 UO.com Website (EN-US)"
+                },
+                "Id": "tcm:58-151576-8",
+                "Title": "GDS - Calendar Block Container"
+               },
+               "Fields": {
+                "heading": {
+                 "Name": "heading",
+                 "Values": [
+                  "##LongDateFormat##"
+                 ],
+                 "FieldType": 2,
+                 "KeywordValues": []
+                },
+                "blocksData": {
+                 "Name": "blocksData",
+                 "Values": [
+                  "tcm:58-157878"
+                 ],
+                 "LinkedComponentValues": [
+                  {
+                   "LastPublishedDate": "0001-01-01T00:00:00",
+                   "RevisionDate": "2022-08-18T15:34:38.65Z",
+                   "Schema": {
+                    "Folder": {
+                     "PublicationId": "tcm:0-58-1",
+                     "Id": "tcm:58-18711-2",
+                     "Title": "Calendar"
+                    },
+                    "RootElementName": "GDSCalendarBlock",
+                    "Publication": {
+                     "Id": "tcm:0-58-1",
+                     "Title": "060 UO.com Website (EN-US)"
+                    },
+                    "Id": "tcm:58-151575-8",
+                    "Title": "GDS - Calendar Block"
+                   },
+                   "Fields": {
+                    "iconImage": {
+                     "Name": "iconImage",
+                     "Values": [
+                      "tcm:58-151600"
+                     ],
+                     "LinkedComponentValues": [
+                      {
+                       "LastPublishedDate": "0001-01-01T00:00:00",
+                       "RevisionDate": "2022-05-26T18:22:48.16Z",
+                       "Schema": {
+                        "Folder": {
+                         "PublicationId": "tcm:0-58-1",
+                         "Id": "tcm:58-58-2",
+                         "Title": "Multimedia Schemas"
+                        },
+                        "RootElementName": "undefined",
+                        "Publication": {
+                         "Id": "tcm:0-58-1",
+                         "Title": "060 UO.com Website (EN-US)"
+                        },
+                        "Id": "tcm:58-400-8",
+                        "Title": "Image - Global"
+                       },
+                       "Fields": {},
+                       "MetadataFields": {},
+                       "ComponentType": 0,
+                       "Multimedia": {
+                        "Url": "/uor/en/us/files/Images/pumpkin.png",
+                        "MimeType": "image/png",
+                        "FileName": "pumpkin.png",
+                        "FileExtension": "png",
+                        "Size": 62575,
+                        "Width": 0,
+                        "Height": 0
+                       },
+                       "Version": 1,
+                       "Id": "tcm:58-151600",
+                       "Title": "pumpkin-vergd"
+                      }
+                     ],
+                     "FieldType": 5
+                    },
+                    "eyebrow": {
+                     "Name": "eyebrow",
+                     "Values": [
+                      "Halloween Horror Nights"
+                     ],
+                     "FieldType": 0,
+                     "KeywordValues": []
+                    },
+                    "heading": {
+                     "Name": "heading",
+                     "Values": [
+                      "No Event Today"
+                     ],
+                     "FieldType": 0,
+                     "KeywordValues": []
+                    },
+                    "description": {
+                     "Name": "description",
+                     "Values": [
+                      "Please visit our site for more information"
+                     ],
+                     "FieldType": 2,
+                     "KeywordValues": []
+                    },
+                    "ctaButton": {
+                     "Name": "ctaButton",
+                     "Values": [],
+                     "EmbeddedValues": [
+                      {
+                       "type": {
+                        "Name": "type",
+                        "Values": [
+                         "tertiary-small"
+                        ],
+                        "FieldType": 3,
+                        "CategoryName": "GDS - Button Types",
+                        "CategoryId": "tcm:58-6718-512",
+                        "KeywordValues": [
+                         {
+                          "IsRoot": false,
+                          "IsAbstract": false,
+                          "Description": "tertiary-small",
+                          "Key": "tertiary-small",
+                          "ParentKeywords": [],
+                          "MetadataFields": {},
+                          "Id": "tcm:58-137829-1024",
+                          "Title": "tertiary-small"
+                         }
+                        ]
+                       },
+                       "target": {
+                        "Name": "target",
+                        "Values": [
+                         "blank"
+                        ],
+                        "FieldType": 3,
+                        "CategoryName": "GDS - Button Target",
+                        "CategoryId": "tcm:58-6719-512",
+                        "KeywordValues": [
+                         {
+                          "IsRoot": false,
+                          "IsAbstract": false,
+                          "Description": "blank",
+                          "Key": "blank",
+                          "ParentKeywords": [],
+                          "MetadataFields": {},
+                          "Id": "tcm:58-73868-1024",
+                          "Title": "blank"
+                         }
+                        ]
+                       }
+                      }
+                     ],
+                     "FieldType": 4,
+                     "KeywordValues": []
+                    }
+                   },
+                   "MetadataFields": {
+                    "contentId": {
+                     "Name": "contentId",
+                     "Values": [
+                      "no-event-calendar-data-block-1"
+                     ],
+                     "NumericValues": [],
+                     "DateTimeValues": [],
+                     "LinkedComponentValues": [],
+                     "FieldType": 0,
+                     "XPath": "tcm:Metadata/custom:Metadata/custom:contentId",
+                     "KeywordValues": []
+                    }
+                   },
+                   "ComponentType": 1,
+                   "Version": 5,
+                   "Id": "tcm:58-157878",
+                   "Title": "GDS - HHN - SHARED - Calendar Block Data - No Event"
+                  }
+                 ],
+                 "FieldType": 6
+                }
+               },
+               "MetadataFields": {},
+               "ComponentType": 1,
+               "Version": 6,
+               "Id": "tcm:58-157869",
+               "Title": "GDS - HHN - SHARED - Calendar Block Data Container -with no event data"
+              }
+             ],
+             "FieldType": 6
+            }
+           }
+          ],
+          "FieldType": 4,
+          "KeywordValues": []
+         }
+        },
+        "MetadataFields": {
+         "contentId": {
+          "Name": "contentId",
+          "Values": [
+           "hhn-calendar-configuration-2026-about"
+          ],
+          "NumericValues": [],
+          "DateTimeValues": [],
+          "LinkedComponentValues": [],
+          "FieldType": 0,
+          "XPath": "tcm:Metadata/custom:Metadata/custom:contentId",
+          "KeywordValues": []
+         }
+        },
+        "ComponentType": 1,
+        "Version": 2,
+        "Id": "tcm:58-346637",
+        "Title": "GDS - HHN - About - 2026 Calendar Configuration"
+       }
+      ],
+      "FieldType": 6
+     },
+     "legendStyle": {
+      "Name": "legendStyle",
+      "Values": [
+       "tcm:58-157862"
+      ],
+      "LinkedComponentValues": [
+       {
+        "LastPublishedDate": "0001-01-01T00:00:00",
+        "RevisionDate": "2022-08-15T20:55:08.453Z",
+        "Schema": {
+         "Folder": {
+          "PublicationId": "tcm:0-58-1",
+          "Id": "tcm:58-18711-2",
+          "Title": "Calendar"
+         },
+         "RootElementName": "GDSCalendarStyle",
+         "Publication": {
+          "Id": "tcm:0-58-1",
+          "Title": "060 UO.com Website (EN-US)"
+         },
+         "Id": "tcm:58-151585-8",
+         "Title": "GDS - Calendar Style"
+        },
+        "Fields": {
+         "styles": {
+          "Name": "styles",
+          "Values": [],
+          "EmbeddedValues": [
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Disabled Style"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Disabled Style",
+               "Key": "disabled-style",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151571-1024",
+               "Title": "Disabled Style"
+              }
+             ]
+            }
+           },
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Selected Style"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Selected Style",
+               "Key": "selected-style",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151574-1024",
+               "Title": "Selected Style"
+              }
+             ]
+            },
+            "image": {
+             "Name": "image",
+             "Values": [
+              "tcm:58-151593"
+             ],
+             "LinkedComponentValues": [
+              {
+               "LastPublishedDate": "0001-01-01T00:00:00",
+               "RevisionDate": "2022-05-26T18:22:46.833Z",
+               "Schema": {
+                "Folder": {
+                 "PublicationId": "tcm:0-58-1",
+                 "Id": "tcm:58-58-2",
+                 "Title": "Multimedia Schemas"
+                },
+                "RootElementName": "undefined",
+                "Publication": {
+                 "Id": "tcm:0-58-1",
+                 "Title": "060 UO.com Website (EN-US)"
+                },
+                "Id": "tcm:58-400-8",
+                "Title": "Image - Global"
+               },
+               "Fields": {},
+               "MetadataFields": {},
+               "ComponentType": 0,
+               "Multimedia": {
+                "Url": "/uor/en/us/files/Images/hhn_texture.png",
+                "MimeType": "image/png",
+                "FileName": "hhn_texture.png",
+                "FileExtension": "png",
+                "Size": 6546,
+                "Width": 0,
+                "Height": 0
+               },
+               "Version": 2,
+               "Id": "tcm:58-151593",
+               "Title": "calendar-icon-texture"
+              }
+             ],
+             "FieldType": 5
+            },
+            "altText": {
+             "Name": "altText",
+             "Values": [
+              "Alternative text field - Selected Style"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "ariaLabel": {
+             "Name": "ariaLabel",
+             "Values": [
+              "ariaLabel field - Selected Style"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Style 1 (Default)"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Style 1 (Default)",
+               "Key": "style-1",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151582-1024",
+               "Title": "Style 1 (Default)"
+              }
+             ]
+            },
+            "image": {
+             "Name": "image",
+             "Values": [
+              "tcm:58-151593"
+             ],
+             "LinkedComponentValues": [
+              {
+               "LastPublishedDate": "0001-01-01T00:00:00",
+               "RevisionDate": "2022-05-26T18:22:46.833Z",
+               "Schema": {
+                "Folder": {
+                 "PublicationId": "tcm:0-58-1",
+                 "Id": "tcm:58-58-2",
+                 "Title": "Multimedia Schemas"
+                },
+                "RootElementName": "undefined",
+                "Publication": {
+                 "Id": "tcm:0-58-1",
+                 "Title": "060 UO.com Website (EN-US)"
+                },
+                "Id": "tcm:58-400-8",
+                "Title": "Image - Global"
+               },
+               "Fields": {},
+               "MetadataFields": {},
+               "ComponentType": 0,
+               "Multimedia": {
+                "Url": "/uor/en/us/files/Images/hhn_texture.png",
+                "MimeType": "image/png",
+                "FileName": "hhn_texture.png",
+                "FileExtension": "png",
+                "Size": 6546,
+                "Width": 0,
+                "Height": 0
+               },
+               "Version": 2,
+               "Id": "tcm:58-151593",
+               "Title": "calendar-icon-texture"
+              }
+             ],
+             "FieldType": 5
+            },
+            "altText": {
+             "Name": "altText",
+             "Values": [
+              "Alternative text field - Style 1"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "ariaLabel": {
+             "Name": "ariaLabel",
+             "Values": [
+              "ariaLabel field - Style 1"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "style": {
+             "Name": "style",
+             "Values": [
+              "Style 2"
+             ],
+             "FieldType": 3,
+             "CategoryName": "GDS - Calendar Legend",
+             "CategoryId": "tcm:58-18710-512",
+             "KeywordValues": [
+              {
+               "IsRoot": false,
+               "IsAbstract": false,
+               "Description": "Style 2",
+               "Key": "style-2",
+               "ParentKeywords": [],
+               "MetadataFields": {},
+               "Id": "tcm:58-151581-1024",
+               "Title": "Style 2"
+              }
+             ]
+            },
+            "image": {
+             "Name": "image",
+             "Values": [
+              "tcm:58-151593"
+             ],
+             "LinkedComponentValues": [
+              {
+               "LastPublishedDate": "0001-01-01T00:00:00",
+               "RevisionDate": "2022-05-26T18:22:46.833Z",
+               "Schema": {
+                "Folder": {
+                 "PublicationId": "tcm:0-58-1",
+                 "Id": "tcm:58-58-2",
+                 "Title": "Multimedia Schemas"
+                },
+                "RootElementName": "undefined",
+                "Publication": {
+                 "Id": "tcm:0-58-1",
+                 "Title": "060 UO.com Website (EN-US)"
+                },
+                "Id": "tcm:58-400-8",
+                "Title": "Image - Global"
+               },
+               "Fields": {},
+               "MetadataFields": {},
+               "ComponentType": 0,
+               "Multimedia": {
+                "Url": "/uor/en/us/files/Images/hhn_texture.png",
+                "MimeType": "image/png",
+                "FileName": "hhn_texture.png",
+                "FileExtension": "png",
+                "Size": 6546,
+                "Width": 0,
+                "Height": 0
+               },
+               "Version": 2,
+               "Id": "tcm:58-151593",
+               "Title": "calendar-icon-texture"
+              }
+             ],
+             "FieldType": 5
+            },
+            "altText": {
+             "Name": "altText",
+             "Values": [
+              "Alternative text field - Style 2"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "ariaLabel": {
+             "Name": "ariaLabel",
+             "Values": [
+              "ariaLabel field - Style 2"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           }
+          ],
+          "FieldType": 4,
+          "KeywordValues": []
+         }
+        },
+        "MetadataFields": {
+         "contentId": {
+          "Name": "contentId",
+          "Values": [
+           "hhn-legend-2"
+          ],
+          "NumericValues": [],
+          "DateTimeValues": [],
+          "LinkedComponentValues": [],
+          "FieldType": 0,
+          "XPath": "tcm:Metadata/custom:Metadata/custom:contentId",
+          "KeywordValues": []
+         }
+        },
+        "ComponentType": 1,
+        "Version": 4,
+        "Id": "tcm:58-157862",
+        "Title": "GDS - HHN - SHARED - Calendar Legend"
+       }
+      ],
+      "FieldType": 6
+     },
+     "resources": {
+      "Name": "resources",
+      "Values": [
+       "tcm:58-157863"
+      ],
+      "LinkedComponentValues": [
+       {
+        "LastPublishedDate": "0001-01-01T00:00:00",
+        "RevisionDate": "2022-08-15T20:55:43.267Z",
+        "Schema": {
+         "Folder": {
+          "PublicationId": "tcm:0-58-1",
+          "Id": "tcm:58-103-2",
+          "Title": "Editorial Schemas"
+         },
+         "RootElementName": "ResourceFile",
+         "Publication": {
+          "Id": "tcm:0-58-1",
+          "Title": "060 UO.com Website (EN-US)"
+         },
+         "Id": "tcm:58-568-8",
+         "Title": "Resource File"
+        },
+        "Fields": {
+         "Resource": {
+          "Name": "Resource",
+          "Values": [],
+          "EmbeddedValues": [
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DaySunLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Sun"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DayMonLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Mon"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DayTueLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Tue"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DayWedLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Wed"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DayThrLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Thur"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DayFriLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Fri"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "DaySatLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Sat"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "sun"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "Sun"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthJanuaryLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "January"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthFebruaryLabe"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "February"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthMarchLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "March"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthAprilLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "April"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthMayLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "May"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthJuneLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "June"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthJulyLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "July"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthAugustLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "August"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthSeptemberLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "September"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthOctoberLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "October"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthNovemberLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "November"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "MonthDecemberLabel"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "December"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           },
+           {
+            "Key": {
+             "Name": "Key",
+             "Values": [
+              "CalendarLongDateFormat"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            },
+            "Value": {
+             "Name": "Value",
+             "Values": [
+              "##LongDateFormat##"
+             ],
+             "FieldType": 0,
+             "KeywordValues": []
+            }
+           }
+          ],
+          "FieldType": 4,
+          "KeywordValues": []
+         }
+        },
+        "MetadataFields": {},
+        "ComponentType": 1,
+        "Version": 2,
+        "Id": "tcm:58-157863",
+        "Title": "GDS - HHN - SHARED - Calendar Resources"
+       }
+      ],
+      "FieldType": 6
+     },
+     "displayDayExceptions": {
+      "Name": "displayDayExceptions",
+      "Values": [
+       "false"
+      ],
+      "FieldType": 3,
+      "CategoryName": "UPR - true/false",
+      "CategoryId": "tcm:58-4798-512",
+      "KeywordValues": [
+       {
+        "IsRoot": false,
+        "IsAbstract": false,
+        "Description": "false",
+        "Key": "false",
+        "ParentKeywords": [],
+        "MetadataFields": {},
+        "Id": "tcm:58-47781-1024",
+        "Title": "false"
+       }
+      ]
+     }
+    },
+    "MetadataFields": {
+     "contentId": {
+      "Name": "contentId",
+      "Values": [
+       "gds-hhn-calendar-2026-about"
+      ],
+      "FieldType": 0,
+      "KeywordValues": []
+     }
+    },
+    "ComponentType": 1,
+    "Categories": [
+     {
+      "Keywords": [
+       {
+        "IsRoot": false,
+        "IsAbstract": false,
+        "Description": "false",
+        "Key": "false",
+        "TaxonomyId": "tcm:58-4798-512",
+        "Path": "\\UPR - true/false\\false",
+        "RelatedKeywords": [],
+        "ParentKeywords": [],
+        "MetadataFields": {},
+        "Id": "tcm:58-47781-1024",
+        "Title": "false"
+       }
+      ],
+      "Id": "tcm:58-4798-512",
+      "Title": "UPR - true/false"
+     },
+     {
+      "Keywords": [],
+      "Id": "tcm:58-7085-512",
+      "Title": "GDS - Page Themes"
+     }
+    ],
+    "Version": 5,
+    "Id": "tcm:58-346636",
+    "Title": "GDS - HHN 2026 - About - Calendar"
+   },
+   "ComponentTemplate": {
+    "RevisionDate": "2023-07-18T18:37:06.667Z",
+    "MetadataFields": {
+     "name": {
+      "Name": "name",
+      "Values": [
+       "gds-event-day-calendar"
+      ],
+      "FieldType": 0,
+      "KeywordValues": []
+     },
+     "schema": {
+      "Name": "schema",
+      "Values": [
+       "GdsEventDayCalendarData"
+      ],
+      "FieldType": 0,
+      "KeywordValues": []
+     },
+     "attributes": {
+      "Name": "attributes",
+      "Values": [],
+      "EmbeddedValues": [
+       {
+        "key": {
+         "Name": "key",
+         "Values": [
+          "type"
+         ],
+         "FieldType": 0,
+         "KeywordValues": []
+        },
+        "value": {
+         "Name": "value",
+         "Values": [
+          "value"
+         ],
+         "FieldType": 0,
+         "KeywordValues": []
+        }
+       }
+      ],
+      "FieldType": 4,
+      "KeywordValues": []
+     }
+    },
+    "Id": "tcm:58-151589-32",
+    "Title": "GDS - Calendar"
+   },
+   "IsDynamic": true,
+   "OrderOnPage": 10
+  }
+ ]
+}

--- a/src/parks/universal/__tests__/hhnSchedule.test.ts
+++ b/src/parks/universal/__tests__/hhnSchedule.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parseUniversalEventCalendar, UniversalOrlando } from "../universal.js";
+
+/**
+ * Halloween Horror Nights is absent from every feed parksapi already reads.
+ * `venues/10010/hours` returns 65 days of 09:00-17:00 with `SpecialEntryUnix`,
+ * `EarlyEntryUnix`, `VenueStatus`, `Holiday` and `IsShowScheduled` all unset,
+ * including 31 October, and HHN is not one of the 14 venues. Without this the
+ * API shows houses OPERATING until 02:00 while the park's published hours
+ * ended at 17:00.
+ *
+ * The event calendar lives on the website instead, in the Tridion CMS payload
+ * behind the `gds-event-day-calendar` component:
+ *
+ *   GET /contentdata/uor/en/us/hhn//about/index.html
+ *
+ * Served as text/html, JSON throughout, no auth and no browser fingerprint
+ * needed. Fixture captured 2026-08-28, trimmed to the calendar presentation.
+ */
+
+const FIXTURE = JSON.parse(
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "fixtures", "hhnEventCalendar.json"),
+    "utf8",
+  ),
+);
+
+const nights = parseUniversalEventCalendar(FIXTURE);
+
+describe("parseUniversalEventCalendar", () => {
+  test("publishes every night the event actually runs", () => {
+    // 49 regular nights + 2 Premium Scream Nights. The 16 "No Event Today"
+    // dates are the nights it does NOT run and must not appear.
+    expect(nights).toHaveLength(51);
+  });
+
+  test("excludes the block that lists the nights with no event", () => {
+    expect(nights.map((n) => n.name)).not.toContain("No Event Today");
+    // 31 August is a "No Event Today" date.
+    expect(nights.find((n) => n.date === "2026-08-31")).toBeUndefined();
+  });
+
+  test("reads the event name when the CMS puts it in `heading`", () => {
+    // Block 1: heading = name, eyebrow = hours.
+    expect(nights.find((n) => n.date === "2026-08-27")).toMatchObject({
+      name: "Halloween Horror Nights Premium Scream Night",
+      openingTime: "18:30",
+      closingTime: "02:00",
+    });
+  });
+
+  test("reads the event name when the CMS puts it in `eyebrow` instead", () => {
+    // Block 2 has them the other way round: heading = "6:30 PM - 2:00 AM".
+    // Trusting position here would name every regular night after its hours.
+    expect(nights.find((n) => n.date === "2026-08-28")).toMatchObject({
+      name: "Halloween Horror Nights",
+      openingTime: "18:30",
+      closingTime: "02:00",
+    });
+  });
+
+  test("accepts both dash characters the same document uses", () => {
+    // Block 1 uses an en dash, block 2 a hyphen.
+    const premium = nights.filter((n) => n.name.includes("Premium"));
+    const regular = nights.filter((n) => n.name === "Halloween Horror Nights");
+    expect(premium).toHaveLength(2);
+    expect(regular).toHaveLength(49);
+  });
+
+  test("marks a past-midnight close as landing on the next day", () => {
+    expect(nights.every((n) => n.closesNextDay)).toBe(true);
+  });
+
+  test("reduces the authored timestamps to plain calendar dates", () => {
+    // eventDates carry authoring noise: "2026-08-27T14:36:10",
+    // "2026-08-28T13:19:17.126". Carrying that through would put an unusable
+    // value in ScheduleEntry.date and break the schedule construction.
+    expect(nights.every((n) => /^\d{4}-\d{2}-\d{2}$/.test(n.date))).toBe(true);
+  });
+
+  test("covers the published season end to end", () => {
+    const dates = nights.map((n) => n.date);
+    expect(dates[0]).toBe("2026-08-27");
+    expect(dates.at(-1)).toBe("2026-11-01");
+    expect(new Set(dates).size).toBe(dates.length);
+  });
+
+  test("returns entries in date order", () => {
+    const dates = nights.map((n) => n.date);
+    expect(dates).toEqual([...dates].sort());
+  });
+
+  test("survives a payload with no calendar rather than throwing", () => {
+    expect(parseUniversalEventCalendar({ ComponentPresentations: [] })).toEqual([]);
+    expect(parseUniversalEventCalendar({})).toEqual([]);
+    expect(parseUniversalEventCalendar(null)).toEqual([]);
+  });
+
+  test("skips a block whose hours are unparseable rather than guessing", () => {
+    const broken = JSON.parse(JSON.stringify(FIXTURE));
+    const cfgs =
+      broken.ComponentPresentations[0].Component.Fields.calendarData
+        .LinkedComponentValues[0].Fields.calendarConfig.EmbeddedValues;
+    for (const c of cfgs) {
+      const f =
+        c.blockData.LinkedComponentValues[0].Fields.blocksData
+          .LinkedComponentValues[0].Fields;
+      if (f.heading) f.heading.Values = ["Coming Soon"];
+      if (f.eyebrow) f.eyebrow.Values = ["Halloween Horror Nights"];
+    }
+    expect(parseUniversalEventCalendar(broken)).toEqual([]);
+  });
+});
+
+describe("UniversalOrlando.buildSchedules", () => {
+  function park(): any {
+    const p: any = new UniversalOrlando();
+    p.eventCalendarURL = "https://example.invalid/calendar";
+    p.eventCalendarPlaceId = "uor.usf";
+    // Two day-park days, the second of which is also an HHN night.
+    p.getVenueSchedule = async () => [
+      {
+        Date: "2026-08-28",
+        VenueStatus: "",
+        OpenTimeString: "2026-08-28T09:00:00-04:00",
+        CloseTimeString: "2026-08-28T17:00:00-04:00",
+      },
+      {
+        Date: "2026-08-31",
+        VenueStatus: "",
+        OpenTimeString: "2026-08-31T09:00:00-04:00",
+        CloseTimeString: "2026-08-31T17:00:00-04:00",
+      },
+    ];
+    p.getEventNights = async () => parseUniversalEventCalendar(FIXTURE);
+    return p;
+  }
+
+  test("attaches the event nights to the park the event runs in", async () => {
+    const schedules = await park().getSchedules();
+    const usf = schedules.find((s: any) => s.id === "uor.usf");
+    const ioa = schedules.find((s: any) => s.id === "uor.ioa");
+
+    expect(usf.schedule.filter((e: any) => e.type === "TICKETED_EVENT")).toHaveLength(51);
+    expect(ioa.schedule.some((e: any) => e.type === "TICKETED_EVENT")).toBe(false);
+  });
+
+  test("publishes the event alongside that day's park hours, not instead of them", async () => {
+    const usf = (await park().getSchedules()).find((s: any) => s.id === "uor.usf");
+    const aug28 = usf.schedule.filter((e: any) => e.date === "2026-08-28");
+
+    expect(aug28.map((e: any) => e.type).sort()).toEqual(["OPERATING", "TICKETED_EVENT"]);
+    const event = aug28.find((e: any) => e.type === "TICKETED_EVENT");
+    expect(event.openingTime).toBe("2026-08-28T18:30:00-04:00");
+    expect(event.closingTime).toBe("2026-08-29T02:00:00-04:00");
+    expect(event.description).toBe("Halloween Horror Nights");
+  });
+
+  test("leaves a day-park day with no event untouched", async () => {
+    // 31 August is a "No Event Today" date.
+    const usf = (await park().getSchedules()).find((s: any) => s.id === "uor.usf");
+    const aug31 = usf.schedule.filter((e: any) => e.date === "2026-08-31");
+    expect(aug31.map((e: any) => e.type)).toEqual(["OPERATING"]);
+  });
+
+  test("still publishes park hours when the event calendar fails", async () => {
+    // A website change must not take the day-park schedule down with it.
+    const p = park();
+    p.getEventNights = async () => { throw new Error("503"); };
+    const usf = (await p.getSchedules()).find((s: any) => s.id === "uor.usf");
+    expect(usf.schedule.filter((e: any) => e.type === "OPERATING")).toHaveLength(2);
+    expect(usf.schedule.some((e: any) => e.type === "TICKETED_EVENT")).toBe(false);
+  });
+
+  test("emits nothing extra when no event calendar is configured", async () => {
+    const p = park();
+    p.eventCalendarPlaceId = "";
+    const usf = (await p.getSchedules()).find((s: any) => s.id === "uor.usf");
+    expect(usf.schedule.every((e: any) => e.type === "OPERATING")).toBe(true);
+  });
+});

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -12,7 +12,7 @@ import {
   EntitySchedule,
   QueueTypeEnum,
 } from '@themeparks/typelib';
-import {formatUTC, parseTimeInTimezone, formatInTimezone, addDays, isBefore, constructDateTime, addMinutes, hostnameFromUrl} from '../../datetime.js';
+import {formatUTC, parseTimeInTimezone, formatInTimezone, addDays, isBefore, constructDateTime, addMinutes, hostnameFromUrl, shiftDateString} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 import {randomPointInRadius} from '../../geo.js';
 
@@ -517,9 +517,51 @@ class Universal extends Destination {
    */
   protected liveEntityRetirementMs = 4 * 60 * 60 * 1000;
 
+  /**
+   * Full URL of the website page payload carrying the ticketed-event calendar
+   * (Halloween Horror Nights). Empty by default: with no URL configured
+   * buildSchedules() emits day-park hours exactly as before and never touches
+   * the site. The whole URL rather than a path because each resort's event
+   * lives on its own microsite.
+   */
+  @config
+  eventCalendarURL: string = '';
+
+  /**
+   * Place id of the park the event runs in, e.g. `uor.usf`. The event calendar
+   * covers one park, not the resort, and without this there is nothing to
+   * attach the schedule to.
+   */
+  @config
+  eventCalendarPlaceId: string = '';
+
   constructor(options?: DestinationConstructor) {
     super(options);
     this.addConfigPrefix('UNIVERSALSTUDIOS');
+  }
+
+  /**
+   * Fetch the event calendar page payload.
+   *
+   * Served as `text/html` but is JSON throughout, so it is read as text and
+   * parsed here rather than letting the HTTP layer decide by content type.
+   */
+  @http({cacheSeconds: 43200, retries: 1} as any)
+  async fetchEventCalendar(): Promise<HTTPObj> {
+    return {
+      method: 'GET',
+      url: this.eventCalendarURL,
+      options: {json: false},
+      tags: ['website'],
+    } as any as HTTPObj;
+  }
+
+  /** Ticketed-event nights for this resort, or [] when not configured. */
+  @cache({ttlSeconds: 43200})
+  async getEventNights(): Promise<UniversalEventNight[]> {
+    if (!this.eventCalendarURL || !this.eventCalendarPlaceId) return [];
+    const body = await (await this.fetchEventCalendar()).text();
+    return parseUniversalEventCalendar(JSON.parse(body));
   }
 
   /**
@@ -1243,6 +1285,11 @@ class Universal extends Destination {
    */
   protected async buildSchedules(): Promise<EntitySchedule[]> {
     const schedules: EntitySchedule[] = [];
+    // Isolated: a website change must not take the day-park hours down with it.
+    const eventNights = await this.getEventNights().catch(err => {
+      console.warn(`[${this.constructor.name}] event calendar unavailable:`, err);
+      return [] as UniversalEventNight[];
+    });
 
     // Iterate the place_id ↔ legacy VenueId map filtered to this resort.
     // The legacy schedule endpoint still wants the numeric VenueId; we only
@@ -1282,6 +1329,26 @@ class Universal extends Destination {
         }
       }
 
+      // Ticketed events (HHN) run after the day park shuts and are absent from
+      // the venue-hours API entirely — every day of the season comes back
+      // 09:00-17:00 with no event fields set. Without these the API shows
+      // attractions OPERATING hours after the park's published close.
+      if (placeId === this.eventCalendarPlaceId) {
+        for (const night of eventNights) {
+          schedule.push({
+            date: night.date,
+            openingTime: constructDateTime(night.date, night.openingTime, this.timezone),
+            closingTime: constructDateTime(
+              night.closesNextDay ? shiftDateString(night.date, 1) : night.date,
+              night.closingTime,
+              this.timezone,
+            ),
+            type: 'TICKETED_EVENT' as const,
+            description: night.name,
+          });
+        }
+      }
+
       schedules.push({
         // sanitizeId for symmetry with the PARK entity emission in
         // buildEntityList — today's allow-list keys are clean (`uor.usf`
@@ -1299,6 +1366,122 @@ class Universal extends Destination {
 /**
  * Universal Studios Orlando
  */
+/** One night of a ticketed event, resolved from the website's event calendar. */
+export interface UniversalEventNight {
+  /** YYYY-MM-DD in the park's own timezone. */
+  date: string;
+  /** Event name, e.g. "Halloween Horror Nights". */
+  name: string;
+  /** Opening time, HH:mm. */
+  openingTime: string;
+  /** Closing time, HH:mm. Past midnight belongs to the following date. */
+  closingTime: string;
+  /** True when the close falls on the day after `date`. */
+  closesNextDay: boolean;
+}
+
+/**
+ * "6:30 PM - 2:00 AM". The separator is a hyphen in some CMS blocks and an
+ * en dash in others, in the same document, so both are accepted.
+ */
+const EVENT_HOURS = /(\d{1,2}):(\d{2})\s*(AM|PM)\s*[-–—]\s*(\d{1,2}):(\d{2})\s*(AM|PM)/i;
+
+/** 12-hour clock to HH:mm. 12 AM is 00, 12 PM is 12. */
+function to24Hour(hour: string, minute: string, meridiem: string): string {
+  let h = Number(hour) % 12;
+  if (meridiem.toUpperCase() === 'PM') h += 12;
+  return `${String(h).padStart(2, '0')}:${minute}`;
+}
+
+/** Read the single `Values` entry off a Tridion field, if present. */
+function tridionValue(field: unknown): string | undefined {
+  const values = (field as {Values?: unknown[]} | undefined)?.Values;
+  return Array.isArray(values) && typeof values[0] === 'string' ? values[0] : undefined;
+}
+
+/**
+ * Parse the ticketed-event calendar out of the website's page payload.
+ *
+ * The payload is the Tridion CMS document behind the site's event-day
+ * calendar. It is served as `text/html` but is JSON throughout.
+ *
+ * Two things about the CMS authoring drive the shape of this function:
+ *
+ *  1. `heading` and `eyebrow` are used inconsistently between blocks. One
+ *     block puts the event name in `heading` and the hours in `eyebrow`; the
+ *     others do the reverse. Whichever field parses as a time range is the
+ *     hours, and the other is the name — position is never trusted.
+ *  2. A block with no time range in either field is not an event. That is how
+ *     the "No Event Today" block, which lists the nights the event does NOT
+ *     run, is excluded rather than published as a night that it is closed.
+ *
+ * `eventDates` carries authoring timestamps (`2026-08-27T14:36:10`) whose time
+ * component is meaningless, so only the date part is read.
+ */
+export function parseUniversalEventCalendar(payload: unknown): UniversalEventNight[] {
+  const presentations = (payload as {ComponentPresentations?: unknown[]})?.ComponentPresentations;
+  if (!Array.isArray(presentations)) return [];
+
+  const calendar = presentations.find(entry =>
+    (entry as any)?.Component?.Schema?.RootElementName === 'GDSCalendar');
+  if (!calendar) return [];
+
+  const configs = (calendar as any)?.Component?.Fields?.calendarData
+    ?.LinkedComponentValues?.[0]?.Fields?.calendarConfig?.EmbeddedValues;
+  if (!Array.isArray(configs)) return [];
+
+  const nights: UniversalEventNight[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of configs) {
+    const blocks = entry?.blockData?.LinkedComponentValues?.[0]?.Fields
+      ?.blocksData?.LinkedComponentValues?.[0]?.Fields;
+    const heading = tridionValue(blocks?.heading);
+    const eyebrow = tridionValue(blocks?.eyebrow);
+
+    // Match once and carry the result, rather than testing with one call and
+    // re-matching with a non-null assertion in another. The assertion would be
+    // correct today and silently wrong the first time the predicate drifts.
+    const labels = [heading, eyebrow].filter((text): text is string => !!text);
+    const hours = labels
+      .map(text => ({text, match: text.match(EVENT_HOURS)}))
+      .find(candidate => candidate.match !== null);
+    if (!hours?.match) continue;
+    const name = labels.find(text => text !== hours.text);
+    if (!name) continue;
+
+    const [, openHour, openMinute, openMeridiem, closeHour, closeMinute, closeMeridiem] =
+      hours.match;
+    const openingTime = to24Hour(openHour, openMinute, openMeridiem);
+    const closingTime = to24Hour(closeHour, closeMinute, closeMeridiem);
+
+    const dates = entry?.eventDates?.DateTimeValues;
+    if (!Array.isArray(dates)) continue;
+
+    for (const value of dates) {
+      if (typeof value !== 'string') continue;
+      const date = value.slice(0, 10);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+      // One night per date. Blocks do not overlap today, but a duplicate would
+      // otherwise publish two schedule entries for the same evening.
+      const key = `${date}:${name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      nights.push({
+        date,
+        name,
+        openingTime,
+        closingTime,
+        closesNextDay: closingTime <= openingTime,
+      });
+    }
+  }
+
+  nights.sort((a, b) => a.date.localeCompare(b.date) || a.name.localeCompare(b.name));
+  return nights;
+}
+
 @destinationController({category: 'Universal'})
 export class UniversalOrlando extends Universal {
   resortLocation = {latitude: 28.4719, longitude: -81.4685};


### PR DESCRIPTION
Universal Studios Florida publishes only day-park hours, while HHN runs 18:30 to 02:00 on most nights of the season. The API therefore shows haunted houses `OPERATING` five hours after the park's published close, with nothing in the schedule accounting for it. Verified live on 2026-08-27/28.

## The data is in none of the feeds we already read

- `venues/10010/hours` returns **65 days**, 28 Aug to 31 Oct, every one of them 09:00-17:00 or 10:00-19:00. Across all 65: **zero** have `SpecialEntryUnix`, `EarlyEntryUnix`, `VenueStatus`, `Holiday` or `IsShowScheduled` set. 31 October included.
- HHN is **not a venue**. `GET /api/venues?city=Orlando&pageSize=All` returns 14: four parks, CityWalk, nine hotels, the resort.
- The website's own park-hours calendar is driven by that same payload, so it shows the same thing.
- The mobile app is a webview of the site (`x-requested-with: com.universalstudios.orlandoresort`), so there is no app-native source either.

It lives on the event-calendar page, as JSON served under a `text/html` content type. Reachable from parksapi's own HTTP stack with no headers, no auth and no TLS impersonation — verified with bare `node:https`, curl with no user-agent, and curl with a browser UA, all returning the same payload.

## Three CMS authoring quirks that shape the parser

| quirk | consequence if ignored |
|---|---|
| `heading` and `eyebrow` are used inconsistently between blocks — one has name/hours, the others hours/name | every regular night gets named after its own opening time |
| a block with no time range is not an event | the "No Event Today" block publishes its 16 non-event nights as 16 extra events |
| `eventDates` carry authoring timestamps (`2026-08-27T14:36:10`) | an unusable value lands in `ScheduleEntry.date` |

The separator in the time range is a hyphen in one block and an en dash in another, in the same document. Both are accepted.

## Result

49 regular nights + 2 Premium Scream Nights, each closing 02:00 the following day.

```
2026-08-27  TICKETED_EVENT 18:30 -> 2026-08-28T02:00  Premium Scream Night
2026-08-28  OPERATING      09:00 -> 17:00
            TICKETED_EVENT 18:30 -> 2026-08-29T02:00  Halloween Horror Nights
2026-08-31  OPERATING      10:00 -> 19:00              (No Event Today)
2026-10-31  OPERATING      09:00 -> 17:00
            TICKETED_EVENT 18:30 -> 2026-11-01T02:00  Halloween Horror Nights
```

Events attach only to the configured park, so IOA, Epic and Volcano Bay are untouched.

## Safety

- A calendar failure is isolated — day-park hours still publish, with a warning.
- `eventCalendarURL` and `eventCalendarPlaceId` both default to empty, so an unconfigured build behaves exactly as today and never contacts the site.

## Verification

- 16 tests against the live captured payload, mutation-verified: reading the fields positionally fails 5 tests, keeping the authored timestamps fails 7, dropping the next-day rollover fails 1, attaching events to every park fails 2, removing the failure isolation fails 1
- full suite green (2160), `npm run dev -- universalorlando` green with the calendar configured: 4 schedules, 494 days
- end to end against the live site: 51 `TICKETED_EVENT` entries on `uor.usf`, none on `uor.ioa`


