### PR TITLE
fix(universal): harden the ticketed-event show gate's config and cache

### DIFF
--- a/src/parks/universal/__tests__/expressNow.test.ts
+++ b/src/parks/universal/__tests__/expressNow.test.ts
@@ -6,8 +6,9 @@
  * format reports every numeric field as a string — drift here would
  * silently produce NaN / wrong-currency-amount, so pinning is worth it.
  */
-import {describe, test, expect} from 'vitest';
-import {parseExpressNowResponse} from '../universal.js';
+import {describe, test, expect, beforeEach} from 'vitest';
+import {parseExpressNowResponse, UniversalOrlando} from '../universal.js';
+import {CacheLib} from '../../../cache.js';
 
 const SAMPLE_PAYLOAD = {
   predictions: [{
@@ -109,5 +110,47 @@ describe('parseExpressNowResponse', () => {
     });
     expect(out['uor.ride.x'].offer_id).toBe('early');
     expect(out['uor.ride.x'].product_price).toBe(15);
+  });
+});
+
+describe('getExpressNowOffers cache discipline', () => {
+  beforeEach(async () => {
+    await CacheLib.clearByClassName('UniversalOrlando');
+  });
+
+  test('an unconfigured instance does not cache {} over a configured one', async () => {
+    // The "not configured" guard used to sit inside @cache, so a single
+    // unconfigured construction wrote {} under the key a configured instance
+    // reads back — blinding it for the full 600s empty-result TTL. Same
+    // defect, and the same fix, as getEventNights.
+    const unconfigured: any = new UniversalOrlando({config: {udxBase: ''}} as any);
+    let unconfiguredFetched = 0;
+    unconfigured.fetchExpressNowOffers = async () => {
+      unconfiguredFetched++;
+      return {json: async () => SAMPLE_PAYLOAD};
+    };
+    await expect(unconfigured.getExpressNowOffers()).resolves.toEqual({});
+    expect(unconfiguredFetched).toBe(0);
+
+    const configured: any = new UniversalOrlando({
+      config: {udxBase: 'https://example.invalid', parkLatitude: '28.4', parkLongitude: '-81.4'},
+    } as any);
+    configured.fetchExpressNowOffers = async () => ({json: async () => SAMPLE_PAYLOAD});
+    const offers = await configured.getExpressNowOffers();
+    expect(Object.keys(offers)).toHaveLength(1);
+  });
+
+  test('a configured instance still caches its result', async () => {
+    const configured: any = new UniversalOrlando({
+      config: {udxBase: 'https://example.invalid', parkLatitude: '28.4', parkLongitude: '-81.4'},
+    } as any);
+    let fetched = 0;
+    configured.fetchExpressNowOffers = async () => {
+      fetched++;
+      return {json: async () => SAMPLE_PAYLOAD};
+    };
+    await configured.getExpressNowOffers();
+    await configured.getExpressNowOffers();
+    expect(fetched).toBe(1);
   });
 });

--- a/src/parks/universal/__tests__/hhnSchedule.test.ts
+++ b/src/parks/universal/__tests__/hhnSchedule.test.ts
@@ -262,6 +262,19 @@ describe("isUniversalEventOperatingNow", () => {
     )).toBeNull();
   });
 
+  test("an unparseable date is unknown, never a confident closed", () => {
+    // A date we cannot read cannot be shown to be irrelevant — its window
+    // might be the one covering now. Returning false here would report every
+    // event show CLOSED on the strength of the OTHER nights parsing.
+    for (const date of ["not-a-date", "2026-09-00", "2026-13-45"]) {
+      expect(isUniversalEventOperatingNow(
+        [{...hollywoodNight[0], date}, {...hollywoodNight[0], date: "2026-11-20"}],
+        DURING,
+        "America/Los_Angeles",
+      )).toBeNull();
+    }
+  });
+
   test("a calendar with nothing usable is unknown rather than closed", () => {
     expect(isUniversalEventOperatingNow([], DURING, "America/Los_Angeles")).toBeNull();
     expect(isUniversalEventOperatingNow(
@@ -273,10 +286,18 @@ describe("isUniversalEventOperatingNow", () => {
 });
 
 describe("UniversalOrlando.buildSchedules", () => {
-  function park(): any {
-    const p: any = new UniversalOrlando();
-    p.eventCalendarURL = "https://example.invalid/calendar";
-    p.eventCalendarPlaceId = "uor.usf";
+  // Configured through constructor config, not plain property assignment:
+  // @config ranks a bare instance value BELOW env (src/config.ts), so an
+  // operator's exported UNIVERSALSTUDIOS_EVENTCALENDAR* would silently
+  // override the assignment and the test would exercise the wrong config.
+  function park(overrides: Record<string, string> = {}): any {
+    const p: any = new UniversalOrlando({
+      config: {
+        eventCalendarURL: "https://example.invalid/calendar",
+        eventCalendarPlaceId: "uor.usf",
+        ...overrides,
+      },
+    } as any);
     // Two day-park days, the second of which is also an HHN night.
     p.getVenueSchedule = async () => [
       {
@@ -356,8 +377,7 @@ describe("UniversalOrlando.buildSchedules", () => {
   });
 
   test("emits nothing extra when no event calendar is configured", async () => {
-    const p = park();
-    p.eventCalendarPlaceId = "";
+    const p = park({ eventCalendarPlaceId: "" });
     const usf = (await p.getSchedules()).find((s: any) => s.id === "uor.usf");
     expect(usf.schedule.every((e: any) => e.type === "OPERATING")).toBe(true);
   });
@@ -379,17 +399,57 @@ describe("event calendar fetch discipline", () => {
   const HOLLYWOOD_CALENDAR =
     "https://www.universalstudioshollywood.com/contentdata/ush/en/us/hhn/about/index.html";
 
-  test("Hollywood defaults to its own official calendar and host park", () => {
-    const hollywood: any = new UniversalStudios();
-    expect(hollywood.eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
-    expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
-  });
+  // Every env name that can influence either resort's calendar config. Tests
+  // that assert a DEFAULT must neutralise all of them: a dev shell or CI
+  // runner with the real operator config exported would otherwise fail the
+  // suite, and the PR that added UNIVERSALSTUDIOSHOLLYWOOD_* made that more
+  // likely, not less.
+  const CALENDAR_ENV = [
+    "UNIVERSALSTUDIOS_EVENTCALENDARURL",
+    "UNIVERSALSTUDIOS_EVENTCALENDARPLACEID",
+    "UNIVERSALORLANDO_EVENTCALENDARURL",
+    "UNIVERSALORLANDO_EVENTCALENDARPLACEID",
+    "UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARURL",
+    "UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARPLACEID",
+  ];
 
-  function withEnv(vars: Record<string, string>, fn: () => void) {
+  /**
+   * Run `fn` with exactly `vars` set and every other calendar env name
+   * cleared, then restore. `undefined` in `vars` means "explicitly absent".
+   */
+  /** Async form of withEnv: @config reads resolve lazily, so awaited work
+   *  must stay inside the cleared window. */
+  async function withEnvAsync(
+    vars: Record<string, string | undefined>,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    const names = new Set([...CALENDAR_ENV, ...Object.keys(vars)]);
     const before = Object.fromEntries(
-      Object.keys(vars).map((k) => [k, process.env[k]]),
+      [...names].map((k) => [k, process.env[k]]),
     );
-    Object.assign(process.env, vars);
+    for (const k of names) delete process.env[k];
+    for (const [k, v] of Object.entries(vars)) {
+      if (v !== undefined) process.env[k] = v;
+    }
+    try {
+      await fn();
+    } finally {
+      for (const [k, v] of Object.entries(before)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  }
+
+  function withEnv(vars: Record<string, string | undefined>, fn: () => void) {
+    const names = new Set([...CALENDAR_ENV, ...Object.keys(vars)]);
+    const before = Object.fromEntries(
+      [...names].map((k) => [k, process.env[k]]),
+    );
+    for (const k of names) delete process.env[k];
+    for (const [k, v] of Object.entries(vars)) {
+      if (v !== undefined) process.env[k] = v;
+    }
     try {
       fn();
     } finally {
@@ -418,6 +478,14 @@ describe("event calendar fetch discipline", () => {
     );
   });
 
+  test("Hollywood defaults to its own official calendar and host park", () => {
+    withEnv({}, () => {
+      const hollywood: any = new UniversalStudios();
+      expect(hollywood.eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
+      expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
+    });
+  });
+
   test("Hollywood's calendar stays reachable under its own env names", () => {
     // The escape hatch for a moved microsite. Unambiguous, so it cannot be
     // picked up by Orlando, and it keeps a URL change a config change rather
@@ -425,16 +493,39 @@ describe("event calendar fetch discipline", () => {
     withEnv(
       {
         UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARURL: "https://example.invalid/moved",
-        UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARPLACEID: "ush.ush",
+        // Deliberately NOT the "ush.ush" default: asserting the default value
+        // back would pass whether or not the override is read at all.
+        UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARPLACEID: "ush.moved",
       },
       () => {
         const hollywood: any = new UniversalStudios();
         expect(hollywood.eventCalendarURL).toBe("https://example.invalid/moved");
-        expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
+        expect(hollywood.eventCalendarPlaceId).toBe("ush.moved");
       },
     );
-    // ...and the default is back once the override is gone.
-    expect((new UniversalStudios() as any).eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
+    // ...and the defaults are back once the override is gone.
+    withEnv({}, () => {
+      const hollywood: any = new UniversalStudios();
+      expect(hollywood.eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
+      expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
+    });
+  });
+
+  test("Orlando still reads the shared legacy prefix", () => {
+    // The suite otherwise only asserts the negative (Hollywood must not see
+    // these). Delete the addConfigPrefix call and Orlando's calendar goes
+    // dark with an otherwise green suite.
+    withEnv(
+      {
+        UNIVERSALSTUDIOS_EVENTCALENDARURL: "https://example.invalid/orlando",
+        UNIVERSALSTUDIOS_EVENTCALENDARPLACEID: "uor.usf",
+      },
+      () => {
+        const orlando: any = new UniversalOrlando();
+        expect(orlando.eventCalendarURL).toBe("https://example.invalid/orlando");
+        expect(orlando.eventCalendarPlaceId).toBe("uor.usf");
+      },
+    );
   });
 
   test("an explicit constructor override still wins over both", () => {
@@ -451,15 +542,47 @@ describe("event calendar fetch discipline", () => {
     // single unconfigured construction wrote [] to the key a configured
     // instance of the same class reads back, silently ungating event shows
     // for the whole 12h TTL.
-    const unconfigured: any = new UniversalOrlando();
-    expect(unconfigured.eventCalendarURL).toBe("");
-    await expect(unconfigured.getEventNights()).resolves.toEqual([]);
+    await withEnvAsync({}, async () => {
+      const unconfigured: any = new UniversalOrlando();
+      expect(unconfigured.eventCalendarURL).toBe("");
+      await expect(unconfigured.getEventNights()).resolves.toEqual([]);
+    });
 
     const configured: any = new UniversalOrlando({ config: CONFIG } as any);
     configured.fetchEventCalendar = async () => ({
       text: async () => JSON.stringify(FIXTURE),
     });
     await expect(configured.getEventNights()).resolves.toHaveLength(51);
+  });
+
+  test("the parsed calendar is cached, not re-fetched every cycle", async () => {
+    // buildSchedules and buildLiveData both call getEventNights on every
+    // cycle. Without the cache each one re-fetches and re-parses a ~300KB
+    // document; nothing else in the suite asserts the cache exists at all.
+    const orlando: any = new UniversalOrlando({ config: CONFIG } as any);
+    let fetched = 0;
+    orlando.fetchEventCalendar = async () => {
+      fetched++;
+      return { text: async () => JSON.stringify(FIXTURE) };
+    };
+    await expect(orlando.getEventNights()).resolves.toHaveLength(51);
+    await expect(orlando.getEventNights()).resolves.toHaveLength(51);
+    expect(fetched).toBe(1);
+  });
+
+  test("fetchEventCalendar stays inside health-check coverage", async () => {
+    // The health harness skips any @http method whose Function.length is > 0
+    // unless it declares healthCheckArgs (src/harness/health.ts). Making
+    // calendarURL a REQUIRED parameter silently dropped the endpoint the whole
+    // event gate depends on out of endpoint monitoring; the default keeps
+    // length at 0. Asserted on the prototype because @http wraps the method.
+    const orlando: any = new UniversalOrlando({ config: CONFIG } as any);
+    expect(Object.getPrototypeOf(orlando).fetchEventCalendar.length).toBe(0);
+    // The argument is genuinely load-bearing rather than decorative: it
+    // reaches the request, which is what makes both cache layers URL-keyed.
+    // Asserted end to end by "repointing the calendar URL…" above, which the
+    // real method cannot cover here because @http performs the request and
+    // the test sandbox blocks the network.
   });
 
   test("repointing the calendar URL does not serve the previous site's nights", async () => {

--- a/src/parks/universal/__tests__/hhnSchedule.test.ts
+++ b/src/parks/universal/__tests__/hhnSchedule.test.ts
@@ -196,10 +196,77 @@ describe("isUniversalEventOperatingNow", () => {
     )).toBe(false);
   });
 
-  test("treats malformed event windows as unknown", () => {
+  // 2026-09-03 23:58 PDT: inside the 03rd's 19:00-01:00 window.
+  const DURING = new Date("2026-09-04T06:58:00.000Z");
+  // 2026-09-04 01:01 PDT: an hour past the same window's close.
+  const AFTER = new Date("2026-09-04T08:01:00.000Z");
+  const farFutureBadNight = {
+    date: "2026-11-01",
+    name: "Halloween Horror Nights",
+    openingTime: "bad",
+    closingTime: "01:00",
+    closesNextDay: true,
+  };
+
+  test("treats a malformed window on a night that could be running as unknown", () => {
     expect(isUniversalEventOperatingNow(
       [{...hollywoodNight[0], openingTime: "bad"}],
-      new Date("2026-09-04T06:58:00.000Z"),
+      DURING,
+      "America/Los_Angeles",
+    )).toBeNull();
+  });
+
+  test("a malformed night elsewhere in the season does not disable the gate", () => {
+    // The calendar covers a whole season — Hollywood publishes 42 nights — so
+    // one bad row in November must not leave every night until then ungated.
+    expect(isUniversalEventOperatingNow(
+      [farFutureBadNight, ...hollywoodNight],
+      DURING,
+      "America/Los_Angeles",
+    )).toBe(true);
+    // Order must not matter: a bad row before the matching one previously
+    // returned early and hid it.
+    expect(isUniversalEventOperatingNow(
+      [...hollywoodNight, farFutureBadNight],
+      DURING,
+      "America/Los_Angeles",
+    )).toBe(true);
+  });
+
+  test("a malformed night elsewhere still allows a confident closed", () => {
+    expect(isUniversalEventOperatingNow(
+      [farFutureBadNight, ...hollywoodNight],
+      AFTER,
+      "America/Los_Angeles",
+    )).toBe(false);
+  });
+
+  test("a malformed night that crossed into today is unknown", () => {
+    // A window running past midnight is keyed to the date it started, so
+    // yesterday's row is still load-bearing for the small hours of today.
+    expect(isUniversalEventOperatingNow(
+      [
+        {...hollywoodNight[0], date: "2026-09-03", closingTime: "nonsense"},
+        {...hollywoodNight[0], date: "2026-09-20"},
+      ],
+      new Date("2026-09-04T07:30:00.000Z"), // 00:30 PDT on the 4th
+      "America/Los_Angeles",
+    )).toBeNull();
+  });
+
+  test("an inverted window on a relevant night is unknown, not closed", () => {
+    expect(isUniversalEventOperatingNow(
+      [{...hollywoodNight[0], closesNextDay: false}], // 19:00 -> 01:00 same day
+      DURING,
+      "America/Los_Angeles",
+    )).toBeNull();
+  });
+
+  test("a calendar with nothing usable is unknown rather than closed", () => {
+    expect(isUniversalEventOperatingNow([], DURING, "America/Los_Angeles")).toBeNull();
+    expect(isUniversalEventOperatingNow(
+      [farFutureBadNight],
+      DURING,
       "America/Los_Angeles",
     )).toBeNull();
   });
@@ -309,12 +376,111 @@ describe("event calendar fetch discipline", () => {
     eventCalendarPlaceId: "uor.usf",
   };
 
+  const HOLLYWOOD_CALENDAR =
+    "https://www.universalstudioshollywood.com/contentdata/ush/en/us/hhn/about/index.html";
+
   test("Hollywood defaults to its own official calendar and host park", () => {
     const hollywood: any = new UniversalStudios();
-    expect(hollywood.eventCalendarURL).toBe(
-      "https://www.universalstudioshollywood.com/contentdata/ush/en/us/hhn//about/index.html",
-    );
+    expect(hollywood.eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
     expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
+  });
+
+  function withEnv(vars: Record<string, string>, fn: () => void) {
+    const before = Object.fromEntries(
+      Object.keys(vars).map((k) => [k, process.env[k]]),
+    );
+    Object.assign(process.env, vars);
+    try {
+      fn();
+    } finally {
+      for (const [k, v] of Object.entries(before)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  }
+
+  test("Orlando's shared-prefix calendar config never reaches Hollywood", () => {
+    // 'UNIVERSALSTUDIOS' is BOTH the legacy prefix both resorts register and
+    // Hollywood's own class name, and in practice it configures Orlando.
+    // Neither env lookup can be scoped to one resort, so Hollywood must not
+    // be reachable by either.
+    withEnv(
+      {
+        UNIVERSALSTUDIOS_EVENTCALENDARURL: "https://example.invalid/orlando",
+        UNIVERSALSTUDIOS_EVENTCALENDARPLACEID: "uor.usf",
+      },
+      () => {
+        const hollywood: any = new UniversalStudios();
+        expect(hollywood.eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
+        expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
+      },
+    );
+  });
+
+  test("Hollywood's calendar stays reachable under its own env names", () => {
+    // The escape hatch for a moved microsite. Unambiguous, so it cannot be
+    // picked up by Orlando, and it keeps a URL change a config change rather
+    // than a release.
+    withEnv(
+      {
+        UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARURL: "https://example.invalid/moved",
+        UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARPLACEID: "ush.ush",
+      },
+      () => {
+        const hollywood: any = new UniversalStudios();
+        expect(hollywood.eventCalendarURL).toBe("https://example.invalid/moved");
+        expect(hollywood.eventCalendarPlaceId).toBe("ush.ush");
+      },
+    );
+    // ...and the default is back once the override is gone.
+    expect((new UniversalStudios() as any).eventCalendarURL).toBe(HOLLYWOOD_CALENDAR);
+  });
+
+  test("an explicit constructor override still wins over both", () => {
+    withEnv({UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARURL: "https://example.invalid/env"}, () => {
+      const hollywood: any = new UniversalStudios({
+        config: {eventCalendarURL: "https://example.invalid/explicit"},
+      } as any);
+      expect(hollywood.eventCalendarURL).toBe("https://example.invalid/explicit");
+    });
+  });
+
+  test("an unconfigured resort does not cache an empty calendar over a configured one", async () => {
+    // The "not configured" early return used to live inside @cache, so a
+    // single unconfigured construction wrote [] to the key a configured
+    // instance of the same class reads back, silently ungating event shows
+    // for the whole 12h TTL.
+    const unconfigured: any = new UniversalOrlando();
+    expect(unconfigured.eventCalendarURL).toBe("");
+    await expect(unconfigured.getEventNights()).resolves.toEqual([]);
+
+    const configured: any = new UniversalOrlando({ config: CONFIG } as any);
+    configured.fetchEventCalendar = async () => ({
+      text: async () => JSON.stringify(FIXTURE),
+    });
+    await expect(configured.getEventNights()).resolves.toHaveLength(51);
+  });
+
+  test("repointing the calendar URL does not serve the previous site's nights", async () => {
+    // The fetch is keyed by the URL it came from, so a config change takes
+    // effect immediately rather than at the next TTL expiry.
+    const first: any = new UniversalOrlando({ config: CONFIG } as any);
+    first.fetchEventCalendar = async () => ({
+      text: async () => JSON.stringify(FIXTURE),
+    });
+    await expect(first.getEventNights()).resolves.toHaveLength(51);
+
+    const second: any = new UniversalOrlando({
+      config: { ...CONFIG, eventCalendarURL: "https://example.invalid/other" },
+    } as any);
+    let requested: string | undefined;
+    second.fetchEventCalendar = async (url: string) => {
+      requested = url;
+      return { text: async () => JSON.stringify([]) };
+    };
+    await expect(second.getEventNights()).resolves.toEqual([]);
+    expect(requested).toBe("https://example.invalid/other");
   });
 
   test("Hollywood refuses an explicitly mismatched Orlando calendar", async () => {

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -484,7 +484,10 @@ type UniversalScheduleResponse = Array<{
  * A malformed night is skipped rather than abandoning the whole calendar. The
  * calendar covers a whole season — Hollywood publishes 42 nights — and one
  * bad row in November must not disable the gate every night until then. Only
- * two things make the answer unknown, mirroring isParkOperatingNow:
+ * two things make the answer unknown, mirroring isParkOperatingNow's
+ * sawValid/sawMalformed shape (though not its relevance rule — that one
+ * compares two timezone projections of the same day and returns a plain
+ * boolean):
  *
  *  - a malformed night on a date that could still be running right now
  *    (tonight's, or last night's for a window that crosses midnight), because
@@ -494,6 +497,17 @@ type UniversalScheduleResponse = Array<{
  *
  * A calendar with usable nights, none of them covering `now`, is the ordinary
  * off-season/daytime case and answers a confident false.
+ *
+ * KNOWN GAP, deliberately not closed here. Those two valves only see rows
+ * that reached this function. parseUniversalEventCalendar already hard-
+ * validates each date and time before building a night, so for calendars it
+ * produces the malformed-row case is close to unreachable — while the failure
+ * that DOES occur upstream, a CMS block dropped for unreadable labels, never
+ * arrives as a row at all. The remaining nights then set sawUsableNight and a
+ * dropped night reads as a confident false, which is the wrong direction. The
+ * fix belongs in the parser (count dropped blocks and surface them), not in
+ * re-validating rows that were validated on the way in. Tracked separately;
+ * behaviour here is unchanged from before this gate existed.
  */
 export function isUniversalEventOperatingNow(
   nights: UniversalEventNight[],
@@ -514,8 +528,17 @@ export function isUniversalEventOperatingNow(
   let sawMalformedRelevantNight = false;
 
   for (const night of nights) {
-    const relevant = validDate.test(night.date) && relevantDates.has(night.date);
-    if (!validDate.test(night.date)
+    // A night can only be ruled out as irrelevant if its DATE is usable —
+    // "2026-13-45" clears the regex but is not a real day, and a date we
+    // cannot place in time might be the very window covering `now`. Such a
+    // night therefore counts as relevant, so it downgrades the answer to
+    // unknown instead of being quietly skipped past into a confident closed.
+    // A usable date with a broken TIME is different: we can still tell it is
+    // months away, and skipping it is the whole point of this loop.
+    const dateUsable = validDate.test(night.date)
+      && Number.isFinite(new Date(`${night.date}T12:00:00Z`).getTime());
+    const relevant = !dateUsable || relevantDates.has(night.date);
+    if (!dateUsable
         || !validTime.test(night.openingTime)
         || !validTime.test(night.closingTime)) {
       if (relevant) sawMalformedRelevantNight = true;
@@ -668,8 +691,14 @@ class Universal extends Destination {
    * Served as `text/html` but is JSON throughout, so it is read as text and
    * parsed here rather than letting the HTTP layer decide by content type.
    */
+  // `calendarURL` defaults rather than being required so that Function.length
+  // stays 0: the health harness skips any @http method with a positive
+  // paramCount and no healthCheckArgs (src/harness/health.ts), and a required
+  // parameter here would quietly drop the event calendar out of endpoint
+  // monitoring. fetchEventNights still passes the URL explicitly, so both the
+  // @http and @cache keys stay URL-derived.
   @http({cacheSeconds: 43200, retries: 1} as any)
-  async fetchEventCalendar(calendarURL: string): Promise<HTTPObj> {
+  async fetchEventCalendar(calendarURL: string = this.eventCalendarURL): Promise<HTTPObj> {
     return {
       method: 'GET',
       url: calendarURL,
@@ -881,10 +910,17 @@ class Universal extends Destination {
    * a stable "nothing for sale" — and re-polling generates a 404 log entry
    * from the http layer each time).
    */
-  @cache({callback: (offers: Record<string, ExpressNowOffer>) => Object.keys(offers).length === 0 ? 600 : 60})
   async getExpressNowOffers(): Promise<Record<string, ExpressNowOffer>> {
+    // Resolved outside the cache, for the same reason getEventNights does it:
+    // an unconfigured instance would otherwise write {} to the key a
+    // configured one reads back and blind it for the full empty-result TTL.
     if (!this.udxBase || !Number.isFinite(this.parkLatitude) || !Number.isFinite(this.parkLongitude)) return {};
+    return await this.fetchExpressNowOfferMap();
+  }
 
+  /** The cached half of getExpressNowOffers: only reached when configured. */
+  @cache({callback: (offers: Record<string, ExpressNowOffer>) => Object.keys(offers).length === 0 ? 600 : 60})
+  protected async fetchExpressNowOfferMap(): Promise<Record<string, ExpressNowOffer>> {
     let resp: HTTPObj;
     try {
       resp = await this.fetchExpressNowOffers();

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -477,10 +477,23 @@ type UniversalScheduleResponse = Array<{
 }>;
 
 /**
- * True/false while `now` is inside/outside a fully usable ticketed-event
- * calendar. `null` means the calendar contains a malformed window, so callers
- * must treat it as unknown rather than using it as proof that event shows are
- * closed.
+ * True/false while `now` is inside/outside a ticketed-event calendar. `null`
+ * means the calendar cannot answer the question, so callers must treat it as
+ * unknown rather than as proof that event shows are closed.
+ *
+ * A malformed night is skipped rather than abandoning the whole calendar. The
+ * calendar covers a whole season — Hollywood publishes 42 nights — and one
+ * bad row in November must not disable the gate every night until then. Only
+ * two things make the answer unknown, mirroring isParkOperatingNow:
+ *
+ *  - a malformed night on a date that could still be running right now
+ *    (tonight's, or last night's for a window that crosses midnight), because
+ *    the row that would have answered the question is the broken one; or
+ *  - no usable night anywhere, which is indistinguishable from a fetch that
+ *    returned a document we failed to understand.
+ *
+ * A calendar with usable nights, none of them covering `now`, is the ordinary
+ * off-season/daytime case and answers a confident false.
  */
 export function isUniversalEventOperatingNow(
   nights: UniversalEventNight[],
@@ -488,25 +501,46 @@ export function isUniversalEventOperatingNow(
   timezone: string,
 ): boolean | null {
   const nowMs = now.getTime();
+  const validDate = /^\d{4}-\d{2}-\d{2}$/;
   const validTime = /^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/;
 
+  // Nights whose window could plausibly still be open at `now`. A night is
+  // keyed to the date it starts, so an event running past midnight is still
+  // yesterday's row.
+  const today = formatDate(now, timezone);
+  const relevantDates = new Set([today, shiftDateString(today, -1)]);
+
+  let sawUsableNight = false;
+  let sawMalformedRelevantNight = false;
+
   for (const night of nights) {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(night.date)
+    const relevant = validDate.test(night.date) && relevantDates.has(night.date);
+    if (!validDate.test(night.date)
         || !validTime.test(night.openingTime)
         || !validTime.test(night.closingTime)) {
-      return null;
+      if (relevant) sawMalformedRelevantNight = true;
+      continue;
     }
+    let openingMs: number;
+    let closingMs: number;
     try {
-      const openingMs = new Date(constructDateTime(night.date, night.openingTime, timezone)).getTime();
+      openingMs = new Date(constructDateTime(night.date, night.openingTime, timezone)).getTime();
       const closingDate = night.closesNextDay ? shiftDateString(night.date, 1) : night.date;
-      const closingMs = new Date(constructDateTime(closingDate, night.closingTime, timezone)).getTime();
-      if (!Number.isFinite(openingMs) || !Number.isFinite(closingMs) || closingMs <= openingMs) return null;
-      if (nowMs >= openingMs && nowMs <= closingMs) return true;
+      closingMs = new Date(constructDateTime(closingDate, night.closingTime, timezone)).getTime();
     } catch {
-      return null;
+      if (relevant) sawMalformedRelevantNight = true;
+      continue;
     }
+    if (!Number.isFinite(openingMs) || !Number.isFinite(closingMs) || closingMs <= openingMs) {
+      if (relevant) sawMalformedRelevantNight = true;
+      continue;
+    }
+    sawUsableNight = true;
+    if (nowMs >= openingMs && nowMs <= closingMs) return true;
   }
-  return false;
+
+  if (sawMalformedRelevantNight) return null;
+  return sawUsableNight ? false : null;
 }
 
 @config
@@ -635,17 +669,26 @@ class Universal extends Destination {
    * parsed here rather than letting the HTTP layer decide by content type.
    */
   @http({cacheSeconds: 43200, retries: 1} as any)
-  async fetchEventCalendar(): Promise<HTTPObj> {
+  async fetchEventCalendar(calendarURL: string): Promise<HTTPObj> {
     return {
       method: 'GET',
-      url: this.eventCalendarURL,
+      url: calendarURL,
       options: {json: false},
       tags: ['website'],
     } as any as HTTPObj;
   }
 
-  /** Ticketed-event nights for this resort, or [] when not configured. */
-  @cache({ttlSeconds: 43200})
+  /**
+   * Ticketed-event nights for this resort, or [] when not configured.
+   *
+   * The "not configured" answers are deliberately resolved OUTSIDE the cache.
+   * Cached, they write [] to the same key a configured run reads back, so a
+   * single unconfigured start silently ungates event shows for the next 12
+   * hours; the empty result is also free to recompute. Only the fetch and
+   * parse are worth caching, and they are keyed by the URL they came from so
+   * repointing the calendar takes effect immediately instead of at the next
+   * TTL expiry.
+   */
   async getEventNights(): Promise<UniversalEventNight[]> {
     if (!this.eventCalendarURL || !this.eventCalendarPlaceId) return [];
     // UniversalOrlando and UniversalStudios share addConfigPrefix
@@ -654,7 +697,19 @@ class Universal extends Destination {
     // none of its parks — but without this Hollywood still fetches and parses
     // a 285KB Orlando document on every schedule build.
     if (!this.parkPlaceIds().includes(this.eventCalendarPlaceId)) return [];
-    const body = await (await this.fetchEventCalendar()).text();
+    return await this.fetchEventNights(this.eventCalendarURL);
+  }
+
+  /**
+   * Fetch and parse the configured event calendar.
+   *
+   * `calendarURL` is passed rather than read from `this` purely so it lands in
+   * the cache key: the same class repointed at a different microsite must not
+   * serve the previous site's nights.
+   */
+  @cache({ttlSeconds: 43200})
+  protected async fetchEventNights(calendarURL: string): Promise<UniversalEventNight[]> {
+    const body = await (await this.fetchEventCalendar(calendarURL)).text();
     return parseUniversalEventCalendar(JSON.parse(body));
   }
 
@@ -1823,11 +1878,22 @@ export class UniversalStudios extends Universal {
         timezone: 'America/Los_Angeles',
         parkLatitude: '34.1381',
         parkLongitude: '-118.3534',
-        // Hollywood shares Universal's legacy config prefix with Orlando, so
-        // constructor defaults prevent Orlando's event URL/place id leaking
-        // across resorts. Callers can still override either value explicitly.
-        eventCalendarURL: 'https://www.universalstudioshollywood.com/contentdata/ush/en/us/hhn//about/index.html',
-        eventCalendarPlaceId: 'ush.ush',
+        // Hollywood's class name IS the shared legacy prefix
+        // ('UNIVERSALSTUDIOS'), so UNIVERSALSTUDIOS_EVENTCALENDAR* — which
+        // in practice configures Orlando — would otherwise be read here and
+        // point Hollywood at Orlando's microsite and host park. Neither the
+        // class-name nor the prefix env lookup can be scoped to one of the
+        // two resorts, so the value is resolved before config exists and
+        // placed in instance config, above every env lookup.
+        //
+        // That leaves nothing for an operator to turn when the microsite
+        // path moves, hence the Hollywood-scoped names read here: they are
+        // unambiguous, cannot collide with Orlando's, and keep a moved URL
+        // a config change rather than a release.
+        eventCalendarURL: process.env.UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARURL
+          || 'https://www.universalstudioshollywood.com/contentdata/ush/en/us/hhn/about/index.html',
+        eventCalendarPlaceId: process.env.UNIVERSALSTUDIOSHOLLYWOOD_EVENTCALENDARPLACEID
+          || 'ush.ush',
         ...options?.config,
       },
     });


### PR DESCRIPTION
Follow-up to #321, on the event-calendar side of the show clock-gate. No change to the day-park gate.

## One bad night no longer disables the season

`isUniversalEventOperatingNow` returned `null` on the first malformed night and stopped iterating. The calendar covers a whole season — Hollywood publishes 42 nights — so a single bad row in November left every event show ungated until then. Worse, the answer depended on row order: a bad row *before* the matching one hid a live event.

Malformed nights are skipped now. The answer is unknown only when:

- the broken row is one that could still be running — tonight's, or last night's for a window that crosses midnight, since a night is keyed to the date it starts; or
- nothing in the calendar parses at all.

A calendar with usable nights, none covering `now`, is the ordinary off-season/daytime case and answers a confident `false`.

A night whose date cannot be placed in time counts as relevant rather than being skipped: `2026-13-45` clears the shape check but is not a real day, and skipping it let the remaining nights carry the answer to a confident CLOSED. A usable date with a broken *time* still skips — that is the point of the loop.

## The unconfigured guard is out of the cache

`getEventNights()` returned `[]` for an unconfigured resort from inside `@cache`, writing that empty result to the key a configured instance of the same class reads back — one unconfigured start silently ungated event shows for the whole 12h TTL. The empty answers are free to recompute and are resolved before the cache now.

`getExpressNowOffers` had the identical defect in the same file and gets the same fix: an unconfigured instance wrote `{}` over the key a configured one reads, blinding it for the full 600s empty-result TTL.

Only the fetch and parse stay cached, keyed by the URL they came from, so repointing the calendar takes effect immediately instead of at the next TTL expiry. No `cacheVersion` bump is needed: the new code reads different `propertyKey`s, so it can never read the old entries, and a poisoned `[]` under the old key is ignored on deploy.

## Hollywood keeps its calendar, and gains a way to change it

`UniversalStudios`'s class name is also `UNIVERSALSTUDIOS`, the legacy prefix **both** resorts register. Neither the class-name nor the prefix env lookup can be scoped to one resort, so `UNIVERSALSTUDIOS_EVENTCALENDAR*` — which in practice configures Orlando — is unreachable-by-design for Hollywood, and its defaults have to sit in constructor config to outrank it.

Verified the hard way: moving them to property defaults (below env, as the repo normally prefers) made Hollywood pick up Orlando's host park and lose all 42 of its nights against the live feed. Reverted. `addConfigPrefix` cannot help either — prefixes are checked *after* the class-name lookup — and renaming the class would change the public destination id.

That left nothing an operator could turn when the microsite path moves, so the defaults now fall back from resort-scoped env names that cannot collide with Orlando's. An explicit constructor override still wins over both.

**The default URL also loses a stray double slash** (`hhn//about` → `hhn/about`). Both forms return 200 with byte-identical 337,600-byte bodies parsing to the same 42 nights. Because `@http` keys its cache by URL, this costs one extra fetch per process on deploy and nothing else.

## Health-check coverage

Making `calendarURL` a required parameter dropped `fetchEventCalendar` out of `npm run health`: the harness skips any `@http` method whose `Function.length` is above zero unless it declares `healthCheckArgs`, so the endpoint the whole gate depends on was reported as `skipped (needs args)`. A default parameter restores it while `fetchEventNights` still passes the URL explicitly, keeping both cache layers URL-keyed. Back to 11 endpoints / 3 skipped, matching `main`.

## Known gaps, deliberately left

Both are pre-existing on `main` and unchanged here; the code comments say so rather than overclaiming.

- **Dropped CMS blocks.** The malformed-row valves only see rows that reached the gate. `parseUniversalEventCalendar` hard-validates each date and time before building a night, so for calendars it produces the malformed-row case is close to unreachable — while the failure that does occur upstream, a block dropped for unreadable labels, never arrives as a row. The surviving nights then set `sawUsableNight` and a dropped night reads as a confident CLOSED. The fix belongs in the parser (count dropped blocks and surface them).
- **DST fall-back.** `constructDateTime` resolves the repeated hour to the earlier instant, so a night closing between 01:00 and 01:59 on a fall-back date reads closed for that hour. Latent: every published night closes at 02:00.

## Verification

Live at 00:32-01:11 PDT, inside the event window — the best moment to exercise the cross-midnight relevance rule:

- Hollywood publishes 42 event nights; rows operating are the event rides plus the event show with a listed performance, everything else closed.
- Orlando returned 96 rows, all closed, outside its window.
- A/B against `main` in isolated worktrees with separate cold caches: **identical** entity IDs, live IDs, status distribution, schedule day counts and `TICKETED_EVENT` rows on both resorts. Sweeping both real calendars hourly across the whole season (2,352 points x 2 parks) produced **0 divergences in 4,704 gate evaluations**.
- Unrelated parks unaffected; nothing outside `src/parks/universal/` imports any changed symbol.

Tests: full suite 2252 passed (104 files), typecheck clean. The suite passes both clean and with the operator's real `UNIVERSALSTUDIOS_EVENTCALENDAR*` exported.

## Test plan

- [x] A malformed night elsewhere in the season does not hide a live event, in either row order
- [x] A malformed night elsewhere still allows a confident closed
- [x] A malformed night that could still be running is unknown
- [x] A malformed night that crossed into today is unknown
- [x] An unparseable or unreal date is unknown, never a confident closed
- [x] An inverted window on a relevant night is unknown, not closed
- [x] An empty or wholly unusable calendar is unknown, not closed
- [x] An unconfigured resort does not cache an empty calendar over a configured one
- [x] An unconfigured resort does not cache empty Express Now offers over a configured one
- [x] A configured resort still caches both
- [x] Repointing the URL does not serve the previous site's nights
- [x] `fetchEventCalendar` stays inside health-check coverage
- [x] Orlando's shared-prefix config never reaches Hollywood, and still reaches Orlando
- [x] Hollywood's calendar is reachable under its own env names; explicit config wins over both
- [x] Suite passes with the operator's real calendar env exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)