### PR TITLE
fix(universal): stop Hollywood fetching Orlando's event calendar

### DIFF
--- a/src/parks/universal/__tests__/hhnSchedule.test.ts
+++ b/src/parks/universal/__tests__/hhnSchedule.test.ts
@@ -1,8 +1,9 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { parseUniversalEventCalendar, UniversalOrlando } from "../universal.js";
+import { parseUniversalEventCalendar, UniversalOrlando, UniversalStudios } from "../universal.js";
+import { CacheLib } from "../../../cache.js";
 
 /**
  * Halloween Horror Nights is absent from every feed parksapi already reads.
@@ -180,5 +181,70 @@ describe("UniversalOrlando.buildSchedules", () => {
     p.eventCalendarPlaceId = "";
     const usf = (await p.getSchedules()).find((s: any) => s.id === "uor.usf");
     expect(usf.schedule.every((e: any) => e.type === "OPERATING")).toBe(true);
+  });
+});
+
+describe("event calendar fetch discipline", () => {
+  // getEventNights is @cache'd on class + method, so entries are shared across
+  // instances and across configs. Each case starts from a clean slate.
+  beforeEach(async () => {
+    await CacheLib.clearByClassName("UniversalOrlando");
+    await CacheLib.clearByClassName("UniversalStudios");
+  });
+
+  const CONFIG = {
+    eventCalendarURL: "https://example.invalid/calendar",
+    eventCalendarPlaceId: "uor.usf",
+  };
+
+  test("Hollywood does not fetch Orlando's calendar", async () => {
+    // Both resorts share addConfigPrefix('UNIVERSALSTUDIOS'), so Hollywood
+    // reads UNIVERSALSTUDIOS_EVENTCALENDARURL as well. buildSchedules() would
+    // never publish those nights, but the fetch and the 285KB parse still ran.
+    const hollywood: any = new UniversalStudios({ config: CONFIG } as any);
+    let fetched = 0;
+    hollywood.fetchEventCalendar = async () => { fetched++; throw new Error("should not fetch"); };
+
+    await expect(hollywood.getEventNights()).resolves.toEqual([]);
+    expect(fetched).toBe(0);
+  });
+
+  test("Orlando does fetch it", async () => {
+    const orlando: any = new UniversalOrlando({ config: CONFIG } as any);
+    let fetched = 0;
+    orlando.fetchEventCalendar = async () => {
+      fetched++;
+      return { text: async () => JSON.stringify(FIXTURE) };
+    };
+
+    await expect(orlando.getEventNights()).resolves.toHaveLength(51);
+    expect(fetched).toBe(1);
+  });
+
+  test("a blocked fetch keeps failing rather than sticking as empty", async () => {
+    // One box's IP is blocked by the site's WAF (2026-08-28). A failure that
+    // cached as [] would mean twelve silent hours of "no events"; it has to
+    // stay loud so the next poll retries and the warning keeps appearing.
+    const orlando: any = new UniversalOrlando({ config: CONFIG } as any);
+    orlando.fetchEventCalendar = async () => { throw new Error("HTTP 403"); };
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await expect(orlando.getEventNights()).rejects.toThrow(/403/);
+    }
+  });
+
+  test("a blocked fetch is reported, not swallowed", async () => {
+    const orlando: any = new UniversalOrlando({ config: CONFIG } as any);
+    orlando.getVenueSchedule = async () => [];
+    orlando.getEventNights = async () => { throw new Error("HTTP 403"); };
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      await orlando.getSchedules();
+    } finally {
+      console.warn = original;
+    }
+    expect(warnings.join("\n")).toMatch(/event calendar unavailable/i);
   });
 });

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -560,8 +560,20 @@ class Universal extends Destination {
   @cache({ttlSeconds: 43200})
   async getEventNights(): Promise<UniversalEventNight[]> {
     if (!this.eventCalendarURL || !this.eventCalendarPlaceId) return [];
+    // UniversalOrlando and UniversalStudios share addConfigPrefix
+    // ('UNIVERSALSTUDIOS'), so Hollywood reads Orlando's calendar config too.
+    // buildSchedules() would never emit those nights — the place id matches
+    // none of its parks — but without this Hollywood still fetches and parses
+    // a 285KB Orlando document on every schedule build.
+    if (!this.parkPlaceIds().includes(this.eventCalendarPlaceId)) return [];
     const body = await (await this.fetchEventCalendar()).text();
     return parseUniversalEventCalendar(JSON.parse(body));
+  }
+
+  /** Place ids of the parks belonging to this resort. */
+  parkPlaceIds(): string[] {
+    return Object.keys(PARK_PLACE_ID_TO_LEGACY_VENUE_ID)
+      .filter(placeId => placeId.startsWith(`${this.resortKey}.`));
   }
 
   /**
@@ -1295,8 +1307,9 @@ class Universal extends Destination {
     // The legacy schedule endpoint still wants the numeric VenueId; we only
     // relabel the emitted EntitySchedule with the new place_id so it joins
     // up with the park entities from buildEntityList.
+    const parkPlaceIds = new Set(this.parkPlaceIds());
     const parkEntries = Object.entries(PARK_PLACE_ID_TO_LEGACY_VENUE_ID).filter(
-      ([placeId]) => placeId.startsWith(`${this.resortKey}.`),
+      ([placeId]) => parkPlaceIds.has(placeId),
     );
 
     for (const [placeId, legacyVenueId] of parkEntries) {


### PR DESCRIPTION
Follow-up to #524, found while diagnosing why HHN hours were missing on one collector box.

## The bug

`UniversalOrlando` and `UniversalStudios` share `addConfigPrefix('UNIVERSALSTUDIOS')`, so Hollywood reads Orlando's calendar config too:

```
universalorlando   class=UniversalOrlando   url=SET  placeId="uor.usf"
universalstudios   class=UniversalStudios   url=SET  placeId="uor.usf"
```

Nothing wrong was published — `buildSchedules()` only emits against a matching place id, and `uor.usf` is not one of Hollywood's parks — but Hollywood still fetched and parsed a **285KB** Orlando document on every schedule build, forever, to produce nothing.

`getEventNights()` now returns early unless the configured place id belongs to this resort.

## Two properties pinned that I had assumed

While diagnosing, one box turned out to be **IP-blocked by the site's WAF** (403 on `www.universalorlando.com`, while two other boxes and my machine get 200). I claimed the resulting failure was being cached as empty and failing silently. Tested properly, **both claims were wrong** — failures already throw on every call, and `buildSchedules()` already warns. They were simply untested, so this adds:

- a blocked fetch keeps throwing instead of sticking as an empty result
- a blocked fetch is reported through `console.warn`, not swallowed

## Worth knowing

`getEventNights` is `@cache`'d on class + method only, so entries are shared across instances **and across configs** — a config change is not picked up until the 12h TTL expires. That surfaced as a test failure when one case cached a success the next case then read. The new tests clear the cache between runs; the behaviour itself is left alone, but it is now documented in the test file.

## Verification

- 20 tests, mutation-verified: letting Hollywood fetch again fails 1, swallowing the failure fails 1, matching every resort in the place-id filter fails 1
- full suite green (2164)

Deployed state for context: #524 is live in prod, publishing 51 `TICKETED_EVENT` nights on `uor.usf` (verified on the wiki), so this is a cleanup on top of working behaviour rather than a fix to it.

