### PR TITLE
test(tdr): pin the schedule and paid-queue shapes, and record why they look thin

### DIFF
--- a/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
+++ b/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
@@ -185,3 +185,205 @@ describe('buildLiveData — standbyTimeDisplayType handling', () => {
     expect(ld[0].queue.STANDBY.waitTime).toBeUndefined();
   });
 });
+
+/**
+ * Schedules come from `/rest/v1/parks/calendars`, which returns one row per
+ * park per day with a plain `openTime`/`closeTime` pair.
+ *
+ * Worth stating up front, because it reads like a bug and is not: every
+ * announced day in the feed currently opens at 09:00, New Year's Eve
+ * included. That is what Tokyo Disney Resort publishes. Checked against
+ * tokyodisneyresort.jp across 2026-08 → 2027-02: the site shows
+ * "9:00 a.m.-9:00 p.m." on 303 park-days, "9:00 a.m.-6:30 p.m." on 5 and
+ * "9:00 a.m.-7:00 p.m." on 2, and the exception dates are the same set the
+ * API returns. `spOpenTime`/`spCloseTime` are empty resort-wide because no
+ * special-hours event is scheduled, so the EXTRA_HOURS branch is dormant
+ * rather than broken. The app has no other park-hours endpoint —
+ * `/rest/v3/parks/conditions` carries `earlyEntryFlg` and `allNightDay` as
+ * bare booleans with no times attached.
+ *
+ * Closed days are dropped rather than emitted: `CLOSED` is not a member of
+ * typelib's ScheduleType, so absence is how a closure is expressed, the same
+ * way every other park in this repo does it.
+ */
+describe('buildSchedules', () => {
+  const calendar = (rows: any[]) => {
+    const probe = new TokyoDisneyResort({});
+    vi.spyOn(probe, 'getCalendar').mockResolvedValue(rows as any);
+    return probe;
+  };
+
+  const day = (over: Record<string, any> = {}) => ({
+    parkType: 'TDL',
+    date: '2026-12-31',
+    openTime: '09:00',
+    closeTime: '21:00',
+    closedDay: false,
+    spOpenTime: '',
+    spCloseTime: '',
+    undecided: false,
+    ...over,
+  });
+
+  test('an operating day is stamped in JST', async () => {
+    const [tdl] = await calendar([day()]).getSchedules();
+
+    expect(tdl.id).toBe('tdl');
+    expect(tdl.schedule).toEqual([{
+      date: '2026-12-31',
+      type: 'OPERATING',
+      openingTime: '2026-12-31T09:00:00+09:00',
+      closingTime: '2026-12-31T21:00:00+09:00',
+    }]);
+  });
+
+  test('each park gets its own schedule entry', async () => {
+    const out = await calendar([
+      day({parkType: 'TDL', closeTime: '21:00'}),
+      day({parkType: 'TDS', closeTime: '18:30'}),
+    ]).getSchedules();
+
+    expect(out.map((s: any) => s.id).sort()).toEqual(['tdl', 'tds']);
+    expect(out.find((s: any) => s.id === 'tds')!.schedule[0].closingTime)
+      .toBe('2026-12-31T18:30:00+09:00');
+  });
+
+  test('the early-close days keep their real closing time', async () => {
+    const [tds] = await calendar([
+      day({parkType: 'TDS', date: '2026-09-25', closeTime: '18:30'}),
+    ]).getSchedules();
+
+    expect(tds.schedule[0].closingTime).toBe('2026-09-25T18:30:00+09:00');
+  });
+
+  test('closed and undecided days are not published', async () => {
+    const out = await calendar([
+      day({date: '2026-12-30', closedDay: true}),
+      day({date: '2026-12-29', undecided: true}),
+    ]).getSchedules();
+
+    expect(out).toEqual([]);
+  });
+
+  test('a day missing either time is skipped rather than published as Invalid Date', async () => {
+    const out = await calendar([
+      day({date: '2026-12-28', openTime: '', closeTime: '21:00'}),
+      day({date: '2026-12-27', closeTime: undefined}),
+    ]).getSchedules();
+
+    expect(out).toEqual([]);
+  });
+
+  test('a park the resort does not surface is ignored', async () => {
+    const out = await calendar([day({parkType: 'TDR'})]).getSchedules();
+
+    expect(out).toEqual([]);
+  });
+
+  /**
+   * Dormant today — every row in the live feed sends these empty — but the
+   * branch exists, so it is pinned rather than left to rot untested.
+   */
+  test('special hours are published alongside the operating day', async () => {
+    const [tdl] = await calendar([
+      day({spOpenTime: '08:15', spCloseTime: '09:00'}),
+    ]).getSchedules();
+
+    expect(tdl.schedule).toHaveLength(2);
+    expect(tdl.schedule[1]).toMatchObject({
+      date: '2026-12-31',
+      type: 'EXTRA_HOURS',
+      openingTime: '2026-12-31T08:15:00+09:00',
+      closingTime: '2026-12-31T09:00:00+09:00',
+    });
+  });
+
+  test('a half-populated special-hours pair is not published', async () => {
+    const [tdl] = await calendar([day({spOpenTime: '08:15'})]).getSchedules();
+
+    expect(tdl.schedule).toHaveLength(1);
+    expect(tdl.schedule[0].type).toBe('OPERATING');
+  });
+});
+
+/**
+ * Premier Access and Priority Pass reduce to a single boolean each in the
+ * anonymous feed, so the emitted queues are deliberately hollow. Pinned
+ * because the shape looks like a gap and gets re-reported as one: the return
+ * windows and the yen price live behind POST endpoints that want registered
+ * park tickets and a `cid:ctoken` credential, so null is the honest value.
+ */
+describe('buildLiveData — Premier Access and Priority Pass', () => {
+  const conditions = (attraction: Record<string, any>) => {
+    const probe = new TokyoDisneyResort({});
+    vi.spyOn(probe, 'getConditions').mockResolvedValue({
+      attractions: [{
+        facilityCode: 'A1',
+        standbyTimeDisplayType: 'NORMAL',
+        operatings: [{
+          startAt: '2026-06-17T00:00:00.000Z',
+          endAt: '2026-06-17T12:00:00.000Z',
+          operatingStatus: 'OPEN_NOTICE',
+        }],
+        ...attraction,
+      }],
+    } as any);
+    return probe;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOON_JST_UTC));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('SELLING becomes an available paid queue with no window and no real price', async () => {
+    const [row] = await conditions({premierAccessStatus: 'SELLING'}).getLiveData();
+
+    expect(row.queue!.PAID_RETURN_TIME).toEqual({
+      state: 'AVAILABLE',
+      returnStart: null,
+      returnEnd: null,
+      // amount 0 is typelib's floor, not a claim that it is free — `formatted`
+      // is what marks the price unknown.
+      price: {currency: 'JPY', amount: 0, formatted: 'Unknown'},
+    });
+  });
+
+  test('NOT_SELLING_NOW becomes a finished paid queue', async () => {
+    const [row] = await conditions({premierAccessStatus: 'NOT_SELLING_NOW'}).getLiveData();
+
+    expect(row.queue!.PAID_RETURN_TIME!.state).toBe('FINISHED');
+  });
+
+  test('TICKETING becomes an available free return queue with no window', async () => {
+    const [row] = await conditions({priorityPassStatus: 'TICKETING'}).getLiveData();
+
+    expect(row.queue!.RETURN_TIME).toEqual({
+      state: 'AVAILABLE',
+      returnStart: null,
+      returnEnd: null,
+    });
+  });
+
+  test('an attraction offering neither emits neither queue', async () => {
+    const [row] = await conditions({standbyTime: 30}).getLiveData();
+
+    expect(row.queue!.PAID_RETURN_TIME).toBeUndefined();
+    expect(row.queue!.RETURN_TIME).toBeUndefined();
+    expect(row.queue!.STANDBY!.waitTime).toBe(30);
+  });
+
+  test('both queues can sit on one attraction', async () => {
+    const [row] = await conditions({
+      premierAccessStatus: 'SELLING',
+      priorityPassStatus: 'FINISHED',
+    }).getLiveData();
+
+    expect(row.queue!.PAID_RETURN_TIME!.state).toBe('AVAILABLE');
+    expect(row.queue!.RETURN_TIME!.state).toBe('FINISHED');
+  });
+});

--- a/src/parks/tdr/tokyodisneyresort.ts
+++ b/src/parks/tdr/tokyodisneyresort.ts
@@ -559,7 +559,27 @@ export class TokyoDisneyResort extends Destination {
         },
       };
 
-      // Premier Access (paid return time)
+      // Premier Access (paid return time).
+      //
+      // The nulls are a hard limit, not a TODO. `/rest/v7/facilities/
+      // conditions` carries `premierAccessStatus` as SELLING /
+      // NOT_SELLING_NOW and nothing else — no window, no price. The app gets
+      // both from POST endpoints (`/rest/v2/premier-access/available-time/
+      // offer` returns `availableHours[]` and `offer.amount`,
+      // `/rest/v2/priority-pass/offers` returns `startAt`/`endAt`), but every
+      // one of those request bodies requires `encryptTicketNoList` — real
+      // park tickets registered to a signed-in account — and the services
+      // sit behind a `cid:ctoken` credential this client does not hold.
+      // Probed anonymously: `error.invalidAuth` 401 on the GET variants,
+      // 400/415 on the POSTs. The price is a per-purchase quote for a
+      // specific ticket set in any case, not a published per-attraction rate.
+      //
+      // The emitted price reads `{amount: 0, currency: 'JPY', formatted:
+      // 'Unknown'}`. That is the framework's marker for "paid, rate unknown"
+      // (see PaidReturnTimeBuilder), forced by typelib requiring
+      // `price.amount` as a non-null `number`. A consumer reading `amount`
+      // alone will mistake it for free; fixing that properly means widening
+      // PriceData, not changing this call.
       if (attr.premierAccessStatus) {
         ld.queue!.PAID_RETURN_TIME = this.buildPaidReturnTimeQueue(
           attr.premierAccessStatus === 'SELLING' ? 'AVAILABLE' : 'FINISHED',
@@ -585,6 +605,25 @@ export class TokyoDisneyResort extends Destination {
     return liveData;
   }
 
+  /**
+   * Park hours from `/rest/v1/parks/calendars`.
+   *
+   * The output looks wrong and is not: every announced day opens at 09:00,
+   * New Year's Eve included. That is what the resort publishes. Checked
+   * against tokyodisneyresort.jp over 2026-08 → 2027-02 — the site shows
+   * 09:00-21:00 on 303 park-days, 09:00-18:30 on 5 and 09:00-19:00 on 2, and
+   * the exception dates are the same set this endpoint returns. The app has
+   * no other source: `/rest/v3/parks/conditions` carries `earlyEntryFlg` and
+   * `allNightDay` as bare booleans with no times, and `/rest/v2|v3/parks/
+   * calendars` are 404.
+   *
+   * `spOpenTime`/`spCloseTime` are empty on every current row because no
+   * special-hours event is scheduled, so the EXTRA_HOURS branch below is
+   * dormant rather than dead.
+   *
+   * Closed and undecided days are dropped. `CLOSED` is not a typelib
+   * ScheduleType — absence is how a closure is expressed.
+   */
   protected async buildSchedules(): Promise<EntitySchedule[]> {
     const calendar = await this.getCalendar();
 


### PR DESCRIPTION
Investigates the three gaps reported in #527. All three reproduce exactly as
described. Two are not bugs, the third was fixed months ago without anyone
realising, so this adds the tests and the reasoning rather than a fix.

No functional change. That is the finding.

## 1. No `DOWN` recorded before 2026-06-17 — real, already fixed

The reported boundary lands on the v6 → v7 live-conditions migration. The old
decoder was:

```js
switch (condition.facilityStatus) {
  case 'CLOSE_NOTICE': return 'DOWN';
```

`CLOSE_NOTICE` was never a `facilityStatus` value — it belongs to
`operatings[].operatingStatus`, which did not exist until v7. That branch was
dead code matching a field that never carried it, so every downtime fell
through to the `default` arm and published as `CLOSED`.

The v7 rewrite fixed it incidentally. Verified live: 71 rows,
`{CLOSED: 17, OPERATING: 53, DOWN: 1}`. Already covered by an existing test,
so this only notes it. The pre-June history cannot be recovered.

## 2. `paid_return` carries no window and no real price — real, unavailable

The fields exist upstream — the offer response carries an `amount`, and the
pass responses carry `startAt`/`endAt` — but every endpoint serving them
requires park tickets registered to a signed-in account, behind a credential
this client does not hold. Probed anonymously: `error.invalidAuth` on the GET
variants, 400/415 on the POSTs, with a deliberate bogus path returning 404 as
a control that routing works.

The price is a per-purchase quote for a specific ticket set in any case, not a
published per-attraction rate. `/rest/v7/facilities/conditions` gives
`premierAccessStatus` as `SELLING`/`NOT_SELLING_NOW` and `priorityPassStatus`
as `TICKETING`/other, and that is the complete anonymous signal.

`null` is the honest value. The call site now says so.

One real defect falls out, and it is not this repo's: the emitted price reads
`{amount: 0, currency: 'JPY', formatted: 'Unknown'}` because the type requires
a non-null `amount`. A consumer reading `amount` alone will read that as free.
Filed as ThemeParks/typelib#2 rather than worked around here — Disneyland Paris
can reach the same placeholder whenever its upstream price is absent, so it is
not Tokyo-specific.

## 3. Schedule is a constant, not real park hours — not a bug

Every announced day opens at 09:00, New Year's Eve included. That is what the
resort publishes.

| | this endpoint | tokyodisneyresort.jp |
|---|---|---|
| 09:00-21:00 | 301 | 303 |
| 09:00-18:30 | 5 | 5 |
| 09:00-19:00 | 2 | 2 |

The exception dates are the same set — 2026-09-25 TDS, 2026-10-02 TDL,
2026-11-27 TDS, 2026-12-04 TDL, 2027-01-22 TDS, 2027-01-28 both — and their
daily pages carry "Please note the change in Park operating hours". Both parks'
official pages give 31 December 2026 as 9:00 a.m.-9:00 p.m.

There is no second source. The app declares three park endpoints; the calendar
model has exactly the nine fields already typed here, `/rest/v3/parks/conditions`
carries `earlyEntryFlg` and `allNightDay` as bare booleans with no times, and
`/rest/v2|v3/parks/calendars` are 404.

`spOpenTime`/`spCloseTime` are empty resort-wide because no special-hours event
is scheduled, so the `EXTRA_HOURS` branch is dormant rather than broken. It is
now tested in both directions.

Closed days stay dropped: `CLOSED` is not a `ScheduleType`, so absence is how a
closure is expressed, consistent with every other park here. Moot in practice —
0 of 308 rows are `closedDay` or `undecided`, and the resort signals
"not yet announced" by omitting the date entirely.

## What changed

`buildSchedules` had no tests at all. It now has eight: JST stamping, the
per-park split, the early-close days, closed and undecided drops, a day missing
either time, an unsurfaced park type, and both special-hours branches. Five more
pin the hollow Premier Access and Priority Pass queue shapes so they stop
reading as an accidental gap.

19 → 29 tests. Doc comments at both sites record the cross-check and the
endpoint sweep so this does not get re-investigated from scratch.

## Test plan

- [x] `npx vitest run src/parks/tdr` — 29 passed
- [x] `npx tsc --noEmit` — clean
- [x] Live end-to-end against both parks: 71 live rows, 308 calendar entries
- [ ] Review

Closes #527
