### PR TITLE
feat(tools): report live rows the feed no longer contains

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "har": "tsx src/tools/har/index.ts",
     "docs": "typedoc",
     "prepare": "tsc && ([ \"$(git rev-parse --show-toplevel 2>/dev/null)\" = \"$(pwd -P)\" ] && git config core.hooksPath .githooks || true)",
-    "readme": "tsx src/tools/readme/destinations.ts"
+    "readme": "tsx src/tools/readme/destinations.ts",
+    "stale": "tsx --env-file=.env src/tools/staleReport.ts"
   },
   "repository": {
     "type": "git",

--- a/src/tools/__tests__/staleLiveRows.test.ts
+++ b/src/tools/__tests__/staleLiveRows.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from "vitest";
+import { reconcileLiveRows, type ServedRow } from "../staleLiveRows.js";
+
+/**
+ * The retirement gate only tracks ids it has seen live, so anything already
+ * frozen when it first ran can never be retired by it. This comparison is the
+ * read-only half of the reconciliation that closes that hole.
+ *
+ * Everything here is about not over-reporting: a wrong entry in this list
+ * becomes a closed row later, so the bias is toward saying nothing when the
+ * evidence is thin.
+ */
+
+const NOW = new Date("2026-08-29T12:00:00Z");
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 3_600_000).toISOString();
+
+const row = (over: Partial<ServedRow> = {}): ServedRow => ({
+  id: "guid-1",
+  externalId: "park.ride.one",
+  name: "Ride One",
+  entityType: "ATTRACTION",
+  status: "OPERATING",
+  lastUpdated: hoursAgo(100),
+  ...over,
+});
+
+describe("reconcileLiveRows", () => {
+  test("reports a row the build no longer produces", () => {
+    const r = reconcileLiveRows(["park.ride.two"], [row()], NOW);
+    expect(r.stale).toHaveLength(1);
+    expect(r.stale[0]).toMatchObject({ externalId: "park.ride.one", ageHours: 100 });
+  });
+
+  test("says nothing about a row the build still produces", () => {
+    expect(reconcileLiveRows(["park.ride.one"], [row()], NOW).stale).toEqual([]);
+  });
+
+  test("ignores rows the API already serves as closed", () => {
+    // Only OPERATING and DOWN assert the entity is active; a CLOSED row is
+    // already correct and reporting it would re-close it forever.
+    for (const status of ["CLOSED", "REFURBISHMENT", "OPERATING"]) {
+      const r = reconcileLiveRows([], [row({ status })], NOW);
+      expect(r.stale.length, status).toBe(status === "OPERATING" ? 1 : 0);
+    }
+  });
+
+  test("treats DOWN as an active claim too", () => {
+    // A ride stuck DOWN forever is as wrong as one stuck OPERATING.
+    expect(reconcileLiveRows([], [row({ status: "DOWN" })], NOW).stale).toHaveLength(1);
+  });
+
+  test("ignores a row that is merely mid-cycle", () => {
+    expect(reconcileLiveRows([], [row({ lastUpdated: hoursAgo(3) })], NOW).stale).toEqual([]);
+  });
+
+  test("excludes PARK entities by default", () => {
+    // Whether a park should carry live data at all is an open question
+    // an open question; it must not be answered by accident here.
+    expect(reconcileLiveRows([], [row({ entityType: "PARK" })], NOW).stale).toEqual([]);
+  });
+
+  test("skips a row with no externalId rather than guessing", () => {
+    // Nothing to match against the build, so the row cannot be judged.
+    expect(reconcileLiveRows([], [row({ externalId: undefined })], NOW).stale).toEqual([]);
+  });
+
+  test("skips a row with an unparseable timestamp", () => {
+    expect(reconcileLiveRows([], [row({ lastUpdated: "not a date" })], NOW).stale).toEqual([]);
+    expect(reconcileLiveRows([], [row({ lastUpdated: undefined })], NOW).stale).toEqual([]);
+  });
+
+  test("orders oldest first", () => {
+    const rows = [
+      row({ id: "a", externalId: "a", lastUpdated: hoursAgo(60) }),
+      row({ id: "b", externalId: "b", lastUpdated: hoursAgo(900) }),
+      row({ id: "c", externalId: "c", lastUpdated: hoursAgo(300) }),
+    ];
+    expect(reconcileLiveRows([], rows, NOW).stale.map((s) => s.externalId)).toEqual(["b", "c", "a"]);
+  });
+
+  describe("degraded-feed guard", () => {
+    test("flags a build that produced nothing at all", () => {
+      const r = reconcileLiveRows([], [row()], NOW);
+      expect(r.degraded).toMatch(/no live data/);
+    });
+
+    test("flags a build that produced a fraction of what is served", () => {
+      // 10 rows served, 2 produced: a broken poll, not a park that retired 8
+      // attractions overnight.
+      const served = Array.from({ length: 10 }, (_, i) =>
+        row({ id: `g${i}`, externalId: `e${i}` }));
+      const r = reconcileLiveRows(["e0", "e1"], served, NOW);
+      expect(r.degraded).toMatch(/degraded/);
+      expect(r.stale).toHaveLength(8); // still reported, but marked untrustworthy
+    });
+
+    test("stays quiet when the build looks healthy", () => {
+      const served = Array.from({ length: 10 }, (_, i) =>
+        row({ id: `g${i}`, externalId: `e${i}` }));
+      const r = reconcileLiveRows(
+        Array.from({ length: 9 }, (_, i) => `e${i}`), served, NOW);
+      expect(r.degraded).toBeUndefined();
+      expect(r.stale).toHaveLength(1);
+    });
+
+    test("does not flag a genuinely small park", () => {
+      // Four served rows, one produced. Too few to distinguish a broken feed
+      // from a small park, so the guard stays out of it.
+      const served = Array.from({ length: 4 }, (_, i) =>
+        row({ id: `g${i}`, externalId: `e${i}` }));
+      expect(reconcileLiveRows(["e0"], served, NOW).degraded).toBeUndefined();
+    });
+  });
+});

--- a/src/tools/staleLiveRows.ts
+++ b/src/tools/staleLiveRows.ts
@@ -1,0 +1,128 @@
+/**
+ * @module
+ * Find live rows the API is still serving that the park's own feed no longer
+ * contains.
+ *
+ * The live-entity retirement gate (see Destination.retireMissingLiveEntities)
+ * only tracks ids it has observed live, so an entity already frozen when the
+ * gate first ran is invisible to it permanently. This module is the read-only
+ * half of the reconciliation: it says what is stale, and closes nothing.
+ *
+ * Measured 2026-08-29: 636 rows across the fleet are served as OPERATING or
+ * DOWN with a lastUpdated more than two days old, concentrated in seasonal
+ * parks whose feeds drop attractions out of season.
+ */
+
+/** A live row the API is currently serving. */
+export interface ServedRow {
+  /** Remote GUID. */
+  id: string;
+  /** parksapi entity id, as published in the entity's externalId. */
+  externalId?: string;
+  name: string;
+  entityType?: string;
+  status?: string;
+  lastUpdated?: string;
+}
+
+/** One row the feed no longer contains. */
+export interface StaleRow {
+  id: string;
+  externalId: string;
+  name: string;
+  entityType: string;
+  status: string;
+  /** Whole hours since the row was last written. */
+  ageHours: number;
+}
+
+export interface ReconcileOptions {
+  /** Rows younger than this are ignored — a row mid-cycle is not stale. */
+  minAgeHours?: number;
+  /**
+   * Entity types never reported. PARK is excluded by default: whether a park
+   * should carry live data at all is an open product question
+   * an open question, not a staleness bug.
+   */
+  excludeTypes?: string[];
+}
+
+export interface ReconcileResult {
+  stale: StaleRow[];
+  /** Live rows the API serves in a status that implies the entity is active. */
+  servedLive: number;
+  /** Rows the current build produced. */
+  produced: number;
+  /**
+   * Set when the build looks too thin to trust. A feed that returns almost
+   * nothing makes every row look retired, which is exactly how a bad poll
+   * turns into a mass close. The caller must not act on `stale` when this is
+   * set — the same reasoning as the retirement gate's degraded-feed guard.
+   */
+  degraded?: string;
+}
+
+/** Statuses that assert the entity is currently active. */
+const ACTIVE = new Set(['OPERATING', 'DOWN']);
+
+/**
+ * Compare what the API serves against what the current build produced.
+ *
+ * @param produced   parksapi entity ids in this build's live data
+ * @param served     live rows the API is currently serving
+ * @param now        comparison instant, injected so results are deterministic
+ */
+export function reconcileLiveRows(
+  produced: Iterable<string>,
+  served: ServedRow[],
+  now: Date,
+  options: ReconcileOptions = {},
+): ReconcileResult {
+  const minAgeHours = options.minAgeHours ?? 48;
+  const excludeTypes = new Set(options.excludeTypes ?? ['PARK']);
+  const producedIds = new Set(produced);
+
+  const active = served.filter(row => ACTIVE.has(row.status ?? ''));
+  const stale: StaleRow[] = [];
+
+  for (const row of active) {
+    if (excludeTypes.has(row.entityType ?? '')) continue;
+    // No externalId means nothing can be matched against the build, so the row
+    // cannot be judged either way. Silently closing it would be a guess.
+    if (!row.externalId) continue;
+    if (producedIds.has(row.externalId)) continue;
+
+    const written = row.lastUpdated ? Date.parse(row.lastUpdated) : NaN;
+    if (!Number.isFinite(written)) continue;
+    const ageHours = (now.getTime() - written) / 3_600_000;
+    if (ageHours < minAgeHours) continue;
+
+    stale.push({
+      id: row.id,
+      externalId: row.externalId,
+      name: row.name,
+      entityType: row.entityType ?? 'UNKNOWN',
+      status: row.status ?? '',
+      ageHours: Math.round(ageHours),
+    });
+  }
+
+  stale.sort((a, b) => b.ageHours - a.ageHours);
+
+  const result: ReconcileResult = {
+    stale,
+    servedLive: active.length,
+    produced: producedIds.size,
+  };
+
+  // Guard, mirroring the retirement gate: a build that produced nothing, or a
+  // fraction of what the API serves, is a broken poll rather than a park that
+  // retired most of its attractions overnight.
+  if (producedIds.size === 0 && active.length > 0) {
+    result.degraded = 'build produced no live data at all';
+  } else if (active.length >= 5 && producedIds.size < active.length / 2) {
+    result.degraded = `build produced ${producedIds.size} rows against ${active.length} served — feed looks degraded`;
+  }
+
+  return result;
+}

--- a/src/tools/staleReport.ts
+++ b/src/tools/staleReport.ts
@@ -1,0 +1,127 @@
+/**
+ * @module
+ * Read-only staleness report: what the API still serves that the feed dropped.
+ *
+ * Closes nothing. Prints a table and writes a CSV so the diff can be read
+ * before anything acts on it — at fleet scale this list is several hundred
+ * rows, so it is reviewed, not trusted.
+ *
+ *   npm run stale                 # every registered destination
+ *   npm run stale -- universalorlando disneylandparis
+ */
+import {writeFileSync} from 'node:fs';
+import https from 'node:https';
+import {getDestinationById, getAllDestinations} from '../destinationRegistry.js';
+import {reconcileLiveRows, type ServedRow, type StaleRow} from './staleLiveRows.js';
+
+const API = 'https://api.themeparks.wiki/v1';
+
+function getJSON(url: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      let body = '';
+      res.on('data', chunk => { body += chunk; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(body)); } catch (err) { reject(err); }
+      });
+    }).on('error', reject);
+  });
+}
+
+/**
+ * Live rows the API serves for a destination, joined to entity metadata.
+ *
+ * Joined on the published `externalId`, which is the parksapi DESTINATION
+ * entity id (`universalresort_orlando`), NOT the registry id
+ * (`universalorlando`). The two differ for most destinations.
+ */
+async function fetchServedRows(destinationEntityIds: string[]): Promise<ServedRow[]> {
+  const wanted = new Set(destinationEntityIds);
+  const destinations = await getJSON(`${API}/destinations`);
+  const remote = destinations.destinations?.find((d: any) => wanted.has(d.externalId));
+  if (!remote) return [];
+
+  const rows: ServedRow[] = [];
+  for (const park of remote.parks ?? []) {
+    const [live, children] = await Promise.all([
+      getJSON(`${API}/entity/${park.id}/live`),
+      getJSON(`${API}/entity/${park.id}/children`),
+    ]);
+    const meta = new Map<string, {externalId?: string; entityType?: string}>();
+    meta.set(park.id, {externalId: park.externalId, entityType: 'PARK'});
+    for (const child of children.children ?? []) {
+      meta.set(child.id, {externalId: child.externalId, entityType: child.entityType});
+    }
+    for (const row of live.liveData ?? []) {
+      rows.push({
+        id: row.id,
+        name: row.name,
+        status: row.status,
+        lastUpdated: row.lastUpdated,
+        ...meta.get(row.id),
+      });
+    }
+  }
+  return rows;
+}
+
+async function main(): Promise<void> {
+  const requested = process.argv.slice(2).filter(arg => !arg.startsWith('-'));
+  const ids = requested.length
+    ? requested
+    : (await getAllDestinations()).map(entry => entry.id);
+
+  const all: Array<StaleRow & {destination: string}> = [];
+  const now = new Date();
+
+  for (const id of ids) {
+    let produced: string[] = [];
+    let destinationEntityIds: string[] = [];
+    try {
+      const entry = await getDestinationById(id);
+      if (!entry) { console.log(`${id.padEnd(28)} not registered`); continue; }
+      const destination = new entry.DestinationClass();
+      produced = (await destination.getLiveData()).map(row => row.id);
+      destinationEntityIds = (await destination.getDestinations()).map(entity => entity.id);
+    } catch (err) {
+      // A destination that cannot build says nothing about staleness — its
+      // absent rows are a broken build, not retired entities.
+      console.log(`${id.padEnd(28)} SKIPPED — build failed: ${String(err).slice(0, 70)}`);
+      continue;
+    }
+
+    const served = await fetchServedRows(destinationEntityIds).catch(() => [] as ServedRow[]);
+    if (!served.length) { console.log(`${id.padEnd(28)} no published live rows`); continue; }
+
+    const result = reconcileLiveRows(produced, served, now);
+    const flag = result.degraded ? `  ⚠ ${result.degraded}` : '';
+    console.log(
+      `${id.padEnd(28)} produced ${String(result.produced).padStart(4)} | ` +
+      `served ${String(result.servedLive).padStart(4)} | stale ${String(result.stale.length).padStart(4)}${flag}`,
+    );
+    if (result.degraded) continue; // untrustworthy: report the count, not the rows
+    all.push(...result.stale.map(row => ({...row, destination: id})));
+  }
+
+  all.sort((a, b) => b.ageHours - a.ageHours);
+
+  console.log(`\n${all.length} stale live rows across ${ids.length} destination(s)\n`);
+  for (const row of all.slice(0, 25)) {
+    console.log(
+      `  ${String(Math.round(row.ageHours / 24)).padStart(5)}d  ${row.status.padEnd(9)} ` +
+      `${row.destination.slice(0, 22).padEnd(22)} ${row.name.slice(0, 40)}`,
+    );
+  }
+  if (all.length > 25) console.log(`  … and ${all.length - 25} more`);
+
+  const csv = ['destination,externalId,guid,name,entityType,status,ageHours']
+    .concat(all.map(r =>
+      [r.destination, r.externalId, r.id, `"${r.name.replace(/"/g, '""')}"`, r.entityType, r.status, r.ageHours].join(',')))
+    .join('\n');
+  const path = `/tmp/stale-live-rows.csv`;
+  writeFileSync(path, csv);
+  console.log(`\nCSV: ${path}`);
+}
+
+await main();
+process.exit(0);


### PR DESCRIPTION
Read-only reporting tool. Closes nothing.

The live-entity retirement gate only tracks ids it has observed live, so an entity already frozen when the gate first ran is invisible to it permanently. This says what is stale so the diff can be read before anything acts on it.

## What it found

```
npm run stale
164 stale live rows across 81 destinations
```

| type | rows |
|---|---|
| RESTAURANT | 89 |
| SHOW | 51 |
| ATTRACTION | 24 |

## Why this differs from a naive staleness count

Counting rows by `lastUpdated` age alone gives a far larger number, and it is the wrong measure here: an unchanged row is not rewritten, so its timestamp stays old **while the entity is still present in the feed**. Age measures "has not changed recently", not "no longer exists".

This tool compares against what the current build actually produces, which is the question that matters.

## Deliberately conservative

Every row listed becomes a closed row later, so the bias is toward saying nothing:

- only `OPERATING` and `DOWN` count as active claims; re-closing a `CLOSED` row would never end
- `PARK` excluded — whether a park should carry live data at all is a separate open question
- a row with no `externalId`, or an unparseable timestamp, is skipped rather than guessed at
- a build that produced nothing, or a fraction of what the API serves, is flagged degraded and its rows **withheld**

That last guard earned itself on the first run: one destination produced 0 rows against 21 served and was correctly withheld rather than reported as 21 retirements.

## Verification

- 13 tests, mutation-verified: reporting closed rows, including PARK, guessing at a missing externalId, dropping the age floor, removing the degraded guard, and losing the ordering each fail a test
- full suite green (2177)
- spot-checked against four known frozen rows identified by hand

## Note on the join

The published `externalId` is the destination entity id, not the registry id. Matching on slug silently finds nothing.