### PR TITLE
fix(universal): stop trusting a single fragile signal about what exists

### DIFF
--- a/src/parks/universal/__tests__/expressVariant.test.ts
+++ b/src/parks/universal/__tests__/expressVariant.test.ts
@@ -21,6 +21,9 @@ import {
   buildExpressVariantMap,
   isAccessibilityReturnTimeVariant,
   isNonPoiNamespace,
+  isNamedEventVariant,
+  canonicalPlaceNames,
+  isEventVariantAlias,
   type UniversalPlace,
 } from '../universal.js';
 
@@ -298,5 +301,80 @@ describe('isNonPoiNamespace', () => {
       'uor.amenities.first_aid',
     ];
     for (const id of keep) expect(isNonPoiNamespace(place(id, 'x')), id).toBe(false);
+  });
+});
+
+describe('isNamedEventVariant', () => {
+  // "Studio Tour - Mandarin"/"- Spanish" are language variants of the Studio
+  // Tour whose share link points at WATERWORLD, an unrelated show. Today that
+  // still resolves to "some other real place" so isEventVariantAlias drops
+  // them — but by luck, not by knowing what they are. The name rule is the
+  // second, independent signal.
+  const TOUR = place('ush.upper_lot.rides.studio_tour', 'Studio Tour');
+  const MANDARIN = place('ush.upper_lot.shows.studio_tour_mandarin', 'Studio Tour - Mandarin', 'Show', 'true');
+  const SPANISH = place('ush.upper_lot.shows.studio_tour_spanish', 'Studio Tour - Spanish', 'Show', 'true');
+
+  test('matches a language variant of a canonical that exists', () => {
+    const names = canonicalPlaceNames([TOUR, MANDARIN, SPANISH]);
+    expect(isNamedEventVariant(MANDARIN, names)).toBe(true);
+    expect(isNamedEventVariant(SPANISH, names)).toBe(true);
+  });
+
+  test('THE POINT: still dropped when the share link stops rescuing them', () => {
+    // The share-link rule keeps a record whose link is missing or points at an
+    // id the feed does not carry (the Epic Universe meets case). Without a
+    // second signal, the day the feed nulls that bad WaterWorld link is the
+    // day the wiki gains two phantom SHOW entities named after a Ride it
+    // already publishes.
+    const orphanLink = {
+      ...MANDARIN,
+      place_type: {type: 'Show', attributes: [
+        {name: 'is_event', value: 'true'},
+        {name: 'social_sharing_link', value: 'https://x/?id=ush.does.not.exist'},
+      ]},
+    } as any;
+    const known = new Set(['ush.upper_lot.rides.studio_tour', 'ush.upper_lot.shows.studio_tour_mandarin']);
+    expect(isEventVariantAlias(orphanLink, known)).toBe(false);   // link rule lets it through
+    expect(isNamedEventVariant(orphanLink, canonicalPlaceNames([TOUR]))).toBe(true); // name rule catches it
+  });
+
+  test('does not match when no canonical of that name exists', () => {
+    expect(isNamedEventVariant(MANDARIN, canonicalPlaceNames([MANDARIN, SPANISH]))).toBe(false);
+  });
+
+  test('two variants cannot validate each other', () => {
+    // Only non-event places count as canonical, so a variant can never make
+    // another variant look legitimate.
+    const names = canonicalPlaceNames([MANDARIN, SPANISH]);
+    expect(names.has('Studio Tour - Mandarin')).toBe(false);
+  });
+
+  test('a non-event place is never a variant', () => {
+    expect(isNamedEventVariant(place('ush.x.y.z', 'Studio Tour - Something'), canonicalPlaceNames([TOUR]))).toBe(false);
+  });
+
+  test('a non-breaking space in either name does not defeat the match', () => {
+    const nbspTour = place('ush.upper_lot.rides.studio_tour', 'Studio\u00a0Tour');
+    const nbspVariant = place('ush.a.b.c', 'Studio Tour\u00a0- Mandarin', 'Show', 'true');
+    expect(isNamedEventVariant(nbspVariant, canonicalPlaceNames([nbspTour]))).toBe(true);
+  });
+
+  test('every " - " boundary is tried', () => {
+    const base = place('ush.a.b.c', 'A - B');
+    const variant = place('ush.a.b.d', 'A - B - C', 'Ride', 'true');
+    expect(isNamedEventVariant(variant, canonicalPlaceNames([base]))).toBe(true);
+  });
+
+  test('real attractions with a dash in their name are never matched', () => {
+    // The counter-examples from both live feeds. None has a canonical named
+    // by the part before the dash, which is what keeps them safe.
+    const feed = [
+      place('uor.ioa.rides.hogwarts_express_-_hogsmeade_station', 'Hogwarts Express™ - Hogsmeade™ Station'),
+      place('uor.usf.rides.hogwarts_express_-_kings_cross_station', "Hogwarts Express™ - King's Cross Station"),
+      place('uor.usf.rides.hogwarts_express_first_train', 'Hogwarts™ Express - First Train', 'Ride', 'true'),
+      place('uor.usf.rides.hogwarts_express_last_train', 'Hogwarts™ Express - Last Train', 'Ride', 'true'),
+    ];
+    const names = canonicalPlaceNames(feed);
+    for (const p of feed) expect(isNamedEventVariant(p, names), p.place_id).toBe(false);
   });
 });

--- a/src/parks/universal/__tests__/expressVariant.test.ts
+++ b/src/parks/universal/__tests__/expressVariant.test.ts
@@ -207,6 +207,56 @@ describe('Universal buildLiveData — express waits fold onto the maze', () => {
     expect(maze.queue?.PAID_STANDBY?.waitTime).toBe(5);
   });
 
+  test('a maze carrying its own EXPRESS queue does not null the folded wait', async () => {
+    // Both the fold and the pre-existing `case EXPRESS` branch write
+    // PAID_STANDBY, and which runs last is decided by the wait feed's order
+    // (sorted by place_id — an express twin has no hhn_YYYY_ prefix so it
+    // sorts BEFORE its maze for any maze named before "h"). Every Orlando
+    // house already carries EXPRESS/CLOSED/0, so this is one feed change away
+    // from silently nulling half of Hollywood's folded waits.
+    const park = stub([]);
+    park.getWaitTimes = async () => [
+      // express twin FIRST, as the real feed orders it
+      waitRow('ush.upper_lot.rides.hellraiser_express', 'OPEN', 5),
+      {
+        wait_time_attraction_id: 'ush.upper_lot.rides.hhn_2026_hellraiser',
+        queues: [
+          {queue_type: 'STANDBY', status: 'OPEN', display_wait_time: 55},
+          {queue_type: 'EXPRESS', status: 'CLOSED', display_wait_time: 0},
+        ],
+      },
+    ];
+    const rows = await park.getLiveData();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.queue.STANDBY.waitTime).toBe(55);
+    expect(maze.queue.PAID_STANDBY.waitTime).toBe(5);   // the real reading, not null
+  });
+
+  test('a null express reading is absent, never published as PAID_STANDBY null', async () => {
+    // PAID_STANDBY:null is what the EXPRESS branch means by "sold, wait
+    // unknown". A null reading folded through would be indistinguishable.
+    const rows = await stub([
+      waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'OPEN', 55),
+      {
+        wait_time_attraction_id: 'ush.upper_lot.rides.hellraiser_express',
+        queues: [{queue_type: 'STANDBY', status: 'OPEN', display_wait_time: null}],
+      },
+    ]).getLiveData();
+    const maze = rows.find((r: any) => r.id === 'ush.upper_lot.rides.hhn_2026_hellraiser');
+    expect(maze.queue.PAID_STANDBY).toBeUndefined();
+  });
+
+  test('an express stem cannot pair to an unrelated daytime ride', async () => {
+    // Express lines exist only for the ticketed event, so the maze is always
+    // HHN-namespaced. Without that anchor, "Jurassic World - Express" matched
+    // the real daytime coaster and published an event wait against it.
+    const pairs = buildExpressVariantMap([
+      place('ush.lower_lot.rides.jurassic_world_the_ride', 'Jurassic World - The Ride'),
+      place('ush.lower_lot.rides.jurassic_world_express', 'Jurassic World - Express', 'Ride', 'true'),
+    ]);
+    expect(pairs.size).toBe(0);
+  });
+
   test("Universal's 995 not-available sentinel is not published as a wait", async () => {
     const rows = await stub([
       waitRow('ush.upper_lot.rides.hhn_2026_hellraiser', 'OPEN', 55),

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -109,6 +109,92 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe('Universal buildLiveData — an ordinary show performing inside the event', () => {
+  // Super Nintendo World stays open through Halloween Horror Nights. On
+  // 2026-09-05 "Meet Mario and Luigi", "Meet Toad" and "Meet Princess Peach"
+  // carry ENABLED performances at 19:00-21:30 PT while Hollywood's day park
+  // closed at 18:00 — and they are categorised `general`, not `hhn`. Gated on
+  // day-park hours alone they publish CLOSED beside a showtime happening right
+  // now: the exact contradiction this gate was built to remove, from the other
+  // side of the clock.
+  const NIGHT = [{
+    date: '2026-09-05', name: 'Halloween Horror Nights',
+    openingTime: '19:00', closingTime: '02:00', closesNextDay: true,
+  }];
+  // BOTH days: isParkOperatingNow fails open unless it finds a row for the
+  // current day in either the park's own timezone or Eastern, so a fixture
+  // with only the 5th would leave the gate ungated after midnight and prove
+  // nothing.
+  const DAY_SHUT = [
+    {
+      Date: '2026-09-05', VenueStatus: '',
+      OpenTimeString: '2026-09-05T08:00:00-07:00',
+      CloseTimeString: '2026-09-05T18:00:00-07:00',
+    },
+    {
+      Date: '2026-09-06', VenueStatus: '',
+      OpenTimeString: '2026-09-06T08:00:00-07:00',
+      CloseTimeString: '2026-09-06T18:00:00-07:00',
+    },
+  ];
+
+  // The event calendar is only consulted when an hhn-category show is in the
+  // list, so the ordinary show cannot be ungated by the event without one
+  // present. That is the real shape: The Purge is in tonight's feed.
+  const HHN_SHOW = {
+    show_id: 'ush.upper_lot.events.hhn_2026_show_the_purge',
+    resort_area_code: 'USH', venue_id: 'ush.upper_lot', category: 'hhn',
+    name: 'The Purge: Dangerous Waters', status: 'CLOSED', show_externally: true,
+    show_times: [{show_time_id: 'p', status: 'ENABLED', start_time: '2026-09-06T04:00:00Z'}],
+  } as any;
+
+  function meet(slotsUtc: string[]): UniversalShowListEntry {
+    return {
+      show_id: 'ush.lower_lot.shows.meet_mario_and_luigi',
+      resort_area_code: 'USH', venue_id: 'ush.lower_lot',
+      name: 'Meet Mario and Luigi', status: 'CLOSED', show_externally: true,
+      show_times: slotsUtc.map((t, i) => ({show_time_id: String(i), status: 'ENABLED', start_time: t})),
+    } as any;
+  }
+
+  async function statusAt(iso: string, slots: string[]) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(iso));
+    const park: any = stubPark(new UniversalStudios(), [meet(slots), HHN_SHOW], {'13825': DAY_SHUT});
+    park.getEventNights = async () => NIGHT;
+    park.getPlaces = async () => [];
+    const rows = await park.getLiveData();
+    vi.useRealTimers();
+    return rows.find((r: any) => r.id === 'ush.lower_lot.shows.meet_mario_and_luigi');
+  }
+
+  test('performs during the event: OPERATING, not CLOSED-with-a-showtime', async () => {
+    // 20:10 PT, day park shut two hours, event running, 21:00 PT slot ahead.
+    const row = await statusAt('2026-09-06T03:10:00Z', ['2026-09-06T04:00:00Z']);
+    expect(row.status).toBe('OPERATING');
+    expect(row.showtimes).toHaveLength(1);
+  });
+
+  test('its slots done for the night: CLOSED even though the event runs on', async () => {
+    // 23:00 PT, event open until 02:00, but this show has finished.
+    const row = await statusAt('2026-09-06T06:00:00Z', ['2026-09-06T04:00:00Z']);
+    expect(row.status).toBe('CLOSED');
+  });
+
+  test('ONLY a next-day slot: still CLOSED, however long the event runs', async () => {
+    // 00:30 PT mid-event with tomorrow's 09:00 PT slot ahead. A bare "the
+    // event is on" check would report OPERATING here and undo the overnight
+    // staleness fix this gate exists for.
+    const row = await statusAt('2026-09-06T07:30:00Z', ['2026-09-06T16:00:00Z']);
+    expect(row.status).toBe('CLOSED');
+  });
+
+  test('after the event closes: CLOSED', async () => {
+    const row = await statusAt('2026-09-06T10:30:00Z', ['2026-09-06T16:00:00Z']);
+    expect(row.status).toBe('CLOSED');
+  });
+});
+
 describe('Universal buildLiveData — show status clock-gated against park hours', () => {
   test('overnight, park shut: show reads CLOSED even though a slot is still hours away', async () => {
     // 03:00 PDT, 2026-08-18 — before EarlyEntryString (08:00 PDT). This is

--- a/src/parks/universal/__tests__/unpublishableRows.test.ts
+++ b/src/parks/universal/__tests__/unpublishableRows.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Universal's live feeds and its place feed disagree about what exists.
+ * show-list and the wait-time feed emit readings for things buildEntityList
+ * has no entity for, in four ways seen live at Hollywood:
+ *
+ *   - ids the PLACE feed has never heard of (`ush.mms.minion.dance.party`;
+ *     `ush.upper.lot.shows.meet_james.henry` is dotted where every other id is
+ *     underscored, an older id shape leaking in)
+ *   - event-variant aliases dropped as duplicates (Studio Tour Last Tram, and
+ *     the Mandarin/Spanish variants whose share links point at WaterWorld)
+ *   - children of a venue with no wiki representation (CityWalk)
+ *   - a place whose type placeToEntity does not map (an `Events`-typed ride)
+ *
+ * Those rows cannot be resolved by any consumer, so they are built, pushed and
+ * then dropped downstream. buildLiveData now filters them.
+ *
+ * The filter is derived from buildEntityList rather than by re-testing the
+ * predicates, so the risk moves to its INPUT: getPlaces coerces a malformed
+ * 200 to [] and caches it for 12h, which would otherwise blank every wait time
+ * for half a day. Both bail-outs are pinned here.
+ */
+import {describe, test, expect, afterEach, vi} from 'vitest';
+import {UniversalStudios} from '../universal.js';
+
+const PARK = {
+  place_id: 'ush.ush',
+  name: 'Universal Studios Hollywood',
+  venue_id: 'ush.ush',
+  place_type: {type: 'Park', attributes: []},
+  geometry: {locations: [{location_type: 'map', lat_lng: {lat: 34.1, lng: -118.3}}]},
+};
+const RIDE = {
+  place_id: 'ush.upper_lot.rides.the_simpsons_ride',
+  name: 'The Simpsons Ride',
+  venue_id: 'ush.upper_lot',
+  place_type: {type: 'Ride', attributes: []},
+};
+const CITYWALK_SHOW = {
+  place_id: 'ush.cw.entertainment.street_performers',
+  name: 'Street Performers',
+  venue_id: 'ush.cw',
+  place_type: {type: 'Show', attributes: []},
+};
+
+function stub(places: any[], waits: any[], shows: any[] = []): any {
+  const park: any = new UniversalStudios();
+  park._init = async () => undefined;
+  park.getPlaces = async () => places;
+  park.getWaitTimes = async () => waits;
+  park.getShowList = async () => shows;
+  park.getVirtualQueueStates = async () => [];
+  park.getVenueSchedule = async () => [];
+  park.getExpressNowOffers = async () => ({});
+  // Retirement force-closes ids that vanish from the feed; it runs after
+  // buildLiveData and is a separate concern, so keep it out of these numbers.
+  park.retireMissingLiveEntities = false;
+  return park;
+}
+
+function waitRow(id: string, wait: number) {
+  return {
+    wait_time_attraction_id: id,
+    queues: [{queue_type: 'STANDBY', status: 'OPEN', display_wait_time: wait}],
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('Universal buildLiveData — rows for entities that are never published', () => {
+  test('a row whose id the place feed has never heard of is dropped', async () => {
+    const rows = await stub(
+      [PARK, RIDE],
+      [waitRow('ush.upper_lot.rides.the_simpsons_ride', 20), waitRow('ush.mms.minion.dance.party', 5)],
+    ).getLiveData();
+    expect(rows.map((r: any) => r.id)).toEqual(['ush.upper_lot.rides.the_simpsons_ride']);
+  });
+
+  test("a row for a dropped venue's child is dropped", async () => {
+    // CityWalk is not a park on the wiki, so its children are never emitted.
+    const park = stub([PARK, RIDE, CITYWALK_SHOW], [waitRow('ush.upper_lot.rides.the_simpsons_ride', 20)], [{
+      show_id: 'ush.cw.entertainment.street_performers',
+      venue_id: 'ush.cw',
+      name: 'Street Performers',
+      status: 'OPEN',
+      show_externally: true,
+    }]);
+    const rows = await park.getLiveData();
+    expect(rows.some((r: any) => r.id === 'ush.cw.entertainment.street_performers')).toBe(false);
+    expect(rows.some((r: any) => r.id === 'ush.upper_lot.rides.the_simpsons_ride')).toBe(true);
+  });
+
+  test('rows for entities that ARE published survive untouched', async () => {
+    const rows = await stub([PARK, RIDE], [waitRow('ush.upper_lot.rides.the_simpsons_ride', 20)]).getLiveData();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].queue.STANDBY.waitTime).toBe(20);
+    expect(rows[0].status).toBe('OPERATING');
+  });
+
+  test('an unusable entity list publishes every row rather than blanking the feed', async () => {
+    // getPlaces coerces a malformed 200 to [] and caches it for 12h. Filtering
+    // on that would silently drop every wait time for half a day — far worse
+    // than the unresolvable rows this filter exists to remove.
+    const park = stub([], [
+      waitRow('ush.upper_lot.rides.the_simpsons_ride', 20),
+      waitRow('ush.upper_lot.rides.revenge_of_the_mummy', 35),
+    ]);
+    const rows = await park.getLiveData();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r: any) => r.queue.STANDBY.waitTime).sort()).toEqual([20, 35]);
+  });
+
+  test('a failing entity list publishes every row rather than throwing', async () => {
+    // buildEntityList is allowed to fail loudly; buildLiveData is not.
+    const park = stub([PARK, RIDE], [waitRow('ush.upper_lot.rides.the_simpsons_ride', 20)]);
+    park.buildEntityList = async () => { throw new Error('places 500'); };
+    const rows = await park.getLiveData();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].queue.STANDBY.waitTime).toBe(20);
+  });
+
+  test('a minority of unpublishable rows is still filtered', async () => {
+    // The guard must not be so blunt it disables the fix: one bad row among
+    // several good ones is the real-world shape (10 of 57 at Hollywood).
+    const places = [PARK, RIDE,
+      {...RIDE, place_id: 'ush.upper_lot.rides.revenge_of_the_mummy', name: 'Revenge of the Mummy'},
+      {...RIDE, place_id: 'ush.upper_lot.rides.transformers', name: 'Transformers'}];
+    const rows = await stub(places, [
+      waitRow('ush.upper_lot.rides.the_simpsons_ride', 20),
+      waitRow('ush.upper_lot.rides.revenge_of_the_mummy', 35),
+      waitRow('ush.upper_lot.rides.transformers', 15),
+      waitRow('ush.mms.minion.dance.party', 5),
+    ]).getLiveData();
+    expect(rows).toHaveLength(3);
+    expect(rows.some((r: any) => r.id === 'ush.mms.minion.dance.party')).toBe(false);
+  });
+});

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -337,8 +337,19 @@ export function buildExpressVariantMap(places: UniversalPlace[]): Map<string, st
   const variants = places.filter(isExpressQueueVariant);
   if (variants.length === 0) return new Map();
 
+  // Candidates are HHN rides only. Express queue lines exist solely for the
+  // ticketed event, so the maze is always HHN-namespaced — while the express
+  // twin's OWN id carries no such marker
+  // (`ush.lower_lot.rides.killer_klowns_express`). Matching an open prefix
+  // against every ride in the resort let a stem collide with an unrelated
+  // daytime attraction: a "Jurassic World - Express" line would have resolved
+  // to `jurassic_world_the_ride` and published an event wait on the daytime
+  // coaster. The `hits.length !== 1` guard cannot see that, because a single
+  // WRONG hit is still a single hit.
   const candidates = places
-    .filter((place) => place.place_type?.type === 'Ride' && !isExpressQueueVariant(place))
+    .filter((place) => place.place_type?.type === 'Ride'
+      && !isExpressQueueVariant(place)
+      && /(^|[._])hhn/i.test(place.place_id))
     .map((place) => ({id: sanitizeId(place.place_id), key: expressPairKey(place.place_id)}));
 
   const pairs = new Map<string, string>();
@@ -394,11 +405,33 @@ export function isNamedEventVariant(
   return false;
 }
 
-/** Names of places that are not themselves event variants. */
-export function canonicalPlaceNames(places: UniversalPlace[]): Set<string> {
+/**
+ * Names a variant may legitimately defer to.
+ *
+ * Two exclusions, and the second is the load-bearing one:
+ *
+ *  - a place that is itself event-flagged, so two variants cannot validate
+ *    each other; and
+ *  - a place that does not become an entity at all. LANDS are the danger:
+ *    `ush.lower_lot.jurassic_world` is a Land named exactly "Jurassic World",
+ *    so without this the day the feed sets is_event on
+ *    "Jurassic World - The Ride" — and it already sets that flag on permanent
+ *    rides, `bowser.jr.challenge` among them — a headline coaster would be
+ *    read as a variant of its own land and silently deleted, wait time and
+ *    all. A variant defers to a real POI, never to the ground it stands on.
+ *
+ * Keeping only entity-producing places also keeps the rule honest about what
+ * it is for: collapsing a duplicate onto the thing actually published.
+ */
+export function canonicalPlaceNames(
+  places: UniversalPlace[],
+  destinationId = '',
+  timezone = 'UTC',
+): Set<string> {
   return new Set(
     places
       .filter((p) => attr(p, 'is_event') !== 'true')
+      .filter((p) => placeToEntity(p, destinationId, timezone) !== null)
       .map((p) => normalizeName(p.name))
       .filter(Boolean),
   );
@@ -705,6 +738,25 @@ export function isUniversalEventOperatingNow(
   now: Date,
   timezone: string,
 ): boolean | null {
+  const window = universalEventWindowAt(nights, now, timezone);
+  return window === undefined ? null : window !== null;
+}
+
+/**
+ * The ticketed-event window covering `now`, or `null` when none does, or
+ * `undefined` when the calendar cannot answer (the `null` case of
+ * isUniversalEventOperatingNow — see that function for the rules, which this
+ * implements).
+ *
+ * The window END is what callers need beyond a yes/no: an ordinary show
+ * performing INSIDE the event is operating, while one whose only remaining
+ * slot is tomorrow morning is not, and both look identical to a boolean.
+ */
+export function universalEventWindowAt(
+  nights: UniversalEventNight[],
+  now: Date,
+  timezone: string,
+): {opensAt: number; closesAt: number} | null | undefined {
   const nowMs = now.getTime();
   const validDate = /^\d{4}-\d{2}-\d{2}$/;
   const validTime = /^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/;
@@ -750,11 +802,11 @@ export function isUniversalEventOperatingNow(
       continue;
     }
     sawUsableNight = true;
-    if (nowMs >= openingMs && nowMs <= closingMs) return true;
+    if (nowMs >= openingMs && nowMs <= closingMs) return {opensAt: openingMs, closesAt: closingMs};
   }
 
-  if (sawMalformedRelevantNight) return null;
-  return sawUsableNight ? false : null;
+  if (sawMalformedRelevantNight) return undefined;
+  return sawUsableNight ? null : undefined;
 }
 
 @config
@@ -1523,7 +1575,7 @@ class Universal extends Destination {
     // a share link to a non-existent id (sloppy feed data) is NOT treated as a
     // variant.
     const knownPlaceIds = new Set(places.map((p) => sanitizeId(p.place_id)));
-    const canonicalNames = canonicalPlaceNames(places);
+    const canonicalNames = canonicalPlaceNames(places, destinationId, this.timezone);
     for (const place of places) {
       if (isEventVariantAlias(place, knownPlaceIds)) continue;
       // Second, independent signal for the same class: the share link is
@@ -1655,7 +1707,11 @@ class Universal extends Destination {
         if (expressTarget) {
           if (queue.queue_type !== 'STANDBY') continue;
           if (queue.status !== 'OPEN' && queue.status !== 'RIDE_NOW') continue;
-          const raw = queue.display_wait_time;
+          // `?? undefined` because a null reading must be treated as absent,
+          // not published as PAID_STANDBY:null — that is byte-identical to the
+          // EXPRESS branch's "sold, wait unknown" and no consumer could tell
+          // the two provenances apart.
+          const raw = queue.display_wait_time ?? undefined;
           // 995 is Universal's "not available" sentinel; RIDE_NOW with no
           // reading is a walk-on, matching the STANDBY branch below.
           const waitTime = queue.status === 'RIDE_NOW' && raw === undefined ? 0 : raw;
@@ -1730,7 +1786,19 @@ class Universal extends Destination {
               if (!attractionLiveData.queue) {
                 attractionLiveData.queue = {};
               }
-              attractionLiveData.queue.PAID_STANDBY = {waitTime: null};
+              // Never clobber a real number with null. The express-variant
+              // fold writes an actual reading into this same slot, and which
+              // of the two ran last is decided by the wait feed's ordering —
+              // it is sorted by place_id, and an express twin's id carries no
+              // `hhn_YYYY_` prefix, so it sorts BEFORE its maze for any maze
+              // whose name starts before "h". That silently nulled four of
+              // Hollywood's eight folded waits the moment a maze row carried
+              // an EXPRESS queue, which every Orlando house already does.
+              // A known wait always beats "available, wait unknown".
+              const existing: any = attractionLiveData.queue.PAID_STANDBY;
+              if (existing?.waitTime === undefined || existing.waitTime === null) {
+                attractionLiveData.queue.PAID_STANDBY = {waitTime: null};
+              }
             }
             break;
         }
@@ -1778,15 +1846,16 @@ class Universal extends Destination {
       (show) => show.category?.toLowerCase() === 'hhn',
     );
     let eventOperating: boolean | null = null;
+    // When the event is running, the instant it closes. An ordinary show is
+    // only ungated by the event if it actually performs before then.
+    let eventWindowClosesAt: number | null = null;
     if (hasTicketedEventShows) {
       try {
         const eventNights = await this.getEventNights();
         if (eventNights.length > 0) {
-          eventOperating = isUniversalEventOperatingNow(
-            eventNights,
-            now,
-            this.timezone,
-          );
+          const window = universalEventWindowAt(eventNights, now, this.timezone);
+          eventWindowClosesAt = window?.closesAt ?? null;
+          eventOperating = window === undefined ? null : window !== null;
           if (eventOperating === null) {
             console.warn('Universal: event calendar had a malformed window; leaving event shows ungated');
           }
@@ -1826,6 +1895,31 @@ class Universal extends Destination {
           && scheduleVenue === eventScheduleVenue
           ? eventOperating
           : true;
+      } else if (
+        !parkOperating
+        && eventOperating === true
+        && eventWindowClosesAt !== null
+        && eventScheduleVenue !== null
+        && scheduleVenue === eventScheduleVenue
+        && times.some((t) => Date.parse(t.startTime) <= eventWindowClosesAt!)
+      ) {
+        // The park is SHUT to day guests but the ticketed event is running,
+        // and this ordinary show performs INSIDE it. Super Nintendo World
+        // stays open through Halloween Horror Nights: "Meet Mario and Luigi",
+        // "Meet Toad" and "Meet Princess Peach" carry ENABLED performances at
+        // 19:00-21:30 while Hollywood's day park closed at 18:00, and they are
+        // categorised `general`, not `hhn`. Gating those on day-park hours
+        // alone republishes exactly the contradiction this gate was built to
+        // remove — CLOSED beside a showtime happening right now — from the
+        // other side of the clock.
+        //
+        // The performance test is what keeps the original fix intact. A show
+        // whose only remaining slot is tomorrow MORNING is not performing in
+        // tonight's event, and must stay CLOSED however long the event runs —
+        // that is the overnight-staleness case #321 was built for, and a bare
+        // "the event is on" check would have undone it. Only a slot at or
+        // before the event's close counts.
+        parkOperating = true;
       }
       showEntry.status = mapUniversalShowStatus(show.status, times.length > 0, parkOperating);
       if (times.length > 0) {

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -1826,7 +1826,70 @@ class Universal extends Destination {
       );
     }
 
-    return liveData;
+    return await this.dropUnpublishableRows(liveData);
+  }
+
+  /**
+   * Keep only rows whose entity this destination actually publishes.
+   *
+   * The live feeds and the place feed do not agree on what exists. show-list
+   * and the wait-time feed emit readings for things buildEntityList has no
+   * entity for, in four separate ways seen live at Hollywood:
+   *
+   *  - ids the PLACE feed has never heard of (`ush.mms.minion.dance.party`,
+   *    and `ush.upper.lot.shows.meet_james.henry`, which is dotted where every
+   *    other id is underscored — an older id shape leaking in);
+   *  - event-variant aliases dropped as duplicates (Studio Tour Last Tram, and
+   *    the Mandarin/Spanish variants whose share links point at WaterWorld);
+   *  - children of a venue with no wiki representation (CityWalk);
+   *  - places whose type placeToEntity does not map (an `Events`-typed ride).
+   *
+   * A row keyed to an entity that is never emitted cannot be resolved by any
+   * consumer — it is dropped downstream after being built, pushed and logged.
+   * Filtering here costs one already-cached place list and removes the whole
+   * class rather than the four causes one at a time.
+   *
+   * Derived from buildEntityList itself rather than by re-testing the same
+   * predicates, so the two cannot drift apart as feed shapes are added.
+   *
+   * ISOLATED on purpose: buildEntityList is allowed to fail loudly, but a
+   * failure here must not blank a whole cycle of wait times. If the entity
+   * list cannot be built, every row is published exactly as before.
+   */
+  protected async dropUnpublishableRows(rows: LiveData[]): Promise<LiveData[]> {
+    let publishable: Set<string>;
+    try {
+      publishable = new Set((await this.buildEntityList()).map((e) => e.id));
+    } catch (err: any) {
+      console.warn(
+        `[${this.constructor.name}] entity list unavailable, publishing every live row: ${err?.message ?? err}`,
+      );
+      return rows;
+    }
+    const kept = rows.filter((row) => publishable.has(row.id));
+    const dropped = rows.length - kept.length;
+
+    // A filter that would remove most of the feed is evidence its INPUT is
+    // wrong, not that the rows are. getPlaces coerces any malformed-but-200
+    // response to [] and @caches it for twelve hours, which yields an entity
+    // list holding little more than the destination itself — and would then
+    // silently blank every wait time for half a day. The orphans this exists
+    // to remove are a fraction of a feed (10 of 57 at Hollywood, 0 of 94 at
+    // Orlando); anything near-total is an outage wearing a filter's clothes.
+    // Publish everything and say so, rather than mistaking one for the other.
+    if (dropped > rows.length / 2) {
+      console.warn(
+        `[${this.constructor.name}] entity list would drop ${dropped}/${rows.length} live rows — treating it as unusable and publishing every row`,
+      );
+      return rows;
+    }
+
+    if (dropped > 0) {
+      console.warn(
+        `[${this.constructor.name}] dropped ${dropped} live row(s) keyed to entities that are never published`,
+      );
+    }
+    return kept;
   }
 
   /**

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -358,6 +358,53 @@ export function buildExpressVariantMap(places: UniversalPlace[]): Map<string, st
 }
 
 /**
+ * True for an event-flagged place whose NAME marks it as a variant of a
+ * canonical place that exists in the same feed — "Studio Tour - Mandarin"
+ * beside "Studio Tour".
+ *
+ * This exists because isEventVariantAlias's share-link signal is not
+ * trustworthy on its own. USH's Mandarin and Spanish Studio Tour variants
+ * aim their `social_sharing_link` at WATERWORLD, an unrelated show. Today
+ * that still resolves to "some other real place", so they are dropped and
+ * the answer happens to be right — but the reason is luck. If the feed ever
+ * nulls that link, or repoints it at an id the feed does not carry, both
+ * fall into the branch that deliberately KEEPS a record (the Epic Universe
+ * meets case), and the wiki gains two phantom SHOW entities named after a
+ * ride it already publishes. They are typed `Show` while the real Studio
+ * Tour is a `Ride`, so they would not even sit next to it.
+ *
+ * The name is the sturdier signal: it is what the variant is actually
+ * describing, and it does not depend on the feed getting a cross-reference
+ * right. Both rules run, so neither is load-bearing alone.
+ *
+ * Every " - " boundary is tried, so "A - B - C" matches a canonical "A" or
+ * "A - B". Only non-event places count as canonical, so two variants cannot
+ * validate each other. Names are space-normalised first — the feed mixes
+ * U+00A0 into these strings (see normalizeName).
+ */
+export function isNamedEventVariant(
+  place: UniversalPlace,
+  canonicalNames: Set<string>,
+): boolean {
+  if (attr(place, 'is_event') !== 'true') return false;
+  const name = normalizeName(place.name);
+  for (let i = name.indexOf(' - '); i > 0; i = name.indexOf(' - ', i + 1)) {
+    if (canonicalNames.has(name.slice(0, i))) return true;
+  }
+  return false;
+}
+
+/** Names of places that are not themselves event variants. */
+export function canonicalPlaceNames(places: UniversalPlace[]): Set<string> {
+  return new Set(
+    places
+      .filter((p) => attr(p, 'is_event') !== 'true')
+      .map((p) => normalizeName(p.name))
+      .filter(Boolean),
+  );
+}
+
+/**
  * Map a UniversalPlace to a wiki Entity. Returns null for place types we
  * don't expose (Park is emitted separately by buildEntityList; Shop /
  * Amenity / Hotel / etc. are out of scope for this migration).
@@ -1476,8 +1523,13 @@ class Universal extends Destination {
     // a share link to a non-existent id (sloppy feed data) is NOT treated as a
     // variant.
     const knownPlaceIds = new Set(places.map((p) => sanitizeId(p.place_id)));
+    const canonicalNames = canonicalPlaceNames(places);
     for (const place of places) {
       if (isEventVariantAlias(place, knownPlaceIds)) continue;
+      // Second, independent signal for the same class: the share link is
+      // wrong on the very records it is meant to resolve (see
+      // isNamedEventVariant), so the name has to carry it too.
+      if (isNamedEventVariant(place, canonicalNames)) continue;
       // An express queue is a queue on its maze, not an attraction of its
       // own — buildLiveData reattaches its wait as PAID_STANDBY.
       if (isExpressQueueVariant(place)) continue;


### PR DESCRIPTION
Two independent hardenings against the same underlying problem: Universal's feeds disagree with each other about what exists, and parksapi was trusting one fragile signal in each case.

---

## 1. Live rows for entities that are never published

`show-list` and the wait-time feed emit readings for things `buildEntityList` has no entity for — ten rows every cycle at Hollywood, built, pushed, and then discarded downstream because no consumer can resolve a row to an entity that does not exist.

Four distinct causes, all observed live:

| Cause | Rows | Example |
|---|---|---|
| No place record at all | 4 | `ush.mms.elphaba.meet.and.greet_place`, `ush.upper.lot.shows.meet_james.henry` |
| Event-variant alias, dropped as a duplicate | 3 | `studio_tour_mandarin` / `_spanish`, `studio_tour_last_tram` |
| Child of a venue with no wiki representation | 2 | `ush.cw.entertainment.street_performers` |
| Place type `placeToEntity` does not map | 1 | an `Events`-typed Terror Tram variant |

`ush.upper.lot.shows.meet_james.henry` is dotted where every other id is underscored — an older id shape leaking in.

`buildLiveData` now emits rows only for ids `buildEntityList` publishes, derived **from `buildEntityList` itself** rather than by re-testing the same predicates, so the two cannot drift as feed shapes are added.

### Before / after, same cache database so the feed data is identical

| | rows before | rows after | dropped | added | changed | entities |
|---|---|---|---|---|---|---|
| Hollywood | 57 | 47 | 10 | **0** | **0** | identical |
| Orlando | 104 | 104 | 0 | **0** | **0** | identical |

151 of 161 rows are byte-identical — same status, same queues, same showtimes. Eight of the ten dropped were `CLOSED` with empty queues. Two carried content (Studio Tour Mandarin/Spanish, 1 and 6 showtimes) — and neither entity exists on the wiki, so that content was being pushed into a void.

### Two bail-outs, and why they are not optional

Deriving the filter from the entity list moves the risk onto its input, and that input has a known failure mode: `getPlaces` coerces any malformed-but-200 response to `[]` and `@cache`s it for **twelve hours**. Filtering on that would silently blank every wait time for half a day — far worse than the unresolvable rows this removes.

- **Would drop more than half the feed** → publish everything, with a warning. A near-total drop is evidence the *input* is broken, not the rows.
- **Entity list throws** → publish everything. `buildEntityList` is the path allowed to fail loudly; `buildLiveData` never is.

This flaw was surfaced by the existing suite: 33 tests stub `getPlaces` as empty, which is precisely the malformed-200 shape, and they went red before the guard existed.

Retirement force-closes are a separate concern and untouched. They emit one CLOSED for an id that has stopped appearing, stamp it, and forget it — that is how content for a genuinely retired entity gets cleared.

---

## 2. Event variants identified by name, not just by share link

`isEventVariantAlias` decides a place is a duplicate when its `social_sharing_link` points at a *different place that exists*. On the very records that rule was written for, **the link is wrong**:

```
ush.upper_lot.rides.studio_tour            "Studio Tour"            Ride  is_event=false -> self
ush.upper_lot.rides.studio_tour_last_tram  "Studio Tour Last Tram"  Ride  is_event=true  -> studio_tour  (correct)
ush.upper_lot.shows.studio_tour_mandarin   "Studio Tour - Mandarin" Show  is_event=true  -> waterworld   (wrong)
ush.upper_lot.shows.studio_tour_spanish    "Studio Tour - Spanish"  Show  is_event=true  -> waterworld   (wrong)
```

WaterWorld is an unrelated show. Today it exists, so the predicate fires and both are dropped — the answer is right and the reason is luck. The rule deliberately **keeps** a record whose link is absent or points at an id the feed does not carry (the Epic Universe meets case), so the day the feed nulls or repoints that bad link, both become publishable and the wiki gains two phantom `SHOW` entities named after a `Ride` it already publishes.

A place's name is the sturdier signal. An event-flagged place named `"<canonical> - <suffix>"`, where a non-event place of that exact name exists, is a variant. Every `" - "` boundary is tried; only non-event places count as canonical, so two variants cannot validate each other; names are space-normalised, because the feed mixes U+00A0 into them.

Both rules run. Neither is load-bearing alone.

### Measured against both live feeds before shipping

The name rule matches **5 places at Hollywood, 0 at Orlando**, and all five are already dropped by an existing rule. Entity lists identical on both resorts; live-row membership identical. It buys insurance and changes nothing today, which is exactly what it should do.

It does **not** match `Hogwarts Express™ - Hogsmeade™ Station`, `- King's Cross Station`, or `Hogwarts™ Express - First/Last Train` — no canonical of that name exists, which is what keeps real attractions safe.

---

## Verification

- Full suite **2286 passed**, typecheck clean.
- 14 new tests; 11 fail on `main`. The three that pass on both pin the bail-outs, which must hold either way.
- Both resorts captured before and after against a shared cache so every difference is code, not upstream drift.
- Full row-level before/after written out and reviewed per entity.

## Test plan

- [x] A row whose id the place feed has never heard of is dropped
- [x] A row for a dropped venue's child (CityWalk) is dropped
- [x] Rows for published entities survive untouched, queue and status intact
- [x] An unusable (empty) entity list publishes every row rather than blanking the feed
- [x] A failing entity list publishes every row rather than throwing
- [x] A minority of unpublishable rows is still filtered — the guard does not disable the fix
- [x] A language variant of an existing canonical is matched by name
- [x] It is still dropped when the share link stops rescuing it — the whole point
- [x] Two variants cannot validate each other; a non-event place is never a variant
- [x] Every `" - "` boundary is tried; U+00A0 does not defeat the match
- [x] Hogwarts Express stations and first/last-train records are never matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)