### PR TITLE
fix(universal): stop publishing queues and adverts as attractions

### DIFF
--- a/src/parks/universal/__tests__/expressVariant.test.ts
+++ b/src/parks/universal/__tests__/expressVariant.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Hollywood publishes the express line of each Halloween Horror Nights maze
+ * as its OWN `Ride` place — "Hellraiser - Express" alongside "Hellraiser" —
+ * rather than as a queue on the maze. Left alone those surface as duplicate
+ * attractions whose express wait is published as a STANDBY number, so the
+ * site showed "Sinners - Express 45" next to a Sinners that was really 110,
+ * and for a while the express twins were the only HHN rows the site carried
+ * at all.
+ *
+ * The variants are dropped from the entity list and their wait is folded
+ * onto the maze as PAID_STANDBY. The feed offers no link to pair on, so the
+ * pairing is a slug heuristic — these tests pin both the detection rule
+ * (which must not catch Panda Express or Hogwarts Express) and the
+ * fail-safe: an ambiguous stem discards the wait rather than publishing it
+ * against the wrong maze.
+ */
+import {describe, test, expect, vi, afterEach} from 'vitest';
+import {
+  UniversalStudios,
+  isExpressQueueVariant,
+  buildExpressVariantMap,
+  type UniversalPlace,
+} from '../universal.js';
+
+function place(
+  placeId: string,
+  name: string,
+  type = 'Ride',
+  isEvent = 'false',
+): UniversalPlace {
+  return {
+    place_id: placeId,
+    name,
+    venue_id: placeId.split('.').slice(0, 2).join('.'),
+    place_type: {type, attributes: [{name: 'is_event', value: isEvent}]},
+  } as any as UniversalPlace;
+}
+
+const HELLRAISER = place('ush.upper_lot.rides.hhn_2026_hellraiser', 'Hellraiser');
+const HELLRAISER_EXPRESS = place(
+  'ush.upper_lot.rides.hellraiser_express', 'Hellraiser - Express', 'Ride', 'true',
+);
+
+describe('isExpressQueueVariant', () => {
+  test('matches an express-queue POI', () => {
+    expect(isExpressQueueVariant(HELLRAISER_EXPRESS)).toBe(true);
+  });
+
+  test('does not match the maze itself', () => {
+    expect(isExpressQueueVariant(HELLRAISER)).toBe(false);
+  });
+
+  test('does not match places that merely contain "Express"', () => {
+    // Every real counter-example from both resorts' live feeds. Panda Express
+    // is Dining with no " - " separator; the Hogwarts rides are real
+    // attractions; the train variants are is_event=true but the suffix is the
+    // train, not Express.
+    const decoys: UniversalPlace[] = [
+      place('ush.dining.panda_express', 'Panda Express', 'Dining'),
+      place('uor.cw.dining.panda_express', 'Panda Express', 'Dining'),
+      place('uor.ioa.rides.hogwarts_express_-_hogsmeade_station', 'Hogwarts Express™ - Hogsmeade™ Station'),
+      place('uor.usf.rides.hogwarts_express_-_kings_cross_station', "Hogwarts Express™ - King's Cross Station"),
+      place('uor.usf.rides.hogwarts_express_first_train', 'Hogwarts™ Express - First Train', 'Ride', 'true'),
+      place('uor.usf.rides.hogwarts_express_last_train', 'Hogwarts™ Express - Last Train', 'Ride', 'true'),
+    ];
+    for (const decoy of decoys) {
+      expect(isExpressQueueVariant(decoy), decoy.place_id).toBe(false);
+    }
+  });
+
+  test('an express-named Dining place is never a queue variant', () => {
+    // Belt and braces: even if a dining place were somehow event-flagged and
+    // named with the separator, only Rides carry queues.
+    expect(isExpressQueueVariant(
+      place('ush.dining.something_express', 'Something - Express', 'Dining', 'true'),
+    )).toBe(false);
+  });
+});
+
+describe('buildExpressVariantMap', () => {
+  test('pairs every real Hollywood variant to its maze', () => {
+    // The eight live pairs, including the four whose express stem is only a
+    // PREFIX of the maze slug, and Kill-Ceanera, whose separators differ
+    // ("kill_ceanera" vs "killceanera_music_by_slash").
+    const places = [
+      place('ush.upper_lot.rides.hhn_2026_hellraiser', 'Hellraiser'),
+      place('ush.upper_lot.rides.hhn_2026_sinners', 'Sinners'),
+      place('ush.upper_lot.rides.hhn_2026_evil_dead_burn', 'Evil Dead Burn'),
+      place('ush.lower_lot.rides.hhn_2026_dead_deader_deadest', 'Dead Deader Deadest'),
+      place('ush.upper_lot.rides.hhn_2026_killer_klowns_outer_space', 'Killer Klowns from Outer Space'),
+      place('ush.lower_lot.rides.hhn_2026_ozzy_osbourne_prince_of_darkness', 'Ozzy Osbourne: Prince of Darkness'),
+      place('ush.lower_lot.rides.hhn_2026_stranger_things_5', 'Stranger Things 5'),
+      place('ush.lower_lot.rides.hhn_2026_killceanera_music_by_slash', 'Killceañera: Music by SLASH'),
+      place('ush.upper_lot.rides.hellraiser_express', 'Hellraiser - Express', 'Ride', 'true'),
+      place('ush.upper_lot.rides.sinners_express', 'Sinners - Express', 'Ride', 'true'),
+      place('ush.upper_lot.rides.evil_dead_burn_express', 'Evil Dead Burn - Express', 'Ride', 'true'),
+      place('ush.lower_lot.rides.dead_deader_deadest_express', 'Dead, Deader, Deadest - Express', 'Ride', 'true'),
+      // Note: upstream puts this variant in a DIFFERENT lot from its maze,
+      // so venue cannot be used to disambiguate.
+      place('ush.lower_lot.rides.killer_klowns_express', 'Killer Klowns - Express', 'Ride', 'true'),
+      place('ush.lower_lot.rides.ozzy_osbourne_express', 'Ozzy Osbourne - Express', 'Ride', 'true'),
+      place('ush.lower_lot.rides.stranger_things_express', 'Stranger Things - Express', 'Ride', 'true'),
+      place('ush.upper_lot.rides.kill_ceanera_express', 'Kill-Ceanera - Express', 'Ride', 'true'),
+    ];
+    const pairs = buildExpressVariantMap(places);
+    expect(pairs.size).toBe(8);
+    expect(pairs.get('ush.upper_lot.rides.hellraiser_express'))
+      .toBe('ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(pairs.get('ush.lower_lot.rides.killer_klowns_express'))
+      .toBe('ush.upper_lot.rides.hhn_2026_killer_klowns_outer_space');
+    expect(pairs.get('ush.upper_lot.rides.kill_ceanera_express'))
+      .toBe('ush.lower_lot.rides.hhn_2026_killceanera_music_by_slash');
+    expect(pairs.get('ush.lower_lot.rides.stranger_things_express'))
+      .toBe('ush.lower_lot.rides.hhn_2026_stranger_things_5');
+  });
+
+  test('an unmatched stem is dropped rather than guessed at', () => {
+    const pairs = buildExpressVariantMap([
+      place('ush.upper_lot.rides.hhn_2026_hellraiser', 'Hellraiser'),
+      place('ush.upper_lot.rides.orphan_express', 'Orphan - Express', 'Ride', 'true'),
+    ]);
+    expect(pairs.size).toBe(0);
+  });
+
+  test('an ambiguous stem is dropped rather than attached to either', () => {
+    // Two mazes share the stem, so the express wait cannot be assigned. A
+    // wrong-but-plausible express time is worse than no express time.
+    const pairs = buildExpressVariantMap([
+      place('ush.upper_lot.rides.hhn_2026_sinners', 'Sinners'),
+      place('ush.upper_lot.rides.hhn_2026_sinners_encore', 'Sinners Encore'),
+      place('ush.upper_lot.rides.sinners_express', 'Sinners - Express', 'Ride', 'true'),
+    ]);
+    expect(pairs.size).toBe(0);
+  });
+
+  test('a feed with no variants costs nothing', () => {
+    expect(buildExpressVariantMap([HELLRAISER]).size).toBe(0);
+    expect(buildExpressVariantMap([]).size).toBe(0);
+  });
+});
+
+describe('Universal buildLiveData — express waits fold onto the maze', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const PLACES = [HELLRAISER, HELLRAISER_EXPRESS];
+
+  function stub(waitTimes: any[]): any {
+    const park: any = new UniversalStudios();
+    park._init = async () => undefined;
+    park.getVirtualQueueStates = async () => [];
+    park.getShowList = async () => [];
+    park.getPlaces = async () => PLACES;
+    park.getWaitTimes = async () => waitTimes;
+    park.getVenueSchedule = async () => [];
+    return park;
+  }
+
+  function waitRow(id: string, status: string, wait?: number) {
+    return {
+      wait_time_attraction_id: id,
+      queues: [{queue_type: 'STANDBY', status, display_wait_time: wait}],
+    };
+  }
+
+  test('the express wait becomes PAID_STANDBY on the maze, and the twin disappears', async () => {
+    const rows = await stub([
+      waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'OPEN', 55),
+      waitRow('ush.upper_lot.rides.hellraiser_express', 'OPEN', 5),
+    ]).getLiveData();
+
+    expect(rows.find((r: any) => r.id === 'ush.upper_lot.rides.hellraiser_express')).toBeUndefined();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.queue.STANDBY.waitTime).toBe(55);
+    expect(maze.queue.PAID_STANDBY.waitTime).toBe(5);
+    expect(maze.status).toBe('OPERATING');
+  });
+
+  test('a shut express line publishes no PAID_STANDBY', async () => {
+    const rows = await stub([
+      waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'OPEN', 55),
+      waitRow('ush.upper_lot.rides.hellraiser_express', 'CLOSED'),
+    ]).getLiveData();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.queue.STANDBY.waitTime).toBe(55);
+    expect(maze.queue.PAID_STANDBY).toBeUndefined();
+  });
+
+  test("the express line's state never decides the maze's status", async () => {
+    // The maze is shut and only its express row is open. Folding must move
+    // the number only — reporting the maze OPERATING because its express
+    // queue answered would be exactly the inversion this change exists to
+    // remove.
+    const rows = await stub([
+      waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'CLOSED'),
+      waitRow('ush.upper_lot.rides.hellraiser_express', 'OPEN', 5),
+    ]).getLiveData();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.status).toBe('CLOSED');
+    expect(maze.queue?.PAID_STANDBY?.waitTime).toBe(5);
+  });
+
+  test("Universal's 995 not-available sentinel is not published as a wait", async () => {
+    const rows = await stub([
+      waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'OPEN', 55),
+      waitRow('ush.upper_lot.rides.hellraiser_express', 'OPEN', 995),
+    ]).getLiveData();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.queue.PAID_STANDBY).toBeUndefined();
+  });
+
+  test('a place-list failure costs the express waits, not the live build', async () => {
+    // getPlaces is the entity feed. buildEntityList is allowed to fail loudly;
+    // buildLiveData is not, or one bad entity fetch blanks every wait time.
+    const park = stub([waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'OPEN', 55)]);
+    park.getPlaces = async () => { throw new Error('upstream 500'); };
+    const rows = await park.getLiveData();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.queue.STANDBY.waitTime).toBe(55);
+  });
+});

--- a/src/parks/universal/__tests__/expressVariant.test.ts
+++ b/src/parks/universal/__tests__/expressVariant.test.ts
@@ -19,6 +19,8 @@ import {
   UniversalStudios,
   isExpressQueueVariant,
   buildExpressVariantMap,
+  isAccessibilityReturnTimeVariant,
+  isNonPoiNamespace,
   type UniversalPlace,
 } from '../universal.js';
 
@@ -219,5 +221,82 @@ describe('Universal buildLiveData — express waits fold onto the maze', () => {
     const rows = await park.getLiveData();
     const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
     expect(maze.queue.STANDBY.waitTime).toBe(55);
+  });
+});
+
+describe('isAccessibilityReturnTimeVariant', () => {
+  // Orlando publishes each haunted house's accessibility return service as
+  // its own Ride place. All ten houses are already live, so left alone these
+  // surface as ten duplicate rides named after a queue.
+  const HOUSE = 'uor.usf.rides.hhn_haunted_house_sinners';
+  const DAAP = `${HOUSE}_daap`;
+  const known = new Set([HOUSE, DAAP]);
+
+  function daap(placeId: string, name: string): UniversalPlace {
+    return place(placeId, name, 'Ride', 'true');
+  }
+
+  test('drops the variant when its house is in the feed', () => {
+    expect(isAccessibilityReturnTimeVariant(
+      daap(DAAP, 'Sinners Accessibility Return Time'), known,
+    )).toBe(true);
+  });
+
+  test('keeps the house itself', () => {
+    expect(isAccessibilityReturnTimeVariant(place(HOUSE, 'Sinners'), known)).toBe(false);
+  });
+
+  test('a non-breaking space in the name does not defeat the match', () => {
+    // Exactly one of the ten real names separates the suffix with U+00A0
+    // instead of a space ("MADLANDS: Caged Cannibals\u00a0Accessibility
+    // Return Time"). It is invisible in a log and in a diff, and it silently
+    // let that one variant through until the names were compared byte by
+    // byte. Every name-based match in this file normalises first.
+    expect(isAccessibilityReturnTimeVariant(
+      daap(DAAP, 'Sinners\u00a0Accessibility Return Time'), known,
+    )).toBe(true);
+  });
+
+  test('a variant with no house in the feed is kept, not silently dropped', () => {
+    // Sloppy feed data is not a duplicate. Same discipline as
+    // isEventVariantAlias, which keeps a share link pointing at a phantom id.
+    expect(isAccessibilityReturnTimeVariant(
+      daap('uor.usf.rides.hhn_haunted_house_ghost_daap', 'Ghost Accessibility Return Time'),
+      new Set(['uor.usf.rides.hhn_haunted_house_ghost_daap']),
+    )).toBe(false);
+  });
+
+  test('a _daap id without the return-time name is not assumed to be one', () => {
+    expect(isAccessibilityReturnTimeVariant(daap(DAAP, 'Sinners'), known)).toBe(false);
+  });
+});
+
+describe('isNonPoiNamespace', () => {
+  test('drops passholder marketing typed as attractions', () => {
+    // These arrive typed as real POIs: an Express Pass discount as a Ride,
+    // character meet & greets as a Show, menu blurbs as Dining.
+    const ads: UniversalPlace[] = [
+      place('uor.pad.save.30.select.universal.express.passes', 'Save 30% on Select Universal Express Passes'),
+      place('uor.pad.exclusive.menu.items.in.the.parks', 'Exclusive Menu Items in the Parks', 'Dining'),
+      place('uor.pad.exclusive.menu.items.at.citywalk', 'Exclusive Menu Items at CityWalk', 'Dining'),
+      place('uor.pan.character.meet.and.greets', 'Character Meet & Greets', 'Show'),
+      place('uor.pan.exclusive.menu.items', 'Exclusive Passholder Nights Menu Items', 'Dining'),
+    ];
+    for (const ad of ads) expect(isNonPoiNamespace(ad), ad.place_id).toBe(true);
+  });
+
+  test('keeps every real namespace, including resort-wide categories', () => {
+    // A deny-list, so the risk is over-matching. "dining" and "amenities" are
+    // real second segments that must survive.
+    const keep = [
+      'uor.usf.rides.revenge_of_the_mummy',
+      'uor.ioa.shows.darkartsathogwartscastle',
+      'uor.vb.rides.krakatau_aqua_coaster',
+      'ush.dining.panda_express',
+      'ush.upper_lot.rides.hhn_2026_sinners',
+      'uor.cw.dining.vivo_italian_kitchen',
+      'uor.amenities.first_aid',
+    ];
+    for (const id of keep) expect(isNonPoiNamespace(place(id, 'x')), id).toBe(false);
   });
 });

--- a/src/parks/universal/__tests__/hhnRetirement.test.ts
+++ b/src/parks/universal/__tests__/hhnRetirement.test.ts
@@ -44,6 +44,9 @@ function stubbedPark<T extends UniversalOrlando | UniversalStudios>(park: T, wai
   const p = park as any;
   p.getWaitTimes = async () => waitTimes;
   p.getVirtualQueueStates = async () => [];
+  // buildLiveData reads the place list to fold express-queue POIs onto their
+  // maze; no express variants in these fixtures, so an empty list is exact.
+  p.getPlaces = async () => [];
   p.getShowList = async () => [];
   p.getExpressNowOffers = async () => ({});
   return park;

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -90,6 +90,9 @@ function stubPark<T extends UniversalStudios | UniversalOrlando>(
   (park as any)._init = async () => undefined;
   (park as any).getWaitTimes = async () => [];
   (park as any).getVirtualQueueStates = async () => [];
+  // buildLiveData reads the place list to fold express-queue POIs onto their
+  // maze; no express variants in these fixtures, so an empty list is exact.
+  (park as any).getPlaces = async () => [];
   (park as any).getShowList = async () => showList;
   // venueId-aware, unlike a fixed return value: needed for UOR (4 distinct
   // legacy venue ids sharing one buildLiveData call) to prove each park

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -214,6 +214,80 @@ export function isEventVariantAlias(place: UniversalPlace, knownPlaceIds: Set<st
 }
 
 /**
+ * True for a Hollywood express-queue POI — the feed publishes the express
+ * line of an HHN maze as its OWN `Ride` place ("Hellraiser - Express"
+ * alongside "Hellraiser"), rather than as a queue on the maze.
+ *
+ * Left alone these surface as duplicate attractions whose express wait is
+ * published as a STANDBY number, so the site shows "Sinners - Express 45"
+ * next to a Sinners that is really 110. buildLiveData folds the value onto
+ * the maze as PAID_STANDBY instead (see buildExpressVariantMap).
+ *
+ * Matched on the `" - Express"` name suffix together with `is_event`, which
+ * is deliberately narrow. Both resorts carry places that must NOT match:
+ * Panda Express (Dining, and no " - " separator), Hogwarts Express and its
+ * two stations (real rides, is_event=false), and "Hogwarts™ Express - First
+ * /Last Train" (is_event=true operational variants, but the suffix is the
+ * train, not Express). Verified against the live feed for both resorts.
+ */
+export function isExpressQueueVariant(place: UniversalPlace): boolean {
+  return place.place_type?.type === 'Ride'
+    && attr(place, 'is_event') === 'true'
+    && / - Express$/.test(place.name ?? '');
+}
+
+/** Slug of a place_id with the separators and the season prefix removed. */
+function expressPairKey(placeId: string): string {
+  const leaf = placeId.split('.').pop() ?? placeId;
+  return leaf
+    .replace(/_express$/, '')
+    .replace(/^hhn_\d{4}_/, '')
+    .replace(/[^a-z0-9]/gi, '')
+    .toLowerCase();
+}
+
+/**
+ * Pair each express-queue POI to the maze it belongs to, keyed by sanitized
+ * place_id.
+ *
+ * The feed offers no link to pair on: these records carry no
+ * `social_sharing_link` (which is why isEventVariantAlias never caught them),
+ * no parent and no cross-reference, and two of the eight even sit in a
+ * different lot from their own maze — so venue cannot disambiguate either.
+ * The slug is all there is. Stripping the season prefix and the separators
+ * makes every express stem a prefix of its maze's stem
+ * ("killceanera" -> "killceanera_music_by_slash").
+ *
+ * Because that is a heuristic rather than a key, a stem matching zero or
+ * several mazes is left unpaired: the variant is still dropped from the
+ * entity list, but its wait is discarded rather than risking an express time
+ * published against the wrong maze. Wrong-but-plausible is worse than absent.
+ */
+export function buildExpressVariantMap(places: UniversalPlace[]): Map<string, string> {
+  const variants = places.filter(isExpressQueueVariant);
+  if (variants.length === 0) return new Map();
+
+  const candidates = places
+    .filter((place) => place.place_type?.type === 'Ride' && !isExpressQueueVariant(place))
+    .map((place) => ({id: sanitizeId(place.place_id), key: expressPairKey(place.place_id)}));
+
+  const pairs = new Map<string, string>();
+  for (const variant of variants) {
+    const stem = expressPairKey(variant.place_id);
+    if (!stem) continue;
+    const hits = candidates.filter((c) => c.key.startsWith(stem));
+    if (hits.length !== 1) {
+      console.warn(
+        `Universal: express variant ${variant.place_id} matched ${hits.length} attractions, dropping its wait`,
+      );
+      continue;
+    }
+    pairs.set(sanitizeId(variant.place_id), hits[0].id);
+  }
+  return pairs;
+}
+
+/**
  * Map a UniversalPlace to a wiki Entity. Returns null for place types we
  * don't expose (Park is emitted separately by buildEntityList; Shop /
  * Amenity / Hotel / etc. are out of scope for this migration).
@@ -1334,6 +1408,9 @@ class Universal extends Destination {
     const knownPlaceIds = new Set(places.map((p) => sanitizeId(p.place_id)));
     for (const place of places) {
       if (isEventVariantAlias(place, knownPlaceIds)) continue;
+      // An express queue is a queue on its maze, not an attraction of its
+      // own — buildLiveData reattaches its wait as PAID_STANDBY.
+      if (isExpressQueueVariant(place)) continue;
       const entity = placeToEntity(place, destinationId, this.timezone);
       if (entity) out.push(entity);
     }
@@ -1364,6 +1441,25 @@ class Universal extends Destination {
     const waitTimes = await this.getWaitTimes();
     const vQueueStates = await this.getVirtualQueueStates();
     const showList = await this.getShowList();
+    // Express-queue POIs -> the maze each one belongs to. Their wait is the
+    // express line's, so it is folded onto the maze as PAID_STANDBY rather
+    // than published as a second attraction's STANDBY (see
+    // buildExpressVariantMap). Empty for resorts without the pattern, which
+    // today is everyone except Hollywood.
+    //
+    // Isolated: getPlaces is the entity feed, and a failure there must not
+    // take the whole live build down with it — buildEntityList is the place
+    // that is allowed to fail loudly. Degrading to an empty map costs the
+    // express waits for one cycle and nothing else. In practice it is warm,
+    // since buildEntityList fetches the same @cache'd list every cycle.
+    let expressVariants = new Map<string, string>();
+    try {
+      expressVariants = buildExpressVariantMap(await this.getPlaces());
+    } catch (err: any) {
+      console.warn(
+        `Universal: place list unavailable, express waits will be absent this cycle: ${err?.message ?? err}`,
+      );
+    }
 
     // Process virtual queues
     for (const vQueue of vQueueStates) {
@@ -1422,6 +1518,28 @@ class Universal extends Destination {
         }
 
         if (!rideId) continue;
+
+        // An express-queue POI carries the maze's express wait in its own
+        // STANDBY queue. Fold it onto the maze and emit no row of its own —
+        // the entity no longer exists. Only the number moves: the maze's
+        // status comes from the maze's own queues, never from the state of
+        // its express line.
+        const expressTarget = expressVariants.get(rideId);
+        if (expressTarget) {
+          if (queue.queue_type !== 'STANDBY') continue;
+          if (queue.status !== 'OPEN' && queue.status !== 'RIDE_NOW') continue;
+          const raw = queue.display_wait_time;
+          // 995 is Universal's "not available" sentinel; RIDE_NOW with no
+          // reading is a walk-on, matching the STANDBY branch below.
+          const waitTime = queue.status === 'RIDE_NOW' && raw === undefined ? 0 : raw;
+          if (waitTime === undefined || waitTime === 995) continue;
+          const target = getOrCreateLiveData(expressTarget);
+          if (!target.queue) {
+            target.queue = {};
+          }
+          target.queue.PAID_STANDBY = {waitTime};
+          continue;
+        }
 
         if (!attractionLiveData) {
           attractionLiveData = getOrCreateLiveData(rideId);

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -214,6 +214,76 @@ export function isEventVariantAlias(place: UniversalPlace, knownPlaceIds: Set<st
 }
 
 /**
+ * A place name with every Unicode space folded to a plain one and the ends
+ * trimmed, for matching against.
+ *
+ * The feed mixes them: "MADLANDS: Caged Cannibals\u00a0Accessibility Return
+ * Time" carries a non-breaking space before "Accessibility" where its nine
+ * siblings use an ordinary one. It is invisible in logs and in a diff, and it
+ * silently defeated the suffix test for exactly one of the ten — the kind of
+ * near-miss that looks like a feed change rather than a bug. Normalise before
+ * matching, never match raw.
+ */
+function normalizeName(name: string | undefined): string {
+  return (name ?? '').replace(/\s/g, ' ').trim();
+}
+
+/**
+ * Place-id namespaces that are not points of interest at all.
+ *
+ * Real POIs are keyed under a park or venue (`uor.usf.…`, `ush.upper_lot.…`)
+ * or a resort-wide category (`ush.dining.…`). These two namespaces instead
+ * carry annual-passholder marketing copy, typed as though it were an
+ * attraction — "Save 30% on Select Universal Express Passes" arrives as a
+ * `Ride`, "Character Meet & Greets" as a Show, and the several "Exclusive
+ * Menu Items" entries as Dining. Publishing them puts adverts on the wiki as
+ * rides, so they are dropped by namespace rather than by guessing from copy.
+ *
+ * A deny-list, not a heuristic: everything else is kept. Hollywood uses
+ * neither namespace, and no other second segment overlaps them.
+ */
+const NON_POI_NAMESPACES = new Set(['pad', 'pan']);
+
+/** True for a passholder-marketing entry masquerading as a POI. */
+export function isNonPoiNamespace(place: UniversalPlace): boolean {
+  return NON_POI_NAMESPACES.has(place.place_id?.split('.')[1] ?? '');
+}
+
+/**
+ * True for an Orlando accessibility-return-time POI — the feed publishes each
+ * Halloween Horror Nights house's accessibility return service as its OWN
+ * `Ride` place ("Sinners Accessibility Return Time" beside "Sinners"), the
+ * same shape as Hollywood's express variants.
+ *
+ * All ten houses are already published, so left alone these would surface as
+ * ten duplicate rides named after a queue.
+ *
+ * Unlike the express variants the pairing here is EXACT — dropping the
+ * `_daap` suffix yields the canonical place_id — so the sibling is required
+ * to exist before the variant is discarded. A `_daap` place with no canonical
+ * is sloppy feed data rather than a duplicate, and is kept, matching how
+ * isEventVariantAlias treats a share link pointing at a phantom id.
+ *
+ * The return-time VALUE is deliberately not folded onto the house. Unlike the
+ * express wait, nothing observable carries it: across the wait-time feed, the
+ * virtual-queue feed and the place record itself, these ids produce no live
+ * data outside event hours, so the shape and meaning of the reading are
+ * unconfirmed. Attaching a number whose semantics are a guess is how a wrong
+ * return time reaches a guest who needs an accurate one. Publish the houses
+ * correctly first; fold the value once it can be observed during an event.
+ */
+export function isAccessibilityReturnTimeVariant(
+  place: UniversalPlace,
+  knownPlaceIds: Set<string>,
+): boolean {
+  if (place.place_type?.type !== 'Ride') return false;
+  if (attr(place, 'is_event') !== 'true') return false;
+  if (!/_daap$/.test(place.place_id ?? '')) return false;
+  if (!/ Accessibility Return Time$/.test(normalizeName(place.name))) return false;
+  return knownPlaceIds.has(sanitizeId(place.place_id.replace(/_daap$/, '')));
+}
+
+/**
  * True for a Hollywood express-queue POI — the feed publishes the express
  * line of an HHN maze as its OWN `Ride` place ("Hellraiser - Express"
  * alongside "Hellraiser"), rather than as a queue on the maze.
@@ -233,7 +303,7 @@ export function isEventVariantAlias(place: UniversalPlace, knownPlaceIds: Set<st
 export function isExpressQueueVariant(place: UniversalPlace): boolean {
   return place.place_type?.type === 'Ride'
     && attr(place, 'is_event') === 'true'
-    && / - Express$/.test(place.name ?? '');
+    && / - Express$/.test(normalizeName(place.name));
 }
 
 /** Slug of a place_id with the separators and the season prefix removed. */
@@ -1411,6 +1481,11 @@ class Universal extends Destination {
       // An express queue is a queue on its maze, not an attraction of its
       // own — buildLiveData reattaches its wait as PAID_STANDBY.
       if (isExpressQueueVariant(place)) continue;
+      // An accessibility return time is a service on its house, not an
+      // attraction. Dropped only when the house itself is in the feed.
+      if (isAccessibilityReturnTimeVariant(place, knownPlaceIds)) continue;
+      // Passholder marketing copy typed as a ride/show/dining place.
+      if (isNonPoiNamespace(place)) continue;
       const entity = placeToEntity(place, destinationId, this.timezone);
       if (entity) out.push(entity);
     }


### PR DESCRIPTION
Three feed shapes that publish something other than an attraction as one. All three were found together: the first was making Hollywood's HHN page unreadable, the other two were sitting behind it in the moderation queue.

## 1. Hollywood express queues (`_express`)

The feed publishes the express line of each HHN maze as its **own `Ride` place**:

```
ush.upper_lot.rides.hellraiser_express   "Hellraiser - Express"   is_event=true
ush.upper_lot.rides.hhn_2026_hellraiser  "Hellraiser"             is_event=false
```

Each maze surfaced twice, and the express wait was published as **STANDBY** — the shorter, paid queue wearing the standby label. "Sinners - Express 45" sat next to a Sinners that was really 110. These are real readings, not placeholders: across an evening they move independently (45 / 15 / 10 / 5).

The eight variants are dropped and their wait folded onto the maze as `PAID_STANDBY`:

```
ush.upper_lot.rides.hhn_2026_sinners
  STANDBY       25 min
  PAID_STANDBY   5 min
```

**Only the number moves.** A maze's status still comes from its own queues, so an open express line can never report a shut maze as operating. A closed express line publishes no paid queue rather than a stale one, and Universal's `995` not-available sentinel is filtered.

**Pairing is a heuristic, and fails safe.** These records carry no `social_sharing_link` (which is why `isEventVariantAlias` never caught them), no parent, no cross-reference, and two of the eight sit in a *different lot* from their own maze, so venue cannot disambiguate. Stripping the season prefix and separators makes every express stem a prefix of its maze's — including `kill_ceanera` → `killceanera_music_by_slash`, where the separators themselves differ. Because that is a heuristic and not a key, a stem matching zero or several attractions **drops the wait**: an express time published against the wrong maze is worse than none.

## 2. Orlando accessibility return times (`_daap`)

The same shape, for a more sensitive service:

```
uor.usf.rides.hhn_haunted_house_hellraiser       "Hellraiser"                           <- already live
uor.usf.rides.hhn_haunted_house_hellraiser_daap  "Hellraiser Accessibility Return Time"  <- pending
```

All ten houses are already published, so these would have landed as ten duplicate rides named after a queue.

Here the pairing **is** exact — dropping `_daap` yields the canonical place_id — so the house is required to exist before the variant is discarded. A `_daap` place with no canonical is kept as sloppy feed data rather than assumed to be a duplicate, matching how `isEventVariantAlias` treats a share link pointing at a phantom id.

**The return-time value is deliberately not folded onto the house.** Unlike the express wait, nothing observable carries it — outside event hours these ids produce nothing in the wait-time feed, the virtual-queue feed, or the place record — so the shape and meaning of the reading are unconfirmed. A wrong return time reaches a guest who needs an accurate one. The houses get published correctly now; the value waits until it can be observed during an event.

## 3. Passholder marketing typed as POIs

An Express Pass discount arriving as a `Ride`, character meet & greets as a `Show`, menu blurbs as `Dining`. They live under two place-id namespaces that hold nothing else, so they are dropped by namespace rather than by reading the copy — a deny-list, so real namespaces like `dining` and `amenities` are unaffected.

## The invisible character

One of the ten return-time names separates its suffix with a **non-breaking space** where the other nine use an ordinary one:

```
"MADLANDS: Caged Cannibals Accessibility Return Time"
```

It is invisible in a log and in a diff, and it silently let exactly one variant through — the kind of near-miss that reads as a feed change rather than a bug. Every name-based match here now folds Unicode spaces before testing, the express detector included, and a test pins it.

## Detection is deliberately narrow

Every real counter-example from both live feeds is pinned as a test decoy:

| Place | Why it must not match |
|---|---|
| `Panda Express` (x2) | Dining, and no `" - "` separator |
| `Hogwarts Express™ - Hogsmeade™ Station` | a real ride |
| `Hogwarts Express™ - King's Cross Station` | a real ride |
| `Hogwarts™ Express - First/Last Train` | `is_event=true`, but the suffix is the train |
| `ush.dining.*`, `uor.amenities.*` | real namespaces, not marketing ones |

## Isolation

`buildLiveData` reads the place list to build the express pairing map, so that fetch is wrapped: `buildEntityList` is the path allowed to fail loudly, but a bad entity fetch must never blank every wait time. A failure costs the express waits for one cycle and logs.

## Effect

| | before | after |
|---|---|---|
| Hollywood entities | 104 | 96 |
| Hollywood live rows | 68 | 60 |
| Orlando entities | 346 | 334 |
| Orlando live rows | 96 | 96 |
| Orlando HHN houses | 10 | 10 |

Nothing dropped from Orlando ever carried live data, so no row counts move there. The retired entities become DELETE requests through the normal moderation flow.

## Verification

- Full suite **2272 passed**, typecheck clean.
- 20 tests in the new file; 17 fail on `main` and pass here (the 3 that pass on both are decoy-exclusion locks worth keeping).
- Both resorts run live: Hollywood mazes carry both queues, Orlando keeps all ten houses and loses all ten twins, and no `_express`, `_daap` or marketing entity remains in either.

## Test plan

- [x] Express/return-time/marketing places are detected; the real attraction is not
- [x] Panda Express, both Hogwarts stations, and the first/last train variants are never matched
- [x] Real namespaces (`dining`, `amenities`, park codes) are never matched
- [x] All eight express pairs resolve uniquely, including the cross-lot and differing-separator cases
- [x] An unmatched or ambiguous express stem drops the wait instead of guessing
- [x] A `_daap` place with no house in the feed is kept, not silently dropped
- [x] A non-breaking space in a name does not defeat the match
- [x] The express wait becomes PAID_STANDBY on the maze and the twin disappears
- [x] A shut express line publishes no PAID_STANDBY; the 995 sentinel is not a wait
- [x] The express line's state never decides the maze's status
- [x] A place-list failure costs the express waits, not the live build

🤖 Generated with [Claude Code](https://claude.com/claude-code)