### PR TITLE
feat(tdr): publish the real Premier Access price, not just null

### DIFF
--- a/src/parks/tdr/__tests__/premierAccessPrices.test.ts
+++ b/src/parks/tdr/__tests__/premierAccessPrices.test.ts
@@ -1,0 +1,83 @@
+import {describe, test, expect} from 'vitest';
+import {parsePremierAccessPrices} from '../tokyodisneyresort.js';
+
+/**
+ * The API never carries a Premier Access price — every endpoint that holds one
+ * sits behind a purchase flow needing registered park tickets. The rate itself
+ * is published though, as a flat per-experience figure on the public guide
+ * page, and this reads it.
+ *
+ * Markup below mirrors the live page: each experience is a
+ * `div.listTextArea` holding a `p.heading3` name and a `strong` rate.
+ */
+
+const block = (name: string, yen: string) => `
+  <div class="listBox"><a href="/en/attraction/detail/x/"><div class="listTextArea">
+    <p class="heading3">${name}</p>
+    <p class="text">Attraction</p>
+    <strong>${yen} yen per access</strong>
+  </div></a></div>`;
+
+describe('parsePremierAccessPrices', () => {
+  test('reads a name and its rate', () => {
+    expect(parsePremierAccessPrices(block('Splash Mountain', '1,500')))
+      .toEqual({'Splash Mountain': 1500});
+  });
+
+  /**
+   * The real page is one long document with both parks in it, so a parser that
+   * flattens the tags first reads the tail of the preceding element as part of
+   * the name — "View moreHaunted Mansion". Pairing on the heading avoids that.
+   */
+  test('does not absorb text preceding the heading', () => {
+    const html = `<button>View more</button>${block('Haunted Mansion', '1,000')}`;
+    expect(parsePremierAccessPrices(html)).toEqual({'Haunted Mansion': 1000});
+  });
+
+  test('reads every experience on a page with many', () => {
+    const html = [
+      block('Enchanted Tale of Beauty and the Beast', '2,500'),
+      block('The Happy Ride with Baymax', '1,500'),
+      '<button>View more</button>',
+      block('Soaring: Fantastic Flight', '2,500'),
+      block('Toy Story Mania!', '2,000'),
+    ].join('\n');
+    expect(parsePremierAccessPrices(html)).toEqual({
+      'Enchanted Tale of Beauty and the Beast': 2500,
+      'The Happy Ride with Baymax': 1500,
+      'Soaring: Fantastic Flight': 2500,
+      'Toy Story Mania!': 2000,
+    });
+  });
+
+  /**
+   * Names have to come out exactly as the facility feed writes them or the
+   * join finds nothing. The live page serves literal UTF-8 rather than
+   * entities — verified against the page itself — so typographic punctuation
+   * must survive untouched; numeric entities are decoded in case that changes.
+   */
+  test('passes literal UTF-8 punctuation through unchanged', () => {
+    expect(parsePremierAccessPrices(block('The Villains’ Halloween “Into the Frenzy”', '3,500')))
+      .toEqual({'The Villains’ Halloween “Into the Frenzy”': 3500});
+  });
+
+  test('decodes numeric entities in names', () => {
+    expect(parsePremierAccessPrices(block('Peter Pan&#039;s Never Land Adventure', '2,000')))
+      .toEqual({"Peter Pan's Never Land Adventure": 2000});
+  });
+
+  test('a heading with no rate is skipped', () => {
+    const html = `
+      <div class="listTextArea"><p class="heading3">Space Mountain</p></div>
+      ${block('Big Thunder Mountain', '1,500')}`;
+    expect(parsePremierAccessPrices(html)).toEqual({'Big Thunder Mountain': 1500});
+  });
+
+  test.each([
+    ['no prices at all', '<div><p>Nothing here</p></div>'],
+    ['empty input', ''],
+    ['a rate of zero', block('Free Ride', '000')],
+  ])('%s yields nothing rather than throwing', (_label, html) => {
+    expect(parsePremierAccessPrices(html)).toEqual({});
+  });
+});

--- a/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
+++ b/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
@@ -310,12 +310,20 @@ describe('buildSchedules', () => {
  * Premier Access and Priority Pass reduce to a single boolean each in the
  * anonymous feed, so the emitted queues are deliberately hollow. Pinned
  * because the shape looks like a gap and gets re-reported as one: the return
- * windows and the yen price live behind POST endpoints that want registered
- * park tickets and a `cid:ctoken` credential, so null is the honest value.
+ * windows live behind POST endpoints that want registered park tickets and a
+ * `cid:ctoken` credential, so null is the honest value for those.
+ *
+ * The price is a different matter: the API never carries one, but the rate is
+ * published on the public guide page, so it is filled in when a webBase is
+ * configured and stays null otherwise.
  */
 describe('buildLiveData — Premier Access and Priority Pass', () => {
-  const conditions = (attraction: Record<string, any>) => {
+  const conditions = (attraction: Record<string, any>, prices: Record<string, number> = {}) => {
     const probe = new TokyoDisneyResort({});
+    vi.spyOn(probe, 'getPremierAccessPrices').mockResolvedValue(prices);
+    vi.spyOn(probe, 'getFacilities').mockResolvedValue([
+      {facilityCode: 'A1', name: 'Splash Mountain'} as any,
+    ]);
     vi.spyOn(probe, 'getConditions').mockResolvedValue({
       attractions: [{
         facilityCode: 'A1',
@@ -385,5 +393,40 @@ describe('buildLiveData — Premier Access and Priority Pass', () => {
 
     expect(row.queue!.PAID_RETURN_TIME!.state).toBe('AVAILABLE');
     expect(row.queue!.RETURN_TIME!.state).toBe('FINISHED');
+  });
+
+  /**
+   * The published rate reaches the wire when it is available. Whole yen: JPY
+   * has no minor unit, so the amount is the price rather than a hundredth of
+   * it, unlike the cents every other park reports.
+   */
+  test('a published rate is emitted as the price', async () => {
+    const [row] = await conditions(
+      {premierAccessStatus: 'SELLING'},
+      {'Splash Mountain': 1500},
+    ).getLiveData();
+
+    expect(row.queue!.PAID_RETURN_TIME!.price).toEqual({currency: 'JPY', amount: 1500});
+  });
+
+  test('an experience with no published rate stays null, not zero', async () => {
+    const [row] = await conditions(
+      {premierAccessStatus: 'SELLING'},
+      {'Some Other Ride': 1500},
+    ).getLiveData();
+
+    expect(row.queue!.PAID_RETURN_TIME!.price).toEqual({currency: 'JPY', amount: null});
+  });
+
+  /**
+   * The guide page is a bonus on top of the queue state. If it cannot be read
+   * the queue must still be published — losing a price is acceptable, losing
+   * the live data is not.
+   */
+  test('the queue survives the price lookup failing', async () => {
+    const probe = conditions({premierAccessStatus: 'SELLING'});
+    vi.spyOn(probe, 'getPremierAccessPrices').mockRejectedValue(new Error('site unavailable'));
+
+    await expect(probe.getLiveData()).resolves.toBeDefined();
   });
 });

--- a/src/parks/tdr/tokyodisneyresort.ts
+++ b/src/parks/tdr/tokyodisneyresort.ts
@@ -5,6 +5,7 @@ import {inject} from '../../injector.js';
 import config from '../../config.js';
 import {destinationController} from '../../destinationRegistry.js';
 import {Entity, LiveData, EntitySchedule} from '@themeparks/typelib';
+import {decodeHtmlEntities, stripHtmlTags} from '../../htmlUtils.js';
 import {constructDateTime} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 
@@ -13,6 +14,44 @@ import {TagBuilder} from '../../tags/index.js';
 // ============================================================================
 
 /** Static park data for the two parks in Tokyo Disney Resort */
+/**
+ * Pull the published Premier Access prices out of the guide page.
+ *
+ * The page lists each experience followed by "N,NNN yen per access". Both
+ * parks are in the document at once — one is behind a tab, so it is present in
+ * the markup even when it is not on screen.
+ *
+ * Names are taken verbatim and matched exactly against the facility feed,
+ * which writes them identically. Exact rather than fuzzy on purpose: Tokyo
+ * Disneyland has both "Peter Pan's Flight" and "Peter Pan's Never Land
+ * Adventure", and only the second is sold with Premier Access.
+ */
+export function parsePremierAccessPrices(html: string): Record<string, number> {
+  const prices: Record<string, number> = {};
+  // Each experience is a heading followed by its rate in the same block:
+  //   <p class="heading3">Splash Mountain</p> … <strong>1,500 yen per access</strong>
+  //
+  // Split on the headings and look for a rate inside each one's own span,
+  // rather than flattening the page and scanning it. Stripping the tags leaves
+  // no separator between elements, so a flat scan reads the tail of whatever
+  // precedes a price as part of the name; and pairing a heading with the next
+  // rate anywhere after it lets an experience with no rate borrow the next
+  // one's.
+  const headings = [...html.matchAll(/class="heading3"[^>]*>([\s\S]*?)<\/p>/g)];
+  for (let i = 0; i < headings.length; i++) {
+    const h = headings[i];
+    const from = (h.index ?? 0) + h[0].length;
+    const to = i + 1 < headings.length ? (headings[i + 1].index ?? html.length) : html.length;
+    const rate = /([\d,]{3,7})\s*yen per access/.exec(html.slice(from, to));
+    if (!rate) continue;
+    const name = decodeHtmlEntities(stripHtmlTags(h[1])).replace(/\s+/g, ' ').trim();
+    const yen = Number(rate[1].replace(/,/g, ''));
+    if (!name || !Number.isFinite(yen) || yen <= 0) continue;
+    prices[name] = yen;
+  }
+  return prices;
+}
+
 const PARK_DATA: Record<string, {name: string; lat: number; lng: number}> = {
   tdl: {name: 'Tokyo Disneyland', lat: 35.632896, lng: 139.880394},
   tds: {name: 'Tokyo DisneySea', lat: 35.626411, lng: 139.885099},
@@ -157,6 +196,17 @@ export class TokyoDisneyResort extends Destination {
 
   @config
   fallbackDeviceId: string = '';
+
+  /**
+   * Base of the public guide site, e.g. https://www.tokyodisneyresort.jp.
+   *
+   * Unset by default, which makes the Premier Access price lookup a no-op and
+   * leaves the published price at `amount: null` — the same output as before
+   * this existed. Set it only in a build whose HTTP client the site accepts
+   * (see fetchPremierAccessPrices).
+   */
+  @config
+  webBase: string = '';
 
   @config
   timezone: string = 'Asia/Tokyo';
@@ -374,6 +424,72 @@ export class TokyoDisneyResort extends Destination {
   /**
    * Get calendar data (cached 12h)
    */
+  /**
+   * URL of the Disney Premier Access guide page, which carries the published
+   * price for each experience.
+   *
+   * Public because a caller that has to fetch this with its own HTTP client
+   * (see fetchPremierAccessPrices) must build the same URL rather than keeping
+   * a second copy of the path that can drift from this one.
+   */
+  premierAccessPricesUrl(): string {
+    return `${this.webBase}/en/tdr/guide/app_service/disneypremieraccess.html`;
+  }
+
+  /**
+   * The Premier Access guide page.
+   *
+   * The site refuses parksapi's own HTTP client, so this does not complete
+   * unless the caller supplies a client it accepts (see
+   * premierAccessPricesUrl). With no webBase configured the price lookup is
+   * skipped entirely, so the default build never calls this.
+   */
+  @http({cacheSeconds: 60 * 60 * 12, retries: 1})
+  async fetchPremierAccessPrices(): Promise<HTTPObj> {
+    return {
+      method: 'GET',
+      url: this.premierAccessPricesUrl(),
+      options: {json: false},
+      tags: ['website'],
+    } as HTTPObj;
+  }
+
+  /**
+   * Published Premier Access price per experience, keyed on the experience
+   * name exactly as the guide page writes it.
+   *
+   * The API never carries a price. Every endpoint that does sits behind a
+   * purchase flow requiring park tickets registered to a signed-in account, so
+   * an anonymous client cannot read one — but the rate itself is published, a
+   * flat per-experience figure on the public guide page. That is what this
+   * reads.
+   *
+   * Two things it is not. It is a rate card rather than a live quote, so it
+   * says what an experience costs, not what any particular guest was charged.
+   * And some entries carry an eligibility period ("From September 16 through
+   * October 31"); those are not parsed, because the live feed already tells us
+   * whether Premier Access is being sold for an experience today and that is
+   * the better signal.
+   *
+   * Amounts are whole yen. JPY has no minor unit, so the value is the price
+   * itself rather than a hundredth of it.
+   *
+   * Returns an empty map on any failure. A price is a bonus on top of the
+   * queue state, and never a reason to lose it.
+   */
+  @cache({ttlSeconds: 60 * 60 * 12})
+  async getPremierAccessPrices(): Promise<Record<string, number>> {
+    if (!this.webBase) return {};
+    try {
+      const resp = await this.fetchPremierAccessPrices();
+      const html = await resp.text();
+      return parsePremierAccessPrices(html);
+    } catch (err) {
+      console.warn(`[${this.constructor.name}] Premier Access prices unavailable:`, err);
+      return {};
+    }
+  }
+
   @cache({ttlSeconds: 60 * 60 * 12})
   async getCalendar(): Promise<TDRCalendarEntry[]> {
     const resp = await this.fetchCalendar();
@@ -527,6 +643,14 @@ export class TokyoDisneyResort extends Destination {
 
   protected async buildLiveData(): Promise<LiveData[]> {
     const conditions = await this.getConditions();
+    // Prices are a bonus on top of the queue state. Both of these degrade to
+    // empty rather than throwing, so a guide-page change cannot cost us the
+    // live data.
+    const prices = await this.getPremierAccessPrices().catch(() => ({} as Record<string, number>));
+    const nameByCode = new Map<string, string>(
+      (await this.getFacilities().catch(() => []))
+        .map((f) => [String(f.facilityCode), f.name] as const),
+    );
     const liveData: LiveData[] = [];
 
     if (!conditions?.attractions) {
@@ -561,31 +685,29 @@ export class TokyoDisneyResort extends Destination {
 
       // Premier Access (paid return time).
       //
-      // The nulls are a hard limit, not a TODO. `/rest/v7/facilities/
-      // conditions` carries `premierAccessStatus` as SELLING /
-      // NOT_SELLING_NOW and nothing else — no window, no price. The app gets
-      // both from POST endpoints (`/rest/v2/premier-access/available-time/
-      // offer` returns `availableHours[]` and `offer.amount`,
-      // `/rest/v2/priority-pass/offers` returns `startAt`/`endAt`), but every
-      // one of those request bodies requires `encryptTicketNoList` — real
-      // park tickets registered to a signed-in account — and the services
-      // sit behind a `cid:ctoken` credential this client does not hold.
-      // Probed anonymously: `error.invalidAuth` 401 on the GET variants,
-      // 400/415 on the POSTs. The price is a per-purchase quote for a
-      // specific ticket set in any case, not a published per-attraction rate.
+      // The return WINDOW is genuinely unavailable. /rest/v7/facilities/
+      // conditions carries premierAccessStatus and nothing else; the endpoints
+      // that hold a window all require park tickets registered to a signed-in
+      // account, so an anonymous client cannot read one. Those nulls are a
+      // hard limit, not a TODO.
       //
-      // The emitted price is `{currency: 'JPY', amount: null}` — paid, rate
-      // unknown. `amount: 0` would mean genuinely free, which this is not.
-      // Before typelib 1.2.0 the type required a non-null amount and this
-      // published `0` with a `formatted: 'Unknown'` marker, which read as
-      // free to anyone looking at `amount` alone.
+      // The PRICE is not. It is published as a flat per-experience rate on the
+      // public guide page, and getPremierAccessPrices() reads it when a
+      // webBase is configured. Absent that it stays null, which means "paid,
+      // rate unknown" — never 0, which would say the queue is free.
+      //
+      // An earlier version of this comment claimed the price was a
+      // per-purchase quote and therefore unobtainable. That was wrong: the API
+      // not carrying a value is not the same as the value being unpublished.
       if (attr.premierAccessStatus) {
+        const facilityName = nameByCode.get(String(attr.facilityCode));
+        const yen = facilityName ? prices[facilityName] : undefined;
         ld.queue!.PAID_RETURN_TIME = this.buildPaidReturnTimeQueue(
           attr.premierAccessStatus === 'SELLING' ? 'AVAILABLE' : 'FINISHED',
           null,
           null,
           'JPY',
-          null,
+          yen ?? null,
         );
       }
 


### PR DESCRIPTION
Tokyo publishes a flat per-experience rate for Disney Premier Access on its public guide page. We were emitting `null` for all of them.

## The mistake this corrects

The code comment and my notes said the price sat behind the purchase flow and could not be read. Half of that is true — the return **window** genuinely is gated, since every endpoint carrying one needs park tickets registered to a signed-in account. But I generalised from *"the API does not carry a price"* to *"the price is unobtainable"*, and never looked at the guide page, despite having used that same site to verify the schedule data in #528.

## What it reads

25 rates across both parks — 1,000 yen for Haunted Mansion up to 3,500 for the Halloween show. Verified by running the shipped algorithm against the live page, not a fixture:

```
parsed from the real page:                        25 / 25
names resolving to a facilityCode:                23 / 25
attractions currently selling Premier Access:     14, of which priced: 14
```

The two unresolved names are seasonal shows whose eligibility period has not started (`Sep 16–Oct 31`, `from Sep 30`), so they are absent from the facility feed anyway. That is also why eligibility periods are **not** parsed — the live feed already says whether an experience is selling today, which is the better signal.

Matching is **exact, not fuzzy**, on purpose: Tokyo Disneyland runs both `Peter Pan's Flight` and `Peter Pan's Never Land Adventure`, and only the second is sold this way.

**Amounts are whole yen.** JPY has no minor unit, so the value is the price itself rather than a hundredth of it as everywhere else.

## Off by default

`webBase` is unset by default, making the lookup a no-op and leaving the price at `null` — byte-identical to current output. The site refuses parksapi's own HTTP client, so a build that wants prices supplies one the site accepts and sets `webBase`; `premierAccessPricesUrl()` is public so that caller builds the same URL rather than keeping a copy that drifts. Same arrangement Movieland already uses for its calendar.

The lookup is a bonus on top of the queue and never a reason to lose it — it returns an empty map on failure **and** the call site catches, so neither a changed page nor a failing cache can cost us the live data.

## Two bugs the tests caught

**The first parser flattened the HTML.** `stripHtmlTags` removes tags with no separator, so the page collapses into one run and the name capture absorbed ~80 characters of preceding text — `"View moreHaunted Mansion"`. Rewritten to split on headings and find a rate within each heading's own span.

**Mocking the price lookup to reject killed the live data**, because the `try/catch` is inside the method and the mock bypassed it. Hardened at the call site, matching how `getFacilities` is already handled there.

## Test plan

- [x] `npx vitest run` — 103 files, 2194 tests, green
- [x] `npx tsc --noEmit` — clean
- [x] Parser run against the live page: 25/25
- [x] Join verified against live facility feed: 14/14 currently-selling attractions priced
- [ ] Review