### PR TITLE
feat: publish an unknown paid-queue price as null, not zero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@themeparks/typelib": "^1.1.5",
+        "@themeparks/typelib": "^1.2.0",
         "adm-zip": "^0.6.0",
         "ajv": "^8.17.1",
         "sift": "^17.1.3",
@@ -935,9 +935,9 @@
       "license": "MIT"
     },
     "node_modules/@themeparks/typelib": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@themeparks/typelib/-/typelib-1.1.5.tgz",
-      "integrity": "sha512-zxKatrGw/Dw+e+wcu0xIR1Oe0+SSSWy4pUitivW2uD/qz4eWVHNJd3NRgBEeiM8/rNtwVN4CP2dldh6hVOzXQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@themeparks/typelib/-/typelib-1.2.0.tgz",
+      "integrity": "sha512-sCpbcBeroaPzZ4ayebX7i/0rzGc3ghU1dWyCWp10HgqMbwK+u3xtKDXCSmFHVkVk84G4fzP7RhFaWatvO/Dulw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@themeparks/typelib": "^1.1.5",
+    "@themeparks/typelib": "^1.2.0",
     "adm-zip": "^0.6.0",
     "ajv": "^8.17.1",
     "sift": "^17.1.3",

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1228,7 +1228,11 @@ describe('Cache', () => {
   });
 
   describe('SQLite WAL Mode', () => {
-    test('WAL and busy_timeout PRAGMAs should be settable on file-based databases', () => {
+    // Generous timeout for the same reason as cachePragmas.test.ts: opening a
+    // real on-disk SQLite in WAL is slow on a loaded machine and will blow the
+    // 5s default. Unique path alone was not enough — this still timed out at
+    // 6.4s once the collision was fixed.
+    test('WAL and busy_timeout PRAGMAs should be settable on file-based databases', {timeout: 60_000}, () => {
       // The test suite uses in-memory database which doesn't support WAL.
       // Verify the PRAGMAs work on a temp file-based database instead.
       //

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1228,11 +1228,12 @@ describe('Cache', () => {
   });
 
   describe('SQLite WAL Mode', () => {
-    // Generous timeout for the same reason as cachePragmas.test.ts: opening a
-    // real on-disk SQLite in WAL is slow on a loaded machine and will blow the
-    // 5s default. Unique path alone was not enough — this still timed out at
-    // 6.4s once the collision was fixed.
-    test('WAL and busy_timeout PRAGMAs should be settable on file-based databases', {timeout: 60_000}, () => {
+    // Headroom against worker starvation, not against SQLite. The open plus
+    // three pragmas measures under a second even on a heavily loaded machine;
+    // what blows the 5s default is the whole vitest worker being starved by a
+    // parallel run. 15s is ~20x the worst measured value and still fails fast
+    // if this ever genuinely wedges.
+    test('WAL and busy_timeout PRAGMAs should be settable on file-based databases', {timeout: 15_000}, () => {
       // The test suite uses in-memory database which doesn't support WAL.
       // Verify the PRAGMAs work on a temp file-based database instead.
       //

--- a/src/__tests__/cachePragmas.test.ts
+++ b/src/__tests__/cachePragmas.test.ts
@@ -1,29 +1,57 @@
+import { DatabaseSync } from 'node:sqlite';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { applyPersistencePragmas } from '../cache.js';
 
 // The shared test setup forces CACHE_DB_PATH=:memory: (vitest.setup.ts), where
 // journal_mode is 'memory' and synchronous is moot. To prove the PERSISTENT
-// cache gets the fsync-tolerant pragmas, re-import the module against a real
-// on-disk path.
+// cache gets the fsync-tolerant pragmas, apply them to a real on-disk database.
+//
+// Two things were wrong with the previous version of this test and both are
+// fixed here.
+//
+// It re-imported the cache module under a mutated CACHE_DB_PATH, needing
+// vi.resetModules() plus a dynamic import, which turned a slow test into a
+// pathological one — 60s timeouts under a loaded worker pool. The module now
+// calls the same exported function this test calls, so the guarantee survives
+// without the module registry games.
+//
+// And the underlying work is genuinely slow: opening an on-disk SQLite and
+// switching it to WAL costs seconds when the disk is busy with a parallel test
+// run, measured at 5.2s with the imports already gone. So it also gets a
+// generous timeout. A gate test may not fail because something else was
+// running.
 describe('cache DB fsync pragmas (on-disk)', () => {
-  // Generous timeout on purpose. This re-imports the cache module from scratch
-  // after resetModules() and opens a real on-disk SQLite in WAL, and both are
-  // slow enough on a loaded machine to blow the 5s default. It is slow, not
-  // hanging — a gate test may not fail because something else was running.
-  it('opens the persistent cache in WAL with synchronous=NORMAL', {timeout: 60_000}, async () => {
+  it('opens a persistent cache in WAL with synchronous=NORMAL', {timeout: 60_000}, () => {
     const dir = mkdtempSync(join(tmpdir(), 'cache-pragma-'));
-    process.env.CACHE_DB_PATH = join(dir, 'cache.sqlite');
-    vi.resetModules();
-    const { database } = await import('../cache.js');
-    expect(
-      (database.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode,
-    ).toBe('wal');
-    // 0=OFF 1=NORMAL 2=FULL — NORMAL fsyncs at checkpoints, not per commit.
-    expect(
-      (database.prepare('PRAGMA synchronous').get() as { synchronous: number }).synchronous,
-    ).toBe(1);
-    rmSync(dir, { recursive: true, force: true });
+    const db = new DatabaseSync(join(dir, 'cache.sqlite'));
+    try {
+      applyPersistencePragmas(db);
+
+      expect(
+        (db.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode,
+      ).toBe('wal');
+      // 0=OFF 1=NORMAL 2=FULL — NORMAL fsyncs at checkpoints, not per commit.
+      expect(
+        (db.prepare('PRAGMA synchronous').get() as { synchronous: number }).synchronous,
+      ).toBe(1);
+      expect(
+        (db.prepare('PRAGMA busy_timeout').get() as { timeout: number }).timeout,
+      ).toBe(5000);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves an in-memory database alone rather than throwing', () => {
+    const db = new DatabaseSync(':memory:');
+    try {
+      expect(() => applyPersistencePragmas(db)).not.toThrow();
+    } finally {
+      db.close();
+    }
   });
 });

--- a/src/__tests__/cachePragmas.test.ts
+++ b/src/__tests__/cachePragmas.test.ts
@@ -1,35 +1,30 @@
-import { DatabaseSync } from 'node:sqlite';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { applyPersistencePragmas } from '../cache.js';
+import { openDatabase } from '../cache.js';
 
 // The shared test setup forces CACHE_DB_PATH=:memory: (vitest.setup.ts), where
-// journal_mode is 'memory' and synchronous is moot. To prove the PERSISTENT
-// cache gets the fsync-tolerant pragmas, apply them to a real on-disk database.
+// journal_mode cannot be WAL. To prove the PERSISTENT cache gets the
+// fsync-tolerant pragmas, open a real on-disk database.
 //
-// Two things were wrong with the previous version of this test and both are
-// fixed here.
+// Test openDatabase(), not applyPersistencePragmas(), and not the module's
+// exported `database`. openDatabase is the only way this module builds a cache
+// database, so covering it covers the wiring as well as the behaviour. An
+// earlier version of this test called the pragma function directly, which
+// passed happily with the module's own call to it deleted — it proved the
+// function body and nothing about what ships.
 //
-// It re-imported the cache module under a mutated CACHE_DB_PATH, needing
-// vi.resetModules() plus a dynamic import, which turned a slow test into a
-// pathological one — 60s timeouts under a loaded worker pool. The module now
-// calls the same exported function this test calls, so the guarantee survives
-// without the module registry games.
-//
-// And the underlying work is genuinely slow: opening an on-disk SQLite and
-// switching it to WAL costs seconds when the disk is busy with a parallel test
-// run, measured at 5.2s with the imports already gone. So it also gets a
-// generous timeout. A gate test may not fail because something else was
-// running.
-describe('cache DB fsync pragmas (on-disk)', () => {
-  it('opens a persistent cache in WAL with synchronous=NORMAL', {timeout: 60_000}, () => {
+// It does NOT re-import the module under a mutated CACHE_DB_PATH. That needs
+// vi.resetModules() plus a dynamic import, which measured 5-7x slower and sat
+// at a 60s timeout under a loaded worker pool. The SQLite work itself is
+// sub-second even on a busy machine, so the timeout below is headroom against
+// worker starvation, not against the database.
+describe('cache database construction', () => {
+  it('opens a persistent cache in WAL with synchronous=NORMAL', {timeout: 15_000}, () => {
     const dir = mkdtempSync(join(tmpdir(), 'cache-pragma-'));
-    const db = new DatabaseSync(join(dir, 'cache.sqlite'));
+    const db = openDatabase(join(dir, 'cache.sqlite'));
     try {
-      applyPersistencePragmas(db);
-
       expect(
         (db.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode,
       ).toBe('wal');
@@ -46,10 +41,39 @@ describe('cache DB fsync pragmas (on-disk)', () => {
     }
   });
 
-  it('leaves an in-memory database alone rather than throwing', () => {
-    const db = new DatabaseSync(':memory:');
+  it('creates the schema as well as the pragmas', {timeout: 15_000}, () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cache-schema-'));
+    const db = openDatabase(join(dir, 'cache.sqlite'));
     try {
-      expect(() => applyPersistencePragmas(db)).not.toThrow();
+      const tables = (db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+        .all() as Array<{ name: string }>).map((r) => r.name);
+
+      expect(tables).toContain('cache');
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * WAL needs a file, so an in-memory database keeps journal_mode=memory — but
+   * busy_timeout and synchronous do apply, and none of the three throws. Worth
+   * pinning, because the pragma call used to carry a comment claiming this was
+   * the case the try/catch existed for.
+   */
+  it('leaves an in-memory database on its own journal mode without throwing', () => {
+    const db = openDatabase(':memory:', true);
+    try {
+      expect(
+        (db.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode,
+      ).toBe('memory');
+      expect(
+        (db.prepare('PRAGMA busy_timeout').get() as { timeout: number }).timeout,
+      ).toBe(5000);
+      expect(
+        (db.prepare('PRAGMA synchronous').get() as { synchronous: number }).synchronous,
+      ).toBe(1);
     } finally {
       db.close();
     }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,8 +9,9 @@ const CLEANUP_INTERVAL_MS = parseInt(process.env.CACHE_CLEANUP_INTERVAL_MS || '3
 // Track if we're in temporary mode
 let isTemporaryMode = false;
 
-// Initialize database (can be re-initialized)
-let database = new DatabaseSync(CACHE_DB_PATH);
+// Initialize database (can be re-initialized). Assigned below, once
+// openDatabase() is defined — every cache database is built through it.
+let database: DatabaseSync;
 
 export {database};
 
@@ -89,39 +90,58 @@ function initializeDatabase(db: DatabaseSync, skipMigration: boolean = false): v
   `);
 }
 
-// Initialize the default database
-initializeDatabase(database);
-
 /**
- * Enable WAL mode and busy timeout for better concurrent access.
+ * Apply the pragmas the cache relies on.
  *
- * WAL allows readers and writers to operate simultaneously, and busy_timeout
- * prevents SQLITE_BUSY errors under contention.
+ * WAL lets readers and writers work simultaneously, and busy_timeout waits out
+ * a competing writer instead of throwing SQLITE_BUSY.
  *
- * synchronous=NORMAL: with WAL, fsync only at checkpoints, not per commit.
- * This is the hot HTTP-response cache — hammered during a park's entity/sync
- * sweep — and DatabaseSync is synchronous, so per-commit fsync on a slow or
- * saturated disk stalls the caller's event loop. NORMAL only risks losing the
- * last uncheckpointed cache rows on a hard crash, which are just re-fetched.
+ * synchronous=NORMAL: with WAL, fsync happens at checkpoints rather than per
+ * commit. This is the hot HTTP-response cache — hammered during a park's
+ * entity/sync sweep — and DatabaseSync is synchronous, so per-commit fsync on
+ * a slow or saturated disk stalls the caller's event loop. NORMAL only risks
+ * losing the last uncheckpointed cache rows on a hard crash, and those are
+ * just re-fetched.
  *
- * Exported so a test can prove the behaviour against a real on-disk database.
- * The alternative — re-importing this module under a mutated CACHE_DB_PATH —
- * needs `vi.resetModules()` plus a dynamic import, which intermittently hangs
- * in a loaded vitest worker pool.
+ * On an in-memory database `journal_mode` stays `memory` — WAL needs a file —
+ * but `busy_timeout` and `synchronous` do apply. None of the three throws
+ * there, so the catch below is not for that case: it is for a real failure
+ * such as another process holding the database, which would otherwise leave us
+ * running on `journal_mode=delete` with `synchronous=FULL` in silence.
  *
- * No-ops on an in-memory database, which cannot do WAL.
+ * @internal Exported so a test can prove the behaviour against a real on-disk
+ * database. Not part of the supported package surface.
  */
 export function applyPersistencePragmas(db: DatabaseSync): void {
   try {
     db.exec('PRAGMA journal_mode=WAL');
     db.exec('PRAGMA busy_timeout=5000');
     db.exec('PRAGMA synchronous=NORMAL');
-  } catch {
-    // Ignore if PRAGMAs fail (e.g. in-memory databases)
+  } catch (err) {
+    console.warn('Cache: failed to apply persistence pragmas, continuing on SQLite defaults:', err);
   }
 }
 
-applyPersistencePragmas(database);
+/**
+ * Open a cache database.
+ *
+ * The single construction path, so a cache database without its pragmas is not
+ * a state this module can reach. Pragmas go on BEFORE the schema deliberately:
+ * `initializeDatabase` runs five DDL statements, and running those under the
+ * default `journal_mode=delete` + `synchronous=FULL` costs roughly eight times
+ * as much on a cold start (p50 2572ms against 324ms, measured on a loaded
+ * machine) — synchronously, at import time, blocking the event loop.
+ *
+ * @internal
+ */
+export function openDatabase(path: string, skipMigration: boolean = false): DatabaseSync {
+  const db = new DatabaseSync(path);
+  applyPersistencePragmas(db);
+  initializeDatabase(db, skipMigration);
+  return db;
+}
+
+database = openDatabase(CACHE_DB_PATH);
 
 // Cleanup interval reference
 let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -148,9 +168,8 @@ class CacheLib {
     // Stop cleanup if running
     this.stopCleanup();
 
-    // Create new in-memory database
-    database = new DatabaseSync(':memory:');
-    initializeDatabase(database, true); // Skip migration for in-memory DB
+    // Create new in-memory database (skip migration — nothing to migrate)
+    database = openDatabase(':memory:', true);
   }
 
   /**

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -92,21 +92,36 @@ function initializeDatabase(db: DatabaseSync, skipMigration: boolean = false): v
 // Initialize the default database
 initializeDatabase(database);
 
-// Enable WAL mode and busy timeout for better concurrent access.
-// WAL allows readers and writers to operate simultaneously, and
-// busy_timeout prevents SQLITE_BUSY errors under contention.
-try {
-  database.exec('PRAGMA journal_mode=WAL');
-  database.exec('PRAGMA busy_timeout=5000');
-  // synchronous=NORMAL: with WAL, fsync only at checkpoints, not per commit.
-  // This is the hot HTTP-response cache — hammered during a park's entity/sync
-  // sweep — and DatabaseSync is synchronous, so per-commit fsync on a slow or
-  // saturated disk stalls the caller's event loop. NORMAL only risks losing the
-  // last uncheckpointed cache rows on a hard crash, which are just re-fetched.
-  database.exec('PRAGMA synchronous=NORMAL');
-} catch {
-  // Ignore if PRAGMAs fail (e.g. in-memory databases)
+/**
+ * Enable WAL mode and busy timeout for better concurrent access.
+ *
+ * WAL allows readers and writers to operate simultaneously, and busy_timeout
+ * prevents SQLITE_BUSY errors under contention.
+ *
+ * synchronous=NORMAL: with WAL, fsync only at checkpoints, not per commit.
+ * This is the hot HTTP-response cache — hammered during a park's entity/sync
+ * sweep — and DatabaseSync is synchronous, so per-commit fsync on a slow or
+ * saturated disk stalls the caller's event loop. NORMAL only risks losing the
+ * last uncheckpointed cache rows on a hard crash, which are just re-fetched.
+ *
+ * Exported so a test can prove the behaviour against a real on-disk database.
+ * The alternative — re-importing this module under a mutated CACHE_DB_PATH —
+ * needs `vi.resetModules()` plus a dynamic import, which intermittently hangs
+ * in a loaded vitest worker pool.
+ *
+ * No-ops on an in-memory database, which cannot do WAL.
+ */
+export function applyPersistencePragmas(db: DatabaseSync): void {
+  try {
+    db.exec('PRAGMA journal_mode=WAL');
+    db.exec('PRAGMA busy_timeout=5000');
+    db.exec('PRAGMA synchronous=NORMAL');
+  } catch {
+    // Ignore if PRAGMAs fail (e.g. in-memory databases)
+  }
 }
+
+applyPersistencePragmas(database);
 
 // Cleanup interval reference
 let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;

--- a/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
+++ b/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
@@ -347,9 +347,9 @@ describe('buildLiveData — Premier Access and Priority Pass', () => {
       state: 'AVAILABLE',
       returnStart: null,
       returnEnd: null,
-      // amount 0 is typelib's floor, not a claim that it is free — `formatted`
-      // is what marks the price unknown.
-      price: {currency: 'JPY', amount: 0, formatted: 'Unknown'},
+      // Premier Access pricing sits behind an authenticated purchase flow, so
+      // the amount is genuinely unknown rather than zero.
+      price: {currency: 'JPY', amount: null},
     });
   });
 

--- a/src/parks/tdr/tokyodisneyresort.ts
+++ b/src/parks/tdr/tokyodisneyresort.ts
@@ -574,12 +574,11 @@ export class TokyoDisneyResort extends Destination {
       // 400/415 on the POSTs. The price is a per-purchase quote for a
       // specific ticket set in any case, not a published per-attraction rate.
       //
-      // The emitted price reads `{amount: 0, currency: 'JPY', formatted:
-      // 'Unknown'}`. That is the framework's marker for "paid, rate unknown"
-      // (see PaidReturnTimeBuilder), forced by typelib requiring
-      // `price.amount` as a non-null `number`. A consumer reading `amount`
-      // alone will mistake it for free; fixing that properly means widening
-      // PriceData, not changing this call.
+      // The emitted price is `{currency: 'JPY', amount: null}` — paid, rate
+      // unknown. `amount: 0` would mean genuinely free, which this is not.
+      // Before typelib 1.2.0 the type required a non-null amount and this
+      // published `0` with a `formatted: 'Unknown'` marker, which read as
+      // free to anyone looking at `amount` alone.
       if (attr.premierAccessStatus) {
         ld.queue!.PAID_RETURN_TIME = this.buildPaidReturnTimeQueue(
           attr.premierAccessStatus === 'SELLING' ? 'AVAILABLE' : 'FINISHED',

--- a/src/virtualQueue/VIRTUAL_QUEUE_GUIDE.md
+++ b/src/virtualQueue/VIRTUAL_QUEUE_GUIDE.md
@@ -430,7 +430,9 @@ if (!result.valid) {
 - All return time rules apply
 - Must have `price` object
 - Currency must be 3-letter code (USD, EUR, GBP, JPY)
-- Amount should be in cents (or 0)
+- Amount is in cents. Use `null` when the provider confirms a paid queue but
+  does not publish a price, and `0` only when the queue is genuinely free —
+  they are different claims and consumers read them differently
 
 **Boarding Group Queues:**
 - PAUSED status should have `nextAllocationTime`

--- a/src/virtualQueue/__tests__/builder.test.ts
+++ b/src/virtualQueue/__tests__/builder.test.ts
@@ -121,6 +121,24 @@ describe('VQueueBuilder', () => {
       });
     });
 
+    it('should publish a non-finite amount as unknown rather than as nonsense', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        // NaN is what `Math.round(undefined * 100)` and `parseFloat('12,50')`
+        // produce. JSON.stringify renders it as null anyway, so it would
+        // arrive looking exactly like a legitimate unknown price.
+        const queue = VQueueBuilder.paidReturnTime()
+          .available()
+          .withPrice('USD', Math.round((undefined as any) * 100))
+          .build();
+
+        expect(queue.price).toEqual({currency: 'USD', amount: null});
+        expect(warn).toHaveBeenCalledOnce();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
     it('should default an unset price amount to null, not free', () => {
       const queue = VQueueBuilder.paidReturnTime().available().build();
 

--- a/src/virtualQueue/__tests__/builder.test.ts
+++ b/src/virtualQueue/__tests__/builder.test.ts
@@ -106,21 +106,25 @@ describe('VQueueBuilder', () => {
       });
     });
 
-    it('should mark null price amount as Unknown', () => {
+    it('should publish an unknown price amount as null', () => {
       const queue = VQueueBuilder.paidReturnTime()
         .available()
         .withWindow('2024-10-15T14:30:00-04:00', null)
         .withPrice('EUR', null)
         .build();
 
-      // typelib forces amount to be a number, so null is stored as 0 with
-      // the optional `formatted: 'Unknown'` marker so consumers can
-      // distinguish "price unknown" from "free"
+      // null means "this queue costs money, the provider does not say how
+      // much". The currency survives, which is real information.
       expect(queue.price).toEqual({
         currency: 'EUR',
-        amount: 0,
-        formatted: 'Unknown',
+        amount: null,
       });
+    });
+
+    it('should default an unset price amount to null, not free', () => {
+      const queue = VQueueBuilder.paidReturnTime().available().build();
+
+      expect(queue.price.amount).toBeNull();
     });
 
     it('should not mark zero price as unknown (free is distinct)', () => {

--- a/src/virtualQueue/builder.ts
+++ b/src/virtualQueue/builder.ts
@@ -93,6 +93,20 @@ export class PaidReturnTimeBuilder extends ReturnTimeBuilder {
    */
   withPrice(currency: string, amountCents: number | null): this {
     this._currency = currency;
+    // A non-finite amount is a caller bug — an unparsed upstream string, or
+    // arithmetic on an absent field. It cannot be published either way:
+    // JSON.stringify renders NaN as null, which since typelib 1.2.0 is a
+    // meaningful value ("paid, price unpublished") rather than obvious
+    // nonsense, so a NaN would arrive looking like a legitimate unknown.
+    // Normalise it to null so the shape is honest, and say so, because
+    // nothing else downstream will.
+    if (amountCents !== null && !Number.isFinite(amountCents)) {
+      console.warn(
+        `[VQueueBuilder] non-finite paid-queue amount (${amountCents}) for ${currency}, publishing as unknown`,
+      );
+      this._amount = null;
+      return this;
+    }
     this._amount = amountCents;
     return this;
   }

--- a/src/virtualQueue/builder.ts
+++ b/src/virtualQueue/builder.ts
@@ -80,7 +80,7 @@ export class ReturnTimeBuilder {
  */
 export class PaidReturnTimeBuilder extends ReturnTimeBuilder {
   private _currency: string = 'USD';
-  private _amount: number | null = 0;
+  private _amount: number | null = null;
 
   /**
    * Set price for paid return time.
@@ -88,9 +88,8 @@ export class PaidReturnTimeBuilder extends ReturnTimeBuilder {
    * @param currency - Currency code (e.g., 'USD', 'EUR')
    * @param amountCents - Price in cents (e.g., 1500 for $15.00). Pass `null`
    *   when the API confirms a paid queue exists but does not expose the price
-   *   (e.g. Tokyo Disney Premier Access). The built queue will have
-   *   `amount: 0, formatted: 'Unknown'` so consumers can distinguish unknown
-   *   from free.
+   *   (e.g. Tokyo Disney Premier Access). The built queue carries
+   *   `amount: null`, which is distinct from `amount: 0` meaning free.
    */
   withPrice(currency: string, amountCents: number | null): this {
     this._currency = currency;
@@ -103,15 +102,12 @@ export class PaidReturnTimeBuilder extends ReturnTimeBuilder {
    */
   build(): NonNullable<LiveQueue['PAID_RETURN_TIME']> {
     const baseQueue = super.build();
-    // typelib's PriceData.amount is required as `number`, so we can't
-    // store `null` directly. Use the optional `formatted` field to mark
-    // unknown prices — this is distinct from `amount: 0` which means free.
-    const price = this._amount === null
-      ? {currency: this._currency as any, amount: 0, formatted: 'Unknown'}
-      : {currency: this._currency as any, amount: this._amount};
+    // typelib >=1.2.0 types PriceData.amount as `number | null`, so an
+    // unknown price is published as `null`. `amount: 0` keeps its own
+    // meaning: the queue is genuinely free.
     return {
       ...baseQueue,
-      price,
+      price: {currency: this._currency as any, amount: this._amount},
     };
   }
 }


### PR DESCRIPTION
Adopts `@themeparks/typelib@1.2.0`, which widens `PriceData.amount` to `number | null` (ThemeParks/typelib#2).

> ⚠️ **Do not merge before `tpwserver` regenerates its OpenAPI spec on typelib 1.2.0.** See *Merge gate* below.

## The problem

The type required a number, so the only representable value for "this queue costs money and the provider does not publish a price" was `0` — a factual claim that it is free. The real meaning lived in an optional `formatted: 'Unknown'` string that was easy to miss, and a reported data bug came from exactly that: someone read `amount` and concluded Tokyo Premier Access cost nothing.

`null` now means paid-but-unpublished, `0` means genuinely free, and the currency survives either way.

## Blast radius, measured live

All 198 parks on the production API were scanned: 35 `PAID_RETURN_TIME` rows exist.

| Park | rows | before | after |
|---|---|---|---|
| Tokyo Disney Resort | 10 | `{amount: 0, formatted: "Unknown"}` | `{amount: null}` |
| Disneyland Paris | 18 | real (500–1600 EUR) | **byte-identical** |
| Universal Orlando | 0 | — | — |
| WDW / Disneyland Resort | 7 | real — built by the collector, untouched | unchanged |

**No row anywhere means genuinely free.** Every `0` served today is Tokyo's unknown, so consumers treating zeros as unknown are currently right 100% of the time, and the new shape says it unambiguously.

DLP was sampled 40 times over 50 minutes of open park (14:24–15:14 CEST): price present in all 720 row-observations, so its `price != null` fallback is defensive and was never seen to fire.

## Merge gate

`tpwserver/typesrc/entity.json` declares `PriceData` as `required: ["amount","currency"]` with `amount: {"type":"number"}` and no `nullable`. tpwserver has typelib 1.1.3 installed. Until it regenerates on 1.2.0, a consumer generating a strict client from the published spec (Swift/Kotlin/Go/C# with a non-optional `Int`) will fail to decode Tokyo's 10 rows where it previously decoded `0`.

Suggested order: tpwserver bump + regenerate → this PR → collector `npm run bump`.

## Hardening from review

A non-finite amount reaching `withPrice` is now normalised to `null` with a warning. `JSON.stringify(NaN)` is `null`, and since `null` is now meaningful, a `NaN` would have arrived looking like a legitimate unknown rather than obvious nonsense.

## Cache commits (2 and 3)

Commit 2 was wrong and commit 3 fixes it — kept separate rather than rewritten, because the failure is instructive.

Commit 2 extracted the pragma block into an exported function and claimed "same guarantee". Review disproved that by mutation: commenting out the module's single `applyPersistencePragmas(database)` call left the whole suite green, while the test commit 2 deleted caught it with `expected 'delete' to be 'wal'`. The new test proved the function body; the wiring is what ships.

Commit 3 makes `openDatabase(path, skipMigration)` the only construction path, so a cache database without pragmas is unreachable, and the same mutation now fails two assertions. It also applies pragmas **before** the schema: five DDL statements under `journal_mode=delete` + `synchronous=FULL` measured p50 2572ms vs 324ms reordered, synchronously at import time.

Timeouts drop 60s → 15s. The open-plus-pragmas work never exceeds 0.72s even at load 20; what blew the 5s default was worker starvation. Two inline comments were also factually wrong — WAL on `:memory:` does not throw, and `busy_timeout`/`synchronous` do apply there — so the bare `catch` now logs instead of hiding a real failure.

## Test plan

- [x] `npx vitest run` — 103 files, 2239 tests
- [x] `npx tsc --noEmit` — clean
- [x] Mutation-tested: removing the pragma call fails 2 tests
- [x] Live-verified across TDR, DLP, Universal + all 198 production parks
- [ ] Review