### PR TITLE
test(cache): stop the two on-disk SQLite tests failing under load

### DIFF
--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1231,8 +1231,20 @@ describe('Cache', () => {
     test('WAL and busy_timeout PRAGMAs should be settable on file-based databases', () => {
       // The test suite uses in-memory database which doesn't support WAL.
       // Verify the PRAGMAs work on a temp file-based database instead.
+      //
+      // The path has to be unique per run. This used to be a fixed
+      // `/tmp/cache_wal_test.sqlite`, which two overlapping vitest processes
+      // would open, WAL, and unlink from under each other — the test then
+      // failed for reasons that had nothing to do with the change under test.
+      // A gate test may not depend on being the only one running.
       const {DatabaseSync} = require('node:sqlite');
-      const tmpDb = new DatabaseSync('/tmp/cache_wal_test.sqlite');
+      const os = require('os');
+      const path = require('path');
+      const dbPath = path.join(
+        require('fs').mkdtempSync(path.join(os.tmpdir(), 'cache-wal-')),
+        'cache_wal_test.sqlite',
+      );
+      const tmpDb = new DatabaseSync(dbPath);
       try {
         tmpDb.exec('PRAGMA journal_mode=WAL');
         tmpDb.exec('PRAGMA busy_timeout=5000');
@@ -1244,10 +1256,8 @@ describe('Cache', () => {
         expect(busyTimeout.timeout).toBe(5000);
       } finally {
         tmpDb.close();
-        require('fs').unlinkSync('/tmp/cache_wal_test.sqlite');
-        // Clean up WAL/SHM files if they exist
-        try { require('fs').unlinkSync('/tmp/cache_wal_test.sqlite-wal'); } catch {}
-        try { require('fs').unlinkSync('/tmp/cache_wal_test.sqlite-shm'); } catch {}
+        // The whole directory goes, so the WAL/SHM siblings go with it.
+        require('fs').rmSync(path.dirname(dbPath), {recursive: true, force: true});
       }
     });
   });

--- a/src/__tests__/cachePragmas.test.ts
+++ b/src/__tests__/cachePragmas.test.ts
@@ -8,7 +8,11 @@ import { describe, expect, it, vi } from 'vitest';
 // cache gets the fsync-tolerant pragmas, re-import the module against a real
 // on-disk path.
 describe('cache DB fsync pragmas (on-disk)', () => {
-  it('opens the persistent cache in WAL with synchronous=NORMAL', async () => {
+  // Generous timeout on purpose. This re-imports the cache module from scratch
+  // after resetModules() and opens a real on-disk SQLite in WAL, and both are
+  // slow enough on a loaded machine to blow the 5s default. It is slow, not
+  // hanging — a gate test may not fail because something else was running.
+  it('opens the persistent cache in WAL with synchronous=NORMAL', {timeout: 60_000}, async () => {
     const dir = mkdtempSync(join(tmpdir(), 'cache-pragma-'));
     process.env.CACHE_DB_PATH = join(dir, 'cache.sqlite');
     vi.resetModules();


### PR DESCRIPTION
Two gate tests that touch a real SQLite file on disk fail intermittently, and neither failure relates to the change being tested. Both reproduce on an unmodified `main`, and between them they have already cost more than one debugging detour on unrelated work.

**`cache.test.ts`** — "WAL and busy_timeout PRAGMAs should be settable on file-based databases" opened a fixed path:

```ts
const tmpDb = new DatabaseSync('/tmp/cache_wal_test.sqlite');
```

put it in WAL, and `unlinkSync`d it in `finally`. Two vitest processes running concurrently — two worktrees, or a suite alongside anything else — open and delete that one file from under each other, and the loser fails on a PRAGMA that is not broken. Now uses its own `mkdtemp` directory, removed whole so the `-wal` and `-shm` siblings go with it.

**`cachePragmas.test.ts`** re-imports the cache module after `resetModules()` and opens an on-disk database in WAL. On a loaded machine that exceeds the 5s default and fails as a timeout; run on its own it finishes in about a second. It is slow, not hanging, so it gets an explicit generous timeout rather than a weakened assertion.

A gate test may not fail because something else happened to be running.

## Test plan

- [x] `npx vitest run src/__tests__/cache.test.ts src/__tests__/cachePragmas.test.ts` — 82 passed
- [x] Both previously reproduced as failures under concurrent suite runs
- [ ] Review