### PR TITLE
fix(tdr): stop an unconfigured run caching away the Premier Access price

### DIFF
--- a/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
+++ b/src/parks/tdr/__tests__/tokyodisneyresort.test.ts
@@ -1,5 +1,6 @@
 import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest';
 import {mapAttractionStatus, TokyoDisneyResort} from '../tokyodisneyresort.js';
+import {CacheLib} from '../../../cache.js';
 
 const NOON_JST_UTC = '2026-06-17T03:00:00.000Z'; // 12:00 JST = parks open
 
@@ -428,5 +429,96 @@ describe('buildLiveData — Premier Access and Priority Pass', () => {
     vi.spyOn(probe, 'getPremierAccessPrices').mockRejectedValue(new Error('site unavailable'));
 
     await expect(probe.getLiveData()).resolves.toBeDefined();
+  });
+});
+
+/**
+ * The price lookup caches, and what it caches has to be worth keeping.
+ *
+ * Two failure modes this guards, both of which cost a real day of prices on
+ * 2026-09-02. An unconfigured build must not write an empty map under the key
+ * a configured build reads, and a fetch that came back empty must not sit
+ * there for half a day.
+ */
+describe('getPremierAccessPrices caching', () => {
+  const priced = (webBase: string, html: string) => {
+    const probe = new TokyoDisneyResort({});
+    (probe as any).webBase = webBase;
+    const fetchSpy = vi.spyOn(probe, 'fetchPremierAccessPrices')
+      .mockResolvedValue({text: async () => html} as any);
+    return {probe, fetchSpy};
+  };
+
+  const page = `
+    <div class="listTextArea">
+      <p class="heading3">Splash Mountain</p>
+      <strong>1,500 yen per access</strong>
+    </div>`;
+
+  beforeEach(() => {
+    CacheLib.clearByClassName('TokyoDisneyResort');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    CacheLib.clearByClassName('TokyoDisneyResort');
+  });
+
+  test('with no webBase it returns empty without fetching', async () => {
+    const {probe, fetchSpy} = priced('', page);
+
+    expect(await probe.getPremierAccessPrices()).toEqual({});
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The regression. The guard used to sit inside the cached method, so the
+   * empty map an unconfigured process returned was stored under the key every
+   * later call reads — and configuring webBase afterwards changed nothing
+   * until the twelve hour TTL ran out.
+   */
+  test('an unconfigured call does not poison a later configured one', async () => {
+    const {probe: unconfigured} = priced('', page);
+    expect(await unconfigured.getPremierAccessPrices()).toEqual({});
+
+    const {probe, fetchSpy} = priced('https://example.test', page);
+
+    expect(await probe.getPremierAccessPrices()).toEqual({'Splash Mountain': 1500});
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  test('a rate card is held for half a day', async () => {
+    vi.useFakeTimers();
+    const {probe, fetchSpy} = priced('https://example.test', page);
+
+    await probe.getPremierAccessPrices();
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    expect(await probe.getPremierAccessPrices()).toEqual({'Splash Mountain': 1500});
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * An empty page means the fetch failed or the markup moved. Either way it is
+   * a state a fix should clear in minutes, not one that outlives the deploy.
+   */
+  test('an empty result is retried within minutes', async () => {
+    vi.useFakeTimers();
+    const {probe, fetchSpy} = priced('https://example.test', '<html>nothing</html>');
+
+    expect(await probe.getPremierAccessPrices()).toEqual({});
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    await probe.getPremierAccessPrices();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('a throwing fetch yields empty rather than losing the live data', async () => {
+    const probe = new TokyoDisneyResort({});
+    (probe as any).webBase = 'https://example.test';
+    vi.spyOn(probe, 'fetchPremierAccessPrices').mockRejectedValue(new Error('handshake'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(await probe.getPremierAccessPrices()).toEqual({});
   });
 });

--- a/src/parks/tdr/tokyodisneyresort.ts
+++ b/src/parks/tdr/tokyodisneyresort.ts
@@ -476,10 +476,33 @@ export class TokyoDisneyResort extends Destination {
    *
    * Returns an empty map on any failure. A price is a bonus on top of the
    * queue state, and never a reason to lose it.
+   *
+   * The webBase guard sits here, outside the cache, on purpose. Inside the
+   * cached method it would write an empty map under the same key a configured
+   * run reads, so a build that starts unconfigured and gets its webBase later
+   * keeps serving that empty map until the TTL runs out. That happened once,
+   * on 2026-09-02: the price shipped, the config landed an hour behind it, and
+   * every Premier Access queue published a null price for the rest of the day
+   * with nothing in the logs to say why.
    */
-  @cache({ttlSeconds: 60 * 60 * 12})
   async getPremierAccessPrices(): Promise<Record<string, number>> {
     if (!this.webBase) return {};
+    return this.loadPremierAccessPrices();
+  }
+
+  /**
+   * Fetch and parse the guide page.
+   *
+   * Split from getPremierAccessPrices so only a configured lookup is ever
+   * cached, and given a TTL that depends on what came back: half a day for a
+   * real rate card, five minutes for an empty one. An empty result means the
+   * fetch failed or the page changed shape, and neither deserves to outlive a
+   * fix by twelve hours. The success path is what the long TTL is for — the
+   * rate card changes a few times a year.
+   */
+  @cache({callback: (prices: Record<string, number> | undefined) =>
+    prices && Object.keys(prices).length > 0 ? 60 * 60 * 12 : 60 * 5})
+  async loadPremierAccessPrices(): Promise<Record<string, number>> {
     try {
       const resp = await this.fetchPremierAccessPrices();
       const html = await resp.text();


### PR DESCRIPTION
## What broke

The `webBase` guard sat inside the cached lookup:

```ts
@cache({ttlSeconds: 60 * 60 * 12})
async getPremierAccessPrices() {
  if (!this.webBase) return {};   // <- cached under the same key as a real result
  ...
}
```

A process running without `webBase` writes that empty map under the key
every later call reads. Configuring `webBase` afterwards changes nothing
until the twelve hour TTL runs out, and because a missing price is silent
by design (a price must never cost us the queue state), there is nothing
in the logs to say why every Premier Access queue is publishing a null
price.

This is not hypothetical — it cost a full day of Tokyo prices on
2026-09-02, with the fetch itself working perfectly the whole time.

## The fix

- Guard moves outside the cache, so only a configured lookup is stored.
- The fetch moves into `loadPremierAccessPrices()`, whose TTL depends on
  the result: 12 hours for a real rate card, 5 minutes for an empty one.
  An empty result means the fetch failed or the page changed shape, and
  neither deserves to outlive the fix by half a day. The rate card itself
  changes a few times a year, so the long TTL still applies where it earns
  its keep.

The rename also makes the poisoned key unreachable, so an affected
deployment self-heals on the next release rather than needing its cache
touched.

## Tests

Three added, each verified by reverting the specific change it covers:

| Test | Reverted | Result |
|---|---|---|
| an unconfigured call does not poison a later configured one | guard back inside the cached method | fails |
| an empty result is retried within minutes | fixed 12h TTL | fails |
| a rate card is held for half a day | fixed 5m TTL | fails |

Plus coverage for the no-`webBase` short circuit not fetching at all, and
a throwing fetch still yielding an empty map rather than losing live data.

Full suite: 103 files, 2199 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)