### PR TITLE
fix(universal): a performance near the operating session outranks the published hours

### DIFF
--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -124,8 +124,14 @@ describe('a performance happening now outranks the published windows', () => {
     show_times: slots.map((t, i) => ({show_time_id: String(i), status: 'ENABLED', start_time: t})),
   } as any);
   // parkOperating=false throughout: the park is shut / the event is not open.
+  // These cases isolate the +/-30 minute imminence logic, so they hand it an
+  // interval that always contains both the instant and the slot. Whether a
+  // performance is INSIDE an operating session is the anchoring rule, covered
+  // by the buildLiveData tests further down.
+  const ANY_SESSION = [{start: -Infinity, end: Infinity}];
   const verdict = (s: UniversalShowListEntry, iso: string) =>
-    mapUniversalShowStatus(s.status, true, false, hasImminentPerformance(s, new Date(iso)));
+    mapUniversalShowStatus(s.status, true, false,
+      hasImminentPerformance(s, new Date(iso), ANY_SESSION));
 
   test('a single performance 20 minutes away reads OPERATING', () => {
     expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T00:10:00Z')).toBe('OPERATING');
@@ -172,7 +178,7 @@ describe('a performance happening now outranks the published windows', () => {
   test('disabled slots are ignored', () => {
     const s: any = show(['2026-09-06T00:30:00.000Z']);
     s.show_times[0].status = 'DISABLED';
-    expect(hasImminentPerformance(s, new Date('2026-09-06T00:10:00.000Z'))).toBe(false);
+    expect(hasImminentPerformance(s, new Date('2026-09-06T00:10:00.000Z'), ANY_SESSION)).toBe(false);
   });
 
   test('a show with no show_times at all is not imminent', () => {
@@ -180,7 +186,7 @@ describe('a performance happening now outranks the published windows', () => {
     // is load-bearing in production and nothing else exercises it.
     expect(hasImminentPerformance({show_id: 'a', name: 'b', status: 'OPEN',
       show_externally: true, resort_area_code: 'X', venue_id: 'x.y'} as any,
-      new Date('2026-09-06T00:10:00.000Z'))).toBe(false);
+      new Date('2026-09-06T00:10:00.000Z'), ANY_SESSION)).toBe(false);
   });
 
   test('THE WINDOW IS EXACTLY 30 MINUTES, in both directions', () => {
@@ -188,10 +194,10 @@ describe('a performance happening now outranks the published windows', () => {
     // exactly 30 minutes out at the moment it first goes wrong — so inclusive
     // 30 is load-bearing, not decorative, and retuning it must break a test.
     const s = show(['2026-09-06T00:30:00.000Z']);
-    expect(hasImminentPerformance(s, new Date('2026-09-06T00:00:00.000Z'))).toBe(true);  // -30m exactly
-    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:00.000Z'))).toBe(true);  // +30m exactly
-    expect(hasImminentPerformance(s, new Date('2026-09-05T23:59:59.000Z'))).toBe(false); // -30m01s
-    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:01.000Z'))).toBe(false); // +30m01s
+    expect(hasImminentPerformance(s, new Date('2026-09-06T00:00:00.000Z'), ANY_SESSION)).toBe(true);  // -30m exactly
+    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:00.000Z'), ANY_SESSION)).toBe(true);  // +30m exactly
+    expect(hasImminentPerformance(s, new Date('2026-09-05T23:59:59.000Z'), ANY_SESSION)).toBe(false); // -30m01s
+    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:01.000Z'), ANY_SESSION)).toBe(false); // +30m01s
   });
 });
 
@@ -343,6 +349,56 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
     expect(rows.find((r: any) => r.id === 'ush.lower_lot.shows.meet_toad').status).toBe('OPERATING');
   });
 
+  test('THE EVENT ARM IS VENUE-SCOPED: another park hosting HHN does not unlock this one', async () => {
+    // The hhn status branch is deliberately scoped to the configured host
+    // park. Without the same scope on the imminent rule, ONE hhn-category
+    // show anywhere in the feed opened it at EVERY venue for the whole event
+    // night: an Epic Universe show with a 23:30 slot read OPERATING three and
+    // a half hours past Epic's 20:00 close, because Halloween Horror Nights
+    // was running over at Universal Studios Florida.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-06T03:25:00.000Z')); // 23:25 EDT
+    const day = (date: string, venueDate: string) => ([{
+      Date: date, VenueStatus: '',
+      OpenTimeString: `${venueDate}T10:00:00-04:00`,
+      CloseTimeString: `${venueDate}T20:00:00-04:00`,
+    }]);
+    const epicShow: any = {
+      show_id: 'uor.eu.shows.celestialgoodnight', resort_area_code: 'UOR',
+      venue_id: 'uor.eu', name: 'Universal Celestial Goodnight', status: 'CLOSED',
+      show_externally: true,
+      show_times: [{show_time_id: '0', status: 'ENABLED', start_time: '2026-09-06T03:30:00.000Z'}],
+    };
+    const hhnAtUsf: any = {
+      show_id: 'uor.usf.events.hhn_2026_show_the_purge', resort_area_code: 'UOR',
+      venue_id: 'uor.usf', category: 'hhn', name: 'The Purge',
+      status: 'OPEN', show_externally: true, show_times: [],
+    };
+    const park: any = stubPark(
+      new UniversalOrlando({config: {eventCalendarPlaceId: 'uor.usf',
+        eventCalendarURL: 'https://example.invalid/c'}} as any),
+      [epicShow, hhnAtUsf],
+      {
+        '10010': day('2026-09-05', '2026-09-05').concat(day('2026-09-06', '2026-09-06')),
+        '10000': day('2026-09-05', '2026-09-05').concat(day('2026-09-06', '2026-09-06')),
+        '24000': day('2026-09-05', '2026-09-05').concat(day('2026-09-06', '2026-09-06')),
+        '13801': day('2026-09-05', '2026-09-05').concat(day('2026-09-06', '2026-09-06')),
+      },
+    );
+    // HHN is genuinely running at USF, 18:30 -> 02:00.
+    park.getEventNights = async () => [{
+      date: '2026-09-05', name: 'Halloween Horror Nights',
+      openingTime: '18:30', closingTime: '02:00', closesNextDay: true,
+    }];
+    park.getPlaces = async () => [];
+    const rows = await park.getLiveData();
+    vi.useRealTimers();
+    const row = rows.find((r: any) => r.id === 'uor.eu.shows.celestialgoodnight');
+    // Epic closed at 20:00 and its hour of grace expired at 21:00. The event
+    // is at a different park, so it must not reach this show.
+    expect(row.status).toBe('CLOSED');
+  });
+
   test('MEET HELLO KITTY: a mis-stamped slot cannot resurrect a show at 02:30', async () => {
     // The real regression the first version shipped. USH's Meet Hello Kitty
     // carries eleven slots across 09:00-15:00 PDT plus a twelfth at
@@ -393,6 +449,23 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
       'OPEN',
     );
     expect(oneSecondPast.status).toBe('CLOSED');
+  });
+
+  test('THE SLOT must be in the session too, not just the instant', async () => {
+    // Anchoring only `now` leaves the real reach at close+90: at close+50 the
+    // instant is inside the grace, and a slot at close+75 is within half an
+    // hour of it, so a slot mis-stamped past the grace still fires. It is the
+    // same hole that left Meet Hello Kitty's 02:30 phantom blocked by nothing
+    // but the coincidence that the event happens to close at 02:00.
+    //
+    // Day closes 18:00 PT, so the grace ends 19:00. Instant 18:50 (inside),
+    // slot 19:15 (outside).
+    const row = await rowAt(
+      '2026-09-06T01:50:00.000Z',              // 18:50 PT — inside the grace
+      ['2026-09-06T02:15:00.000Z'],            // 19:15 PT — past it
+      'OPEN',
+    );
+    expect(row.status).toBe('CLOSED');
   });
 
   test('an hour past close is the limit, not four hours', async () => {

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -291,6 +291,58 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
     expect(row.status).toBe('CLOSED');
   });
 
+  test('the park-open arm: an unavailable schedule must not lose a live show', async () => {
+    // getVenueSchedule throwing is fail-open: parkOperating=true, window=null.
+    // A show mid-performance then has no future slots and no day window, so
+    // only the parkOperating arm of nearOperatingSession can save it.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-06T01:10:00.000Z'));
+    const show: any = {
+      show_id: 'ush.upper_lot.shows.meet.hamikuma', resort_area_code: 'USH',
+      venue_id: 'ush.upper_lot', name: 'Meet HamiKuma', status: 'CLOSED',
+      show_externally: true,
+      show_times: [{show_time_id: '0', status: 'ENABLED', start_time: '2026-09-06T01:05:00.000Z'}],
+    };
+    const park: any = stubPark(new UniversalStudios(), [show], {});
+    park.getVenueSchedule = async () => { throw new Error('upstream 500'); };
+    park.getEventNights = async () => [];
+    park.getPlaces = async () => [];
+    const rows = await park.getLiveData();
+    vi.useRealTimers();
+    expect(rows.find((r: any) => r.id === 'ush.upper_lot.shows.meet.hamikuma').status).toBe('OPERATING');
+  });
+
+  test('the event arm: an ordinary show mid-performance deep inside the event', async () => {
+    // 23:00 PT — five hours past the day close, so the day window and its
+    // hour of grace are long gone, but HHN runs to 02:00. Only the
+    // eventOperating arm keeps this show alive.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-06T06:00:00.000Z'));
+    const show: any = {
+      show_id: 'ush.lower_lot.shows.meet_toad', resort_area_code: 'USH',
+      venue_id: 'ush.lower_lot', name: 'Meet Toad', status: 'CLOSED',
+      show_externally: true,
+      show_times: [{show_time_id: '0', status: 'ENABLED', start_time: '2026-09-06T05:55:00.000Z'}],
+    };
+    // An hhn-category show must be present: the event calendar is only
+    // fetched when one is, so without it eventOperating stays null and the
+    // arm under test never engages.
+    const hhn: any = {
+      show_id: 'ush.upper_lot.events.hhn_2026_show_the_purge', resort_area_code: 'USH',
+      venue_id: 'ush.upper_lot', category: 'hhn', name: 'The Purge',
+      status: 'OPEN', show_externally: true, show_times: [],
+    };
+    const park: any = stubPark(new UniversalStudios(), [show, hhn], {'13825': DAY_SHUT});
+    park.getEventNights = async () => [{
+      date: '2026-09-05', name: 'Halloween Horror Nights',
+      openingTime: '19:00', closingTime: '02:00', closesNextDay: true,
+    }];
+    park.getPlaces = async () => [];
+    const rows = await park.getLiveData();
+    vi.useRealTimers();
+    expect(rows.find((r: any) => r.id === 'ush.lower_lot.shows.meet_toad').status).toBe('OPERATING');
+  });
+
   test('MEET HELLO KITTY: a mis-stamped slot cannot resurrect a show at 02:30', async () => {
     // The real regression the first version shipped. USH's Meet Hello Kitty
     // carries eleven slots across 09:00-15:00 PDT plus a twelfth at
@@ -298,12 +350,49 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
     // -07:00, landing at 02:30 PDT. Park shut since 18:00, event over at
     // 02:00. Unanchored, the imminent rule published OPERATING for a full
     // hour in the middle of the night off that single row.
+    // Fixture carries the real slot pair: the last good 15:00 PDT slot and
+    // the mis-stamped row. (The helper publishes under the HamiKuma id; what
+    // is under test is the slot shape, not the show's name.)
     const row = await rowAt(
       '2026-09-06T09:30:00.000Z',                                   // 02:30 PDT
       ['2026-09-05T22:00:00.000Z', '2026-09-06T09:30:00.000Z'],     // 15:00 PDT + the bad row
       'OPEN',
     );
     expect(row.status).toBe('CLOSED');
+  });
+
+  test('THE TRANSPOSITION GUARD: a show already ON STAGE past the close', async () => {
+    // The one state that distinguishes the two boolean arguments at the call
+    // site: hasFutureShowtimes=false (parseShowTimes drops a slot that has
+    // already begun), parkOperating=false, performingNow=true. Swap
+    // parkOperating and performingNow and this reads CLOSED — and the
+    // compiler cannot see it, because both are booleans. It is also
+    // Celestial Goodnight's exact shape: one performance, already started,
+    // past the posted close.
+    const row = await rowAt(
+      '2026-09-06T01:10:00.000Z',              // 18:10 PT, ten past the close
+      ['2026-09-06T01:05:00.000Z'],            // 18:05 PT — started, no future slot
+      'CLOSED',
+    );
+    expect(row.status).toBe('OPERATING');
+    expect(row.showtimes ?? []).toHaveLength(0);   // nothing in the future: the point
+  });
+
+  test('THE GRACE IS EXACTLY 60 MINUTES past close', async () => {
+    // Pins POST_CLOSE_GRACE_MS. Without this the constant is free to roam
+    // anywhere in [10m, 100m) with the suite still green.
+    const onTheLimit = await rowAt(
+      '2026-09-06T02:00:00.000Z',              // 19:00 PT = close + 60m exactly
+      ['2026-09-06T02:00:00.000Z'],
+      'OPEN',
+    );
+    expect(onTheLimit.status).toBe('OPERATING');
+    const oneSecondPast = await rowAt(
+      '2026-09-06T02:00:01.000Z',              // close + 60m + 1s
+      ['2026-09-06T02:00:00.000Z'],
+      'OPEN',
+    );
+    expect(oneSecondPast.status).toBe('CLOSED');
   });
 
   test('an hour past close is the limit, not four hours', async () => {

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -195,6 +195,49 @@ describe('a performance happening now outranks the published windows', () => {
   });
 });
 
+describe('resolveParkDay picks the nearest relevant day, not the last one listed', () => {
+  // Hollywood has TWO relevant dates: its own, and the Eastern one the legacy
+  // server keys rows to. Between 21:00 and midnight Pacific the Eastern date
+  // has already rolled over, so both today's and tomorrow's rows are
+  // "relevant". A last-one-wins rule adopts TOMORROW's window and silently
+  // drops the post-close grace — and makes the answer depend on the upstream
+  // array's ordering, which is not a property worth relying on.
+  const TODAY = {
+    Date: '2026-09-05', VenueStatus: '',
+    OpenTimeString: '2026-09-05T08:00:00-07:00',
+    CloseTimeString: '2026-09-05T22:00:00-07:00',
+  };
+  const TOMORROW = {
+    Date: '2026-09-06', VenueStatus: '',
+    OpenTimeString: '2026-09-06T08:00:00-07:00',
+    CloseTimeString: '2026-09-06T22:00:00-07:00',
+  };
+
+  async function windowAt(iso: string, rows: any[]) {
+    const park: any = stubPark(new UniversalStudios(), [], {'13825': rows});
+    const day = await park.resolveParkDay('13825', new Date(iso));
+    return day.window;
+  }
+
+  test('the nearest day wins whichever order the rows arrive in', async () => {
+    // 22:30 PT on the 5th: half an hour past today's 22:00 close, inside the
+    // grace. Tomorrow's window opens 9.5 hours away.
+    const at = '2026-09-06T05:30:00.000Z';
+    const ascending = await windowAt(at, [TODAY, TOMORROW]);
+    const descending = await windowAt(at, [TOMORROW, TODAY]);
+    expect(ascending).toEqual(descending);
+    expect(new Date(ascending.closesAt).toISOString()).toBe('2026-09-06T05:00:00.000Z'); // 22:00 PT on the 5th
+  });
+
+  test('the operating verdict is unaffected by which window is kept', async () => {
+    const at = '2026-09-06T05:30:00.000Z';
+    for (const rows of [[TODAY, TOMORROW], [TOMORROW, TODAY]]) {
+      const park: any = stubPark(new UniversalStudios(), [], {'13825': rows});
+      expect((await park.resolveParkDay('13825', new Date(at))).operating).toBe(false);
+    }
+  });
+});
+
 describe('Universal buildLiveData — the imminent rule is actually wired in', () => {
   // Every other test above calls the pure functions directly. That leaves the
   // call site itself unasserted: replacing hasImminentPerformance(show, now)

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -170,9 +170,104 @@ describe('a performance happening now outranks the published windows', () => {
   });
 
   test('disabled slots are ignored', () => {
-    const s: any = show(['2026-09-06T00:30:00Z']);
+    const s: any = show(['2026-09-06T00:30:00.000Z']);
     s.show_times[0].status = 'DISABLED';
-    expect(hasImminentPerformance(s, new Date('2026-09-06T00:10:00Z'))).toBe(false);
+    expect(hasImminentPerformance(s, new Date('2026-09-06T00:10:00.000Z'))).toBe(false);
+  });
+
+  test('a show with no show_times at all is not imminent', () => {
+    // show_times is optional on UniversalShowListEntry, so the ?? [] fallback
+    // is load-bearing in production and nothing else exercises it.
+    expect(hasImminentPerformance({show_id: 'a', name: 'b', status: 'OPEN',
+      show_externally: true, resort_area_code: 'X', venue_id: 'x.y'} as any,
+      new Date('2026-09-06T00:10:00.000Z'))).toBe(false);
+  });
+
+  test('THE WINDOW IS EXACTLY 30 MINUTES, in both directions', () => {
+    // The constant is sized by Meet HamiKuma's early-access slot, which is
+    // exactly 30 minutes out at the moment it first goes wrong — so inclusive
+    // 30 is load-bearing, not decorative, and retuning it must break a test.
+    const s = show(['2026-09-06T00:30:00.000Z']);
+    expect(hasImminentPerformance(s, new Date('2026-09-06T00:00:00.000Z'))).toBe(true);  // -30m exactly
+    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:00.000Z'))).toBe(true);  // +30m exactly
+    expect(hasImminentPerformance(s, new Date('2026-09-05T23:59:59.000Z'))).toBe(false); // -30m01s
+    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:01.000Z'))).toBe(false); // +30m01s
+  });
+});
+
+describe('Universal buildLiveData — the imminent rule is actually wired in', () => {
+  // Every other test above calls the pure functions directly. That leaves the
+  // call site itself unasserted: replacing hasImminentPerformance(show, now)
+  // with `false`, or transposing it with parkOperating (both booleans, so the
+  // compiler stays silent), passes a suite made only of unit tests. These
+  // drive the real buildLiveData -> getLiveData path instead.
+  const DAY_SHUT = [
+    {Date: '2026-09-05', VenueStatus: '', OpenTimeString: '2026-09-05T08:00:00-07:00', CloseTimeString: '2026-09-05T18:00:00-07:00'},
+    {Date: '2026-09-06', VenueStatus: '', OpenTimeString: '2026-09-06T08:00:00-07:00', CloseTimeString: '2026-09-06T18:00:00-07:00'},
+  ];
+
+  async function rowAt(iso: string, slots: string[], status: string) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(iso));
+    const show: UniversalShowListEntry = {
+      show_id: 'ush.upper_lot.shows.meet.hamikuma',
+      resort_area_code: 'USH', venue_id: 'ush.upper_lot',
+      name: 'Meet HamiKuma', status, show_externally: true,
+      show_times: slots.map((t, i) => ({show_time_id: String(i), status: 'ENABLED', start_time: t})),
+    } as any;
+    const park: any = stubPark(new UniversalStudios(), [show], {'13825': DAY_SHUT});
+    park.getEventNights = async () => [];
+    park.getPlaces = async () => [];
+    const rows = await park.getLiveData();
+    vi.useRealTimers();
+    return rows.find((r: any) => r.id === 'ush.upper_lot.shows.meet.hamikuma');
+  }
+
+  test('just past the close, performance 20 minutes out: the row is OPERATING', async () => {
+    // 18:10 PT, ten minutes after the 18:00 close, slot at 18:30 — Celestial
+    // Goodnight's shape. Only the imminent rule can produce OPERATING here: if
+    // the call site is unwired, or its argument transposed with parkOperating
+    // (false), this reads CLOSED.
+    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T01:30:00.000Z'], 'OPEN');
+    expect(row.status).toBe('OPERATING');
+  });
+
+  test("status CLOSED — the shape Universal actually reports between appearances", async () => {
+    // Meet-and-greets report CLOSED between slots, which is the DEFAULT branch
+    // of mapUniversalShowStatus, not the OPEN branch every other new test
+    // exercises. Both shows this change was written for are this shape.
+    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T01:30:00.000Z'], 'CLOSED');
+    expect(row.status).toBe('OPERATING');
+    expect(row.showtimes).toHaveLength(1);
+  });
+
+  test('park shut and nothing imminent: still CLOSED', async () => {
+    // The control. Same park, same shut hours, slot 14 hours away — the
+    // overnight staleness case, through the full pipeline.
+    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T16:00:00.000Z'], 'CLOSED');
+    expect(row.status).toBe('CLOSED');
+  });
+
+  test('MEET HELLO KITTY: a mis-stamped slot cannot resurrect a show at 02:30', async () => {
+    // The real regression the first version shipped. USH's Meet Hello Kitty
+    // carries eleven slots across 09:00-15:00 PDT plus a twelfth at
+    // 2026-09-06T09:30:00.000Z — tomorrow's 09:30 local stamped Z instead of
+    // -07:00, landing at 02:30 PDT. Park shut since 18:00, event over at
+    // 02:00. Unanchored, the imminent rule published OPERATING for a full
+    // hour in the middle of the night off that single row.
+    const row = await rowAt(
+      '2026-09-06T09:30:00.000Z',                                   // 02:30 PDT
+      ['2026-09-05T22:00:00.000Z', '2026-09-06T09:30:00.000Z'],     // 15:00 PDT + the bad row
+      'OPEN',
+    );
+    expect(row.status).toBe('CLOSED');
+  });
+
+  test('an hour past close is the limit, not four hours', async () => {
+    // 19:40 PT with a slot at 20:00: 1h40m past the 18:00 close, beyond the
+    // grace. The rule must not reach here even though a slot is 20 min away.
+    const row = await rowAt('2026-09-06T02:40:00.000Z', ['2026-09-06T03:00:00.000Z'], 'OPEN');
+    expect(row.status).toBe('CLOSED');
   });
 });
 

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -18,7 +18,7 @@
  * to match the reported incident directly.
  */
 import {describe, test, expect, vi, afterEach} from 'vitest';
-import {UniversalStudios, UniversalOrlando, mapUniversalShowStatus, hasImminentPerformance, type UniversalShowListEntry} from '../universal.js';
+import {UniversalStudios, UniversalOrlando, mapUniversalShowStatus, hasPerformanceUnderway, type UniversalShowListEntry} from '../universal.js';
 
 // Real wall-clock hours from the incident: EXTRA_HOURS 08:00-09:00 PDT,
 // general open 09:00-19:00 PDT. All offsets are -07:00 (Pacific, no DST
@@ -109,95 +109,88 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('a performance happening now outranks the published windows', () => {
+describe('a performance already underway outranks the published windows', () => {
   // Both published windows are incomplete, in opposite directions, and the
   // feed found both on the first night the gate ran:
   //   - Epic Universe's "Universal Celestial Goodnight" has ONE performance at
   //     20:30 against a 20:00 posted park close.
   //   - Hollywood's "Meet HamiKuma" performs at 17:30 and 18:30 during HHN
   //     early access, before the 19:00 ticketed-event window opens.
-  // Each published CLOSED beside a performance that was minutes away or
-  // already on stage. Enumerating windows keeps losing this race.
+  // Each published CLOSED while a performance was on stage.
+  //
+  // The rule looks BACKWARD only. A slot that has begun is evidence; a slot in
+  // the future is a prediction, and this feed's predictions carry phantoms.
   const show = (slots: string[], status = 'OPEN'): UniversalShowListEntry => ({
-    show_id: 'x.y.shows.z', resort_area_code: 'X', venue_id: 'x.y',
-    name: 'A Show', status, show_externally: true,
+    show_id: 'ush.lower_lot.shows.meet_toad', resort_area_code: 'USH',
+    venue_id: 'ush.lower_lot', name: 'Meet Toad', status, show_externally: true,
     show_times: slots.map((t, i) => ({show_time_id: String(i), status: 'ENABLED', start_time: t})),
   } as any);
-  // parkOperating=false throughout: the park is shut / the event is not open.
-  // These cases isolate the +/-30 minute imminence logic, so they hand it an
-  // interval that always contains both the instant and the slot. Whether a
-  // performance is INSIDE an operating session is the anchoring rule, covered
-  // by the buildLiveData tests further down.
+  // These cases isolate the "underway" logic, so they hand it an interval that
+  // always contains both the instant and the slot. Whether a performance is
+  // inside an operating session is the anchoring rule, covered by the
+  // buildLiveData tests below.
   const ANY_SESSION = [{start: -Infinity, end: Infinity}];
-  const verdict = (s: UniversalShowListEntry, iso: string) =>
-    mapUniversalShowStatus(s.status, true, false,
-      hasImminentPerformance(s, new Date(iso), ANY_SESSION));
+  // parkOperating=false throughout: the park is shut / the event is not open.
+  const verdict = (sh: UniversalShowListEntry, iso: string) =>
+    mapUniversalShowStatus(sh.status, true, false,
+      hasPerformanceUnderway(sh, new Date(iso), ANY_SESSION));
 
-  test('a single performance 20 minutes away reads OPERATING', () => {
-    expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T00:10:00Z')).toBe('OPERATING');
+  test('5 minutes after it started: OPERATING', () => {
+    // Celestial Goodnight's shape. parseShowTimes drops a started slot, so
+    // from the parsed list this is indistinguishable from a show that has
+    // finished — it read CLOSED while literally on stage.
+    expect(verdict(show(['2026-09-06T00:30:00.000Z']), '2026-09-06T00:35:00.000Z')).toBe('OPERATING');
   });
 
-  test('the same performance 5 minutes AFTER it started still reads OPERATING', () => {
-    // parseShowTimes drops anything already begun, so a one-slot show is
-    // otherwise indistinguishable from one that finished for the day —
-    // it would read CLOSED while literally on stage.
-    expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T00:35:00Z')).toBe('OPERATING');
+  test('A FUTURE SLOT NEVER COUNTS, however close', () => {
+    // The change from the rejected symmetric version. 20 minutes before a
+    // performance the show has not started; a future slot is also the vector
+    // every phantom arrives on.
+    expect(verdict(show(['2026-09-06T00:30:00.000Z']), '2026-09-06T00:10:00.000Z')).toBe('CLOSED');
+    expect(verdict(show(['2026-09-06T00:30:00.000Z']), '2026-09-06T00:29:59.000Z')).toBe('CLOSED');
   });
 
-  test('45 minutes after the last performance it reads CLOSED again', () => {
-    expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T01:15:00Z')).toBe('CLOSED');
+  test('THE WINDOW IS EXACTLY 30 MINUTES, backwards only', () => {
+    const sh = show(['2026-09-06T00:30:00.000Z']);
+    expect(hasPerformanceUnderway(sh, new Date('2026-09-06T00:30:00.000Z'), ANY_SESSION)).toBe(true);  // t+0
+    expect(hasPerformanceUnderway(sh, new Date('2026-09-06T01:00:00.000Z'), ANY_SESSION)).toBe(true);  // t+30 exactly
+    expect(hasPerformanceUnderway(sh, new Date('2026-09-06T01:00:01.000Z'), ANY_SESSION)).toBe(false); // t+30m01s
+    expect(hasPerformanceUnderway(sh, new Date('2026-09-06T00:29:59.000Z'), ANY_SESSION)).toBe(false); // 1s before
   });
 
-  test('an early-access slot before the event window reads OPERATING', () => {
-    const hamikuma = show(['2026-09-06T00:30:00Z', '2026-09-06T01:30:00Z']);
-    expect(verdict(hamikuma, '2026-09-06T01:05:00Z')).toBe('OPERATING');
+  test('NO TILING: hourly slots leave a real gap', () => {
+    // The reason the forward half was cut. Symmetric, this window was 60
+    // minutes wide and ~80-92% of consecutive slot gaps are 60 minutes or
+    // less, so the union covered a show's entire day and the day gate stopped
+    // working. Backward-only cannot tile.
+    const hourly = show(['2026-09-06T00:30:00.000Z', '2026-09-06T01:30:00.000Z']);
+    expect(verdict(hourly, '2026-09-06T00:45:00.000Z')).toBe('OPERATING'); // 15m into the first
+    expect(verdict(hourly, '2026-09-06T01:15:00.000Z')).toBe('CLOSED');    // between them
+    expect(verdict(hourly, '2026-09-06T01:35:00.000Z')).toBe('OPERATING'); // 5m into the second
   });
 
-  test('a slot 54 minutes away does NOT count — nobody can see it yet', () => {
-    // Meet Mario at 18:06 PT with its next performance at 19:00: park shut,
-    // event not open. CLOSED is the honest answer, and the window must be
-    // tight enough to say so.
-    expect(verdict(show(['2026-09-06T02:00:00Z']), '2026-09-06T01:06:00Z')).toBe('CLOSED');
-  });
-
-  test('THE #321 CASE SURVIVES: a next-day slot never counts as imminent', () => {
-    // 03:00 local, park shut for hours, tomorrow's 09:00 performance listed.
-    // This is the overnight staleness the whole gate was built for; a looser
-    // window would quietly undo it.
-    expect(verdict(show(['2026-09-06T16:00:00Z']), '2026-09-06T10:00:00Z')).toBe('CLOSED');
+  test('THE #321 CASE SURVIVES: a next-day slot never counts', () => {
+    expect(verdict(show(['2026-09-06T16:00:00.000Z']), '2026-09-06T10:00:00.000Z')).toBe('CLOSED');
   });
 
   test('an explicit long closure is not reopened by a stale slot', () => {
-    expect(verdict(show(['2026-09-06T00:30:00Z'], 'EXTENDED_CLOSURE'), '2026-09-06T00:10:00Z')).toBe('CLOSED');
+    expect(verdict(show(['2026-09-06T00:30:00.000Z'], 'EXTENDED_CLOSURE'), '2026-09-06T00:35:00.000Z')).toBe('CLOSED');
   });
 
   test('a delayed show still reads DOWN, not OPERATING', () => {
-    expect(verdict(show(['2026-09-06T00:30:00Z'], 'BRIEF_DELAY'), '2026-09-06T00:10:00Z')).toBe('DOWN');
+    expect(verdict(show(['2026-09-06T00:30:00.000Z'], 'BRIEF_DELAY'), '2026-09-06T00:35:00.000Z')).toBe('DOWN');
   });
 
   test('disabled slots are ignored', () => {
-    const s: any = show(['2026-09-06T00:30:00.000Z']);
-    s.show_times[0].status = 'DISABLED';
-    expect(hasImminentPerformance(s, new Date('2026-09-06T00:10:00.000Z'), ANY_SESSION)).toBe(false);
+    const sh: any = show(['2026-09-06T00:30:00.000Z']);
+    sh.show_times[0].status = 'DISABLED';
+    expect(hasPerformanceUnderway(sh, new Date('2026-09-06T00:35:00.000Z'), ANY_SESSION)).toBe(false);
   });
 
-  test('a show with no show_times at all is not imminent', () => {
-    // show_times is optional on UniversalShowListEntry, so the ?? [] fallback
-    // is load-bearing in production and nothing else exercises it.
-    expect(hasImminentPerformance({show_id: 'a', name: 'b', status: 'OPEN',
+  test('a show with no show_times at all is never underway', () => {
+    expect(hasPerformanceUnderway({show_id: 'a', name: 'b', status: 'OPEN',
       show_externally: true, resort_area_code: 'X', venue_id: 'x.y'} as any,
-      new Date('2026-09-06T00:10:00.000Z'), ANY_SESSION)).toBe(false);
-  });
-
-  test('THE WINDOW IS EXACTLY 30 MINUTES, in both directions', () => {
-    // The constant is sized by Meet HamiKuma's early-access slot, which is
-    // exactly 30 minutes out at the moment it first goes wrong — so inclusive
-    // 30 is load-bearing, not decorative, and retuning it must break a test.
-    const s = show(['2026-09-06T00:30:00.000Z']);
-    expect(hasImminentPerformance(s, new Date('2026-09-06T00:00:00.000Z'), ANY_SESSION)).toBe(true);  // -30m exactly
-    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:00.000Z'), ANY_SESSION)).toBe(true);  // +30m exactly
-    expect(hasImminentPerformance(s, new Date('2026-09-05T23:59:59.000Z'), ANY_SESSION)).toBe(false); // -30m01s
-    expect(hasImminentPerformance(s, new Date('2026-09-06T01:00:01.000Z'), ANY_SESSION)).toBe(false); // +30m01s
+      new Date('2026-09-06T00:35:00.000Z'), ANY_SESSION)).toBe(false);
   });
 });
 
@@ -244,7 +237,7 @@ describe('resolveParkDay picks the nearest relevant day, not the last one listed
   });
 });
 
-describe('Universal buildLiveData — the imminent rule is actually wired in', () => {
+describe('Universal buildLiveData — the underway rule is actually wired in', () => {
   // Every other test above calls the pure functions directly. That leaves the
   // call site itself unasserted: replacing hasImminentPerformance(show, now)
   // with `false`, or transposing it with parkOperating (both booleans, so the
@@ -272,12 +265,12 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
     return rows.find((r: any) => r.id === 'ush.upper_lot.shows.meet.hamikuma');
   }
 
-  test('just past the close, performance 20 minutes out: the row is OPERATING', async () => {
-    // 18:10 PT, ten minutes after the 18:00 close, slot at 18:30 — Celestial
-    // Goodnight's shape. Only the imminent rule can produce OPERATING here: if
-    // the call site is unwired, or its argument transposed with parkOperating
-    // (false), this reads CLOSED.
-    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T01:30:00.000Z'], 'OPEN');
+  test('just past the close, performance already begun: the row is OPERATING', async () => {
+    // 18:10 PT, ten minutes after the 18:00 close, performance started 18:05 —
+    // Celestial Goodnight's shape. Only the underway rule can produce
+    // OPERATING here: if the call site is unwired, or its argument transposed
+    // with parkOperating (false), this reads CLOSED.
+    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T01:05:00.000Z'], 'OPEN');
     expect(row.status).toBe('OPERATING');
   });
 
@@ -285,9 +278,11 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
     // Meet-and-greets report CLOSED between slots, which is the DEFAULT branch
     // of mapUniversalShowStatus, not the OPEN branch every other new test
     // exercises. Both shows this change was written for are this shape.
-    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T01:30:00.000Z'], 'CLOSED');
+    const row = await rowAt('2026-09-06T01:10:00.000Z', ['2026-09-06T01:05:00.000Z'], 'CLOSED');
     expect(row.status).toBe('OPERATING');
-    expect(row.showtimes).toHaveLength(1);
+    // The slot has begun, so parseShowTimes drops it: no future showtimes at
+    // all, which is the state that distinguishes the two boolean arguments.
+    expect(row.showtimes ?? []).toHaveLength(0);
   });
 
   test('park shut and nothing imminent: still CLOSED', async () => {
@@ -357,7 +352,7 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
     // a half hours past Epic's 20:00 close, because Halloween Horror Nights
     // was running over at Universal Studios Florida.
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-09-06T03:25:00.000Z')); // 23:25 EDT
+    vi.setSystemTime(new Date('2026-09-06T03:35:00.000Z')); // 23:35 EDT
     const day = (date: string, venueDate: string) => ([{
       Date: date, VenueStatus: '',
       OpenTimeString: `${venueDate}T10:00:00-04:00`,
@@ -367,6 +362,8 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
       show_id: 'uor.eu.shows.celestialgoodnight', resort_area_code: 'UOR',
       venue_id: 'uor.eu', name: 'Universal Celestial Goodnight', status: 'CLOSED',
       show_externally: true,
+      // Started five minutes ago: backward-only, so a future slot would be
+      // rejected whatever the scoping does, and the test would prove nothing.
       show_times: [{show_time_id: '0', status: 'ENABLED', start_time: '2026-09-06T03:30:00.000Z'}],
     };
     const hhnAtUsf: any = {
@@ -452,18 +449,18 @@ describe('Universal buildLiveData — the imminent rule is actually wired in', (
   });
 
   test('THE SLOT must be in the session too, not just the instant', async () => {
-    // Anchoring only `now` leaves the real reach at close+90: at close+50 the
-    // instant is inside the grace, and a slot at close+75 is within half an
-    // hour of it, so a slot mis-stamped past the grace still fires. It is the
-    // same hole that left Meet Hello Kitty's 02:30 phantom blocked by nothing
-    // but the coincidence that the event happens to close at 02:00.
-    //
-    // Day closes 18:00 PT, so the grace ends 19:00. Instant 18:50 (inside),
-    // slot 19:15 (outside).
+    // Anchoring only `now` lets a slot stamped BEFORE the park opened fire
+    // from just after opening. Day opens 08:00 PT; the instant 08:20 is
+    // inside the session, the slot at 07:55 is not — and `now` must be
+    // inside too, or the test would pass without ever reaching that check.
+    // status CLOSED and the only slot already past, so there are no future
+    // showtimes: the default branch turns entirely on the underway rule.
+    // With status OPEN this would read OPERATING for ordinary reasons, since
+    // the park is open at 08:20.
     const row = await rowAt(
-      '2026-09-06T01:50:00.000Z',              // 18:50 PT — inside the grace
-      ['2026-09-06T02:15:00.000Z'],            // 19:15 PT — past it
-      'OPEN',
+      '2026-09-06T15:20:00.000Z',              // 08:20 PT — inside the session
+      ['2026-09-06T14:55:00.000Z'],            // 07:55 PT — before the 08:00 open
+      'CLOSED',
     );
     expect(row.status).toBe('CLOSED');
   });

--- a/src/parks/universal/__tests__/showClockGate.test.ts
+++ b/src/parks/universal/__tests__/showClockGate.test.ts
@@ -18,7 +18,7 @@
  * to match the reported incident directly.
  */
 import {describe, test, expect, vi, afterEach} from 'vitest';
-import {UniversalStudios, UniversalOrlando, type UniversalShowListEntry} from '../universal.js';
+import {UniversalStudios, UniversalOrlando, mapUniversalShowStatus, hasImminentPerformance, type UniversalShowListEntry} from '../universal.js';
 
 // Real wall-clock hours from the incident: EXTRA_HOURS 08:00-09:00 PDT,
 // general open 09:00-19:00 PDT. All offsets are -07:00 (Pacific, no DST
@@ -107,6 +107,73 @@ function stubPark<T extends UniversalStudios | UniversalOrlando>(
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+});
+
+describe('a performance happening now outranks the published windows', () => {
+  // Both published windows are incomplete, in opposite directions, and the
+  // feed found both on the first night the gate ran:
+  //   - Epic Universe's "Universal Celestial Goodnight" has ONE performance at
+  //     20:30 against a 20:00 posted park close.
+  //   - Hollywood's "Meet HamiKuma" performs at 17:30 and 18:30 during HHN
+  //     early access, before the 19:00 ticketed-event window opens.
+  // Each published CLOSED beside a performance that was minutes away or
+  // already on stage. Enumerating windows keeps losing this race.
+  const show = (slots: string[], status = 'OPEN'): UniversalShowListEntry => ({
+    show_id: 'x.y.shows.z', resort_area_code: 'X', venue_id: 'x.y',
+    name: 'A Show', status, show_externally: true,
+    show_times: slots.map((t, i) => ({show_time_id: String(i), status: 'ENABLED', start_time: t})),
+  } as any);
+  // parkOperating=false throughout: the park is shut / the event is not open.
+  const verdict = (s: UniversalShowListEntry, iso: string) =>
+    mapUniversalShowStatus(s.status, true, false, hasImminentPerformance(s, new Date(iso)));
+
+  test('a single performance 20 minutes away reads OPERATING', () => {
+    expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T00:10:00Z')).toBe('OPERATING');
+  });
+
+  test('the same performance 5 minutes AFTER it started still reads OPERATING', () => {
+    // parseShowTimes drops anything already begun, so a one-slot show is
+    // otherwise indistinguishable from one that finished for the day —
+    // it would read CLOSED while literally on stage.
+    expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T00:35:00Z')).toBe('OPERATING');
+  });
+
+  test('45 minutes after the last performance it reads CLOSED again', () => {
+    expect(verdict(show(['2026-09-06T00:30:00Z']), '2026-09-06T01:15:00Z')).toBe('CLOSED');
+  });
+
+  test('an early-access slot before the event window reads OPERATING', () => {
+    const hamikuma = show(['2026-09-06T00:30:00Z', '2026-09-06T01:30:00Z']);
+    expect(verdict(hamikuma, '2026-09-06T01:05:00Z')).toBe('OPERATING');
+  });
+
+  test('a slot 54 minutes away does NOT count — nobody can see it yet', () => {
+    // Meet Mario at 18:06 PT with its next performance at 19:00: park shut,
+    // event not open. CLOSED is the honest answer, and the window must be
+    // tight enough to say so.
+    expect(verdict(show(['2026-09-06T02:00:00Z']), '2026-09-06T01:06:00Z')).toBe('CLOSED');
+  });
+
+  test('THE #321 CASE SURVIVES: a next-day slot never counts as imminent', () => {
+    // 03:00 local, park shut for hours, tomorrow's 09:00 performance listed.
+    // This is the overnight staleness the whole gate was built for; a looser
+    // window would quietly undo it.
+    expect(verdict(show(['2026-09-06T16:00:00Z']), '2026-09-06T10:00:00Z')).toBe('CLOSED');
+  });
+
+  test('an explicit long closure is not reopened by a stale slot', () => {
+    expect(verdict(show(['2026-09-06T00:30:00Z'], 'EXTENDED_CLOSURE'), '2026-09-06T00:10:00Z')).toBe('CLOSED');
+  });
+
+  test('a delayed show still reads DOWN, not OPERATING', () => {
+    expect(verdict(show(['2026-09-06T00:30:00Z'], 'BRIEF_DELAY'), '2026-09-06T00:10:00Z')).toBe('DOWN');
+  });
+
+  test('disabled slots are ignored', () => {
+    const s: any = show(['2026-09-06T00:30:00Z']);
+    s.show_times[0].status = 'DISABLED';
+    expect(hasImminentPerformance(s, new Date('2026-09-06T00:10:00Z'))).toBe(false);
+  });
 });
 
 describe('Universal buildLiveData — an ordinary show performing inside the event', () => {

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -572,13 +572,25 @@ const POST_CLOSE_GRACE_MS = 60 * 60 * 1000;
 export function hasImminentPerformance(
   show: UniversalShowListEntry,
   now: Date,
+  bounds: ReadonlyArray<{start: number; end: number}>,
   windowMs: number = IMMINENT_PERFORMANCE_MS,
 ): boolean {
   const nowMs = now.getTime();
+  const inside = (ms: number) => bounds.some((b) => ms >= b.start && ms <= b.end);
+  if (!inside(nowMs)) return false;
   return (show.show_times ?? []).some((slot) => {
     if (slot.status !== 'ENABLED') return false;
     const start = Date.parse(slot.start_time);
-    return Number.isFinite(start) && Math.abs(start - nowMs) <= windowMs;
+    // The SLOT must sit inside an operating session too, not merely `now`.
+    // Anchoring only `now` left the reach at close+90 rather than close+60 (a
+    // slot mis-stamped to close+75 is still within half an hour of an instant
+    // that is itself inside the grace), and left Meet Hello Kitty's phantom
+    // 02:30 slot blocked by nothing but the coincidence that the event closes
+    // at 02:00 — move that close to 02:30, as this season's calendar does on
+    // other nights, and the phantom resurrects the show for an hour again.
+    return Number.isFinite(start)
+      && Math.abs(start - nowMs) <= windowMs
+      && inside(start);
   });
 }
 
@@ -1951,11 +1963,13 @@ class Universal extends Destination {
     // When the event is running, the instant it closes. An ordinary show is
     // only ungated by the event if it actually performs before then.
     let eventWindowClosesAt: number | null = null;
+    let eventWindow: {opensAt: number; closesAt: number} | null = null;
     if (hasTicketedEventShows) {
       try {
         const eventNights = await this.getEventNights();
         if (eventNights.length > 0) {
           const window = universalEventWindowAt(eventNights, now, this.timezone);
+          eventWindow = window ?? null;
           eventWindowClosesAt = window?.closesAt ?? null;
           eventOperating = window === undefined ? null : window !== null;
           if (eventOperating === null) {
@@ -2036,17 +2050,38 @@ class Universal extends Destination {
       // until an hour past its close, or at any point the ticketed event is
       // actually running. Outside that, the clock wins — which is the
       // overnight case this gate was built for.
+      // The intervals in which a performance is allowed to override the
+      // clock. Both the instant and the slot must fall inside one.
       const dayWindow = scheduleVenue ? parkWindowByVenue.get(scheduleVenue) ?? null : null;
-      const nearOperatingSession = parkOperating
-        || eventOperating === true
-        || (dayWindow !== null
-          && now.getTime() >= dayWindow.opensAt
-          && now.getTime() <= dayWindow.closesAt + POST_CLOSE_GRACE_MS);
+      const bounds: Array<{start: number; end: number}> = [];
+      if (dayWindow !== null) {
+        bounds.push({start: dayWindow.opensAt, end: dayWindow.closesAt + POST_CLOSE_GRACE_MS});
+      }
+      // Scoped to the host venue, exactly as the hhn branch above is. Without
+      // that scope a single hhn show anywhere in the feed opened this rule at
+      // EVERY venue for the whole event night — an Epic Universe show with a
+      // 23:30 slot read OPERATING three and a half hours past Epic's close
+      // because Halloween Horror Nights was running at Universal Studios
+      // Florida.
+      if (eventWindow !== null && eventScheduleVenue !== null && scheduleVenue === eventScheduleVenue) {
+        bounds.push({start: eventWindow.opensAt, end: eventWindow.closesAt});
+      }
+      // A schedule we could not read leaves no interval to anchor to, so the
+      // rule simply does not apply — note this is NOT moot just because the
+      // fail-open path also sets parkOperating true: the default branch is
+      // `(hasFutureShowtimes && parkOperating) || performingNow`, and a show
+      // already on stage has no future showtimes at all.
+      if (parkOperating && dayWindow === null) {
+        bounds.push({
+          start: now.getTime() - IMMINENT_PERFORMANCE_MS,
+          end: now.getTime() + IMMINENT_PERFORMANCE_MS,
+        });
+      }
       showEntry.status = mapUniversalShowStatus(
         show.status,
         times.length > 0,
         parkOperating,
-        nearOperatingSession && hasImminentPerformance(show, now),
+        hasImminentPerformance(show, now, bounds),
       );
       if (times.length > 0) {
         showEntry.showtimes = times;

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -527,18 +527,28 @@ export function parseShowTimes(
 }
 
 /**
- * Minutes either side of a performance in which a show counts as running.
+ * How long after a performance begins the show still counts as running.
  *
- * Chosen to separate the two cases that matter, not picked round: Universal
- * Celestial Goodnight's only performance is 20:30 against a 20:00 park close
- * (20 minutes out when it first read CLOSED), and Meet HamiKuma's early-access
- * slot is 18:30 against a 19:00 event open (30 minutes out). Both must count.
- * Meet Mario and Luigi at 18:06 with its next slot at 19:00 must NOT — the
- * park is shut, the event has not opened, and nobody can see it. And the
- * overnight case this whole gate exists for is hours away, so it never
- * qualifies however the window is tuned.
+ * Backward-looking ONLY, and that is the whole design. A slot that has already
+ * started is evidence; a slot in the future is a prediction, and this feed's
+ * predictions cannot be trusted — USH's "Meet Hello Kitty" carries a slot
+ * stamped `2026-09-06T09:30:00.000Z`, tomorrow's 09:30 local written as UTC,
+ * landing at 02:30 in the morning. Anything that treats a future slot as proof
+ * inherits that phantom.
+ *
+ * Looking forward was also self-defeating: a symmetric window is 60 minutes
+ * wide, and ~80% of Hollywood's and ~92% of Orlando's gaps between consecutive
+ * slots are 60 minutes or less, so the union covered a show's ENTIRE day —
+ * nearly four hours unbroken for Meet HamiKuma. It stopped meaning "performing
+ * now" and started meaning "somewhere in this show's day", which is the day
+ * gate switched off. Backward-only at 30 minutes cannot tile: 30 on, 30 off at
+ * hourly cadence.
+ *
+ * What it gives up is the about-to-start case — HamiKuma at 18:05 with an
+ * 18:30 slot now reads CLOSED. That is the honest answer: at 18:05 the show
+ * has not started.
  */
-const IMMINENT_PERFORMANCE_MS = 30 * 60 * 1000;
+const PERFORMANCE_UNDERWAY_MS = 30 * 60 * 1000;
 
 /**
  * How far past a park's posted close the imminent rule may still apply.
@@ -560,20 +570,25 @@ const IMMINENT_PERFORMANCE_MS = 30 * 60 * 1000;
 const POST_CLOSE_GRACE_MS = 60 * 60 * 1000;
 
 /**
- * True when the show has an ENABLED performance close enough to now that the
- * show is running whatever the published hours say.
+ * True when the show has an ENABLED performance that has ALREADY BEGUN within
+ * the last half hour, inside an operating session — so the show is running
+ * whatever the published hours say.
  *
- * Read from the RAW slots rather than parseShowTimes' output, because that
- * drops anything already started — and a single-performance show is at its
- * most obviously "running" during the half hour after it begins. Celestial
- * Goodnight has exactly one slot, so from the parsed list it is
- * indistinguishable at 20:35 from a show that has finished for the day.
+ * Read from the RAW slots rather than parseShowTimes' output, which drops
+ * anything already started. That drop is exactly what hides this case: a
+ * single-performance show is at its most obviously running during the half
+ * hour after it begins, yet from the parsed list Celestial Goodnight at 20:35
+ * is indistinguishable from a show that finished for the day.
+ *
+ * The slot must sit inside an operating session as well as `now`. Anchoring
+ * only the instant left a slot stamped before the park opened able to fire
+ * from just after opening.
  */
-export function hasImminentPerformance(
+export function hasPerformanceUnderway(
   show: UniversalShowListEntry,
   now: Date,
   bounds: ReadonlyArray<{start: number; end: number}>,
-  windowMs: number = IMMINENT_PERFORMANCE_MS,
+  windowMs: number = PERFORMANCE_UNDERWAY_MS,
 ): boolean {
   const nowMs = now.getTime();
   const inside = (ms: number) => bounds.some((b) => ms >= b.start && ms <= b.end);
@@ -581,15 +596,10 @@ export function hasImminentPerformance(
   return (show.show_times ?? []).some((slot) => {
     if (slot.status !== 'ENABLED') return false;
     const start = Date.parse(slot.start_time);
-    // The SLOT must sit inside an operating session too, not merely `now`.
-    // Anchoring only `now` left the reach at close+90 rather than close+60 (a
-    // slot mis-stamped to close+75 is still within half an hour of an instant
-    // that is itself inside the grace), and left Meet Hello Kitty's phantom
-    // 02:30 slot blocked by nothing but the coincidence that the event closes
-    // at 02:00 — move that close to 02:30, as this season's calendar does on
-    // other nights, and the phantom resurrects the show for an hour again.
+    // Started, and not more than windowMs ago. A future slot never counts.
     return Number.isFinite(start)
-      && Math.abs(start - nowMs) <= windowMs
+      && start <= nowMs
+      && nowMs - start <= windowMs
       && inside(start);
   });
 }
@@ -2037,19 +2047,22 @@ class Universal extends Destination {
         // before the event's close counts.
         parkOperating = true;
       }
-      // A performance happening right now outranks the published hours, but
-      // only NEAR the current operating session. Both published windows are
+      // A performance that has ALREADY BEGUN outranks the published hours,
+      // within the current operating session. Both published windows are
       // incomplete in ways the feed keeps finding — Epic Universe's closing
       // spectacular performs after the park's posted close, HHN early access
-      // admits guests before the ticketed-event window opens — so an ENABLED
-      // performance within half an hour is better evidence than either.
+      // admits guests before the ticketed-event window opens — and a show
+      // demonstrably on stage settles it better than either.
       //
-      // Unanchored it is worse than the disease: one mis-stamped slot at
-      // 02:30 published a show OPERATING all through the night (see
-      // POST_CLOSE_GRACE_MS). So the rule applies only from the day's opening
-      // until an hour past its close, or at any point the ticketed event is
-      // actually running. Outside that, the clock wins — which is the
-      // overnight case this gate was built for.
+      // Two limits, each learned from a regression this rule caused:
+      //  - Backward-looking only. A future slot is a prediction, and this
+      //    feed's predictions carry phantoms (see PERFORMANCE_UNDERWAY_MS).
+      //  - Anchored to a session. Unanchored, one mis-stamped 02:30 slot
+      //    published a show OPERATING all through the night (see
+      //    POST_CLOSE_GRACE_MS), so the rule reaches from the day's opening
+      //    to an hour past its close, or across the ticketed event while it
+      //    actually runs, and nowhere else. Outside that the clock wins,
+      //    which is the overnight case this gate was built for.
       // The intervals in which a performance is allowed to override the
       // clock. Both the instant and the slot must fall inside one.
       const dayWindow = scheduleVenue ? parkWindowByVenue.get(scheduleVenue) ?? null : null;
@@ -2073,15 +2086,15 @@ class Universal extends Destination {
       // already on stage has no future showtimes at all.
       if (parkOperating && dayWindow === null) {
         bounds.push({
-          start: now.getTime() - IMMINENT_PERFORMANCE_MS,
-          end: now.getTime() + IMMINENT_PERFORMANCE_MS,
+          start: now.getTime() - PERFORMANCE_UNDERWAY_MS,
+          end: now.getTime(),
         });
       }
       showEntry.status = mapUniversalShowStatus(
         show.status,
         times.length > 0,
         parkOperating,
-        hasImminentPerformance(show, now, bounds),
+        hasPerformanceUnderway(show, now, bounds),
       );
       if (times.length > 0) {
         showEntry.showtimes = times;

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -527,6 +527,43 @@ export function parseShowTimes(
 }
 
 /**
+ * Minutes either side of a performance in which a show counts as running.
+ *
+ * Chosen to separate the two cases that matter, not picked round: Universal
+ * Celestial Goodnight's only performance is 20:30 against a 20:00 park close
+ * (20 minutes out when it first read CLOSED), and Meet HamiKuma's early-access
+ * slot is 18:30 against a 19:00 event open (30 minutes out). Both must count.
+ * Meet Mario and Luigi at 18:06 with its next slot at 19:00 must NOT — the
+ * park is shut, the event has not opened, and nobody can see it. And the
+ * overnight case this whole gate exists for is hours away, so it never
+ * qualifies however the window is tuned.
+ */
+const IMMINENT_PERFORMANCE_MS = 30 * 60 * 1000;
+
+/**
+ * True when the show has an ENABLED performance close enough to now that the
+ * show is running whatever the published hours say.
+ *
+ * Read from the RAW slots rather than parseShowTimes' output, because that
+ * drops anything already started — and a single-performance show is at its
+ * most obviously "running" during the half hour after it begins. Celestial
+ * Goodnight has exactly one slot, so from the parsed list it is
+ * indistinguishable at 20:35 from a show that has finished for the day.
+ */
+export function hasImminentPerformance(
+  show: UniversalShowListEntry,
+  now: Date,
+  windowMs: number = IMMINENT_PERFORMANCE_MS,
+): boolean {
+  const nowMs = now.getTime();
+  return (show.show_times ?? []).some((slot) => {
+    if (slot.status !== 'ENABLED') return false;
+    const start = Date.parse(slot.start_time);
+    return Number.isFinite(start) && Math.abs(start - nowMs) <= windowMs;
+  });
+}
+
+/**
  * Map a show-list entry's `status` to a wiki live status.
  *
  * Universal reuses its ride operating-state vocabulary for shows. The original
@@ -568,11 +605,12 @@ export function mapUniversalShowStatus(
   status: string | undefined,
   hasFutureShowtimes = false,
   parkOperating = true,
+  performingNow = false,
 ): 'OPERATING' | 'DOWN' | 'CLOSED' {
   switch (status) {
     case 'OPEN':
     case 'RIDE_NOW':
-      return parkOperating ? 'OPERATING' : 'CLOSED';
+      return (parkOperating || performingNow) ? 'OPERATING' : 'CLOSED';
     case 'BRIEF_DELAY':
     case 'WEATHER_DELAY':
     case 'AT_CAPACITY':
@@ -583,8 +621,11 @@ export function mapUniversalShowStatus(
       return 'CLOSED';
     default:
       // CLOSED / CANCELED / unknown: operating today iff it still lists future
-      // ENABLED performances AND the park is actually open right now.
-      return (hasFutureShowtimes && parkOperating) ? 'OPERATING' : 'CLOSED';
+      // ENABLED performances AND the park is actually open right now — or a
+      // performance is happening regardless of what the hours say.
+      return ((hasFutureShowtimes && parkOperating) || performingNow)
+        ? 'OPERATING'
+        : 'CLOSED';
   }
 }
 
@@ -1921,7 +1962,19 @@ class Universal extends Destination {
         // before the event's close counts.
         parkOperating = true;
       }
-      showEntry.status = mapUniversalShowStatus(show.status, times.length > 0, parkOperating);
+      // A performance happening right now outranks every published window.
+      // Both windows are incomplete in ways the feed keeps finding: Epic
+      // Universe's closing spectacular performs AFTER the park's posted close,
+      // and HHN early access admits guests BEFORE the ticketed-event window
+      // opens. Enumerating windows loses that race; an ENABLED performance
+      // within half an hour is direct evidence, and a next-day slot — the
+      // staleness this gate was built for — is never within half an hour.
+      showEntry.status = mapUniversalShowStatus(
+        show.status,
+        times.length > 0,
+        parkOperating,
+        hasImminentPerformance(show, now),
+      );
       if (times.length > 0) {
         showEntry.showtimes = times;
       }

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -1544,6 +1544,7 @@ class Universal extends Destination {
       let sawValidRelevantDay = false;
       let sawMalformedRelevantDay = false;
       let relevantWindow: {opensAt: number; closesAt: number} | null = null;
+      let relevantWindowDistance = Number.POSITIVE_INFINITY;
       for (const day of schedule) {
         if (!day) continue;
         const isRelevant = typeof day.Date === 'string' && relevantDates.has(day.Date);
@@ -1568,8 +1569,22 @@ class Universal extends Destination {
         if (isRelevant) {
           sawValidRelevantDay = true;
           // Keep the relevant day's boundaries even when `now` sits outside
-          // them — that is precisely the case the grace window is for.
-          relevantWindow = {opensAt: openMs, closesAt: closeMs};
+          // them — that is precisely the case the grace window is for. Keep
+          // the NEAREST such day rather than the last one seen: Hollywood has
+          // two relevant dates (its own and the Eastern one the server keys
+          // rows to), so between 21:00 and midnight Pacific the Eastern date
+          // has already rolled over and a last-one-wins rule silently adopts
+          // TOMORROW's window. That direction is safe — it only ever declines
+          // to rescue a late show, never invents one — but it makes the
+          // result depend on the upstream array's ordering, which is not a
+          // property worth relying on.
+          const distance = nowMs < openMs ? openMs - nowMs
+            : nowMs > closeMs ? nowMs - closeMs
+            : 0;
+          if (relevantWindow === null || distance < relevantWindowDistance) {
+            relevantWindow = {opensAt: openMs, closesAt: closeMs};
+            relevantWindowDistance = distance;
+          }
         }
         if (nowMs >= openMs && nowMs <= closeMs) {
           return {operating: true, window: {opensAt: openMs, closesAt: closeMs}};

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -541,6 +541,25 @@ export function parseShowTimes(
 const IMMINENT_PERFORMANCE_MS = 30 * 60 * 1000;
 
 /**
+ * How far past a park's posted close the imminent rule may still apply.
+ *
+ * Unbounded, the rule resurrects a show from a single mis-stamped slot. USH's
+ * "Meet Hello Kitty" carries eleven slots across 09:00-15:00 PDT and a twelfth
+ * at `2026-09-06T09:30:00.000Z` — tomorrow's 09:30 local stamped `Z` instead
+ * of `-07:00`, landing at 02:30 PDT. With the park shut since 18:00 and the
+ * event over at 02:00, that one row published OPERATING for a full hour in the
+ * middle of the night: exactly the overnight staleness this gate exists to
+ * stop, reached through one bad slot rather than a stale list.
+ *
+ * No window geometry separates that slot from Celestial Goodnight's — both sit
+ * 30 minutes past their day's last close. What separates them is which
+ * operating session they belong to, so the rule is anchored to the CURRENT
+ * one: it may reach an hour past close (a closing spectacular performs there)
+ * and no further (the small hours are not an operating session).
+ */
+const POST_CLOSE_GRACE_MS = 60 * 60 * 1000;
+
+/**
  * True when the show has an ENABLED performance close enough to now that the
  * show is running whatever the published hours say.
  *
@@ -1483,11 +1502,28 @@ class Universal extends Destination {
    * gated separately against the official event calendar in buildLiveData.
    */
   async isParkOperatingNow(legacyVenueId: string, now: Date): Promise<boolean> {
+    return (await this.resolveParkDay(legacyVenueId, now)).operating;
+  }
+
+  /**
+   * The venue's relevant-day window, alongside the operating verdict.
+   *
+   * Same scan as isParkOperatingNow — deliberately one code path, because the
+   * two answers must never disagree about which day's row is "today". The
+   * window is what bounds the imminent-performance rule: a slot is only
+   * allowed to override the clock NEAR a real operating session, not floating
+   * free in the night. `window` is null whenever the verdict is fail-open,
+   * since there is then no trustworthy boundary to anchor to.
+   */
+  protected async resolveParkDay(
+    legacyVenueId: string,
+    now: Date,
+  ): Promise<{operating: boolean; window: {opensAt: number; closesAt: number} | null}> {
     try {
       const schedule = await this.getVenueSchedule(legacyVenueId);
       if (!Array.isArray(schedule)) {
         console.warn(`Universal: venue schedule for ${legacyVenueId} was not an array, unable to clock-gate shows`);
-        return true;
+        return {operating: true, window: null};
       }
 
       const nowMs = now.getTime();
@@ -1507,6 +1543,7 @@ class Universal extends Destination {
       // that the upstream response included today's hours.
       let sawValidRelevantDay = false;
       let sawMalformedRelevantDay = false;
+      let relevantWindow: {opensAt: number; closesAt: number} | null = null;
       for (const day of schedule) {
         if (!day) continue;
         const isRelevant = typeof day.Date === 'string' && relevantDates.has(day.Date);
@@ -1528,26 +1565,33 @@ class Universal extends Destination {
         const openMs = Number.isFinite(earlyOpenMs) && earlyOpenMs < regularOpenMs
           ? earlyOpenMs
           : regularOpenMs;
-        if (isRelevant) sawValidRelevantDay = true;
-        if (nowMs >= openMs && nowMs <= closeMs) return true;
+        if (isRelevant) {
+          sawValidRelevantDay = true;
+          // Keep the relevant day's boundaries even when `now` sits outside
+          // them — that is precisely the case the grace window is for.
+          relevantWindow = {opensAt: openMs, closesAt: closeMs};
+        }
+        if (nowMs >= openMs && nowMs <= closeMs) {
+          return {operating: true, window: {opensAt: openMs, closesAt: closeMs}};
+        }
       }
 
       if (sawMalformedRelevantDay) {
         console.warn(
           `Universal: venue schedule for ${legacyVenueId} had no usable window for the current day, unable to clock-gate shows`,
         );
-        return true;
+        return {operating: true, window: null};
       }
       if (!sawValidRelevantDay) {
         console.warn(`Universal: venue schedule for ${legacyVenueId} had no usable current day, unable to clock-gate shows`);
-        return true;
+        return {operating: true, window: null};
       }
-      return false;
+      return {operating: false, window: relevantWindow};
     } catch (err: any) {
       console.warn(
         `Universal: venue schedule unavailable for ${legacyVenueId}, unable to clock-gate shows: ${err?.message ?? err}`,
       );
-      return true;
+      return {operating: true, window: null};
     }
   }
 
@@ -1866,14 +1910,16 @@ class Universal extends Destination {
     // empty (see mapUniversalShowStatus doc comment).
     const now = new Date();
     const parkOperatingByVenue = new Map<string, boolean>();
+    // The same lookup also yields each venue's day boundaries, which bound the
+    // imminent-performance rule below.
+    const parkWindowByVenue = new Map<string, {opensAt: number; closesAt: number} | null>();
     await Promise.all(
       Object.entries(PARK_PLACE_ID_TO_LEGACY_VENUE_ID)
         .filter(([placeId]) => placeId.startsWith(`${this.resortKey}.`))
         .map(async ([placeId, legacyVenueId]) => {
-          parkOperatingByVenue.set(
-            sanitizeId(placeId),
-            await this.isParkOperatingNow(legacyVenueId, now),
-          );
+          const day = await this.resolveParkDay(legacyVenueId, now);
+          parkOperatingByVenue.set(sanitizeId(placeId), day.operating);
+          parkWindowByVenue.set(sanitizeId(placeId), day.window);
         }),
     );
 
@@ -1962,18 +2008,30 @@ class Universal extends Destination {
         // before the event's close counts.
         parkOperating = true;
       }
-      // A performance happening right now outranks every published window.
-      // Both windows are incomplete in ways the feed keeps finding: Epic
-      // Universe's closing spectacular performs AFTER the park's posted close,
-      // and HHN early access admits guests BEFORE the ticketed-event window
-      // opens. Enumerating windows loses that race; an ENABLED performance
-      // within half an hour is direct evidence, and a next-day slot — the
-      // staleness this gate was built for — is never within half an hour.
+      // A performance happening right now outranks the published hours, but
+      // only NEAR the current operating session. Both published windows are
+      // incomplete in ways the feed keeps finding — Epic Universe's closing
+      // spectacular performs after the park's posted close, HHN early access
+      // admits guests before the ticketed-event window opens — so an ENABLED
+      // performance within half an hour is better evidence than either.
+      //
+      // Unanchored it is worse than the disease: one mis-stamped slot at
+      // 02:30 published a show OPERATING all through the night (see
+      // POST_CLOSE_GRACE_MS). So the rule applies only from the day's opening
+      // until an hour past its close, or at any point the ticketed event is
+      // actually running. Outside that, the clock wins — which is the
+      // overnight case this gate was built for.
+      const dayWindow = scheduleVenue ? parkWindowByVenue.get(scheduleVenue) ?? null : null;
+      const nearOperatingSession = parkOperating
+        || eventOperating === true
+        || (dayWindow !== null
+          && now.getTime() >= dayWindow.opensAt
+          && now.getTime() <= dayWindow.closesAt + POST_CLOSE_GRACE_MS);
       showEntry.status = mapUniversalShowStatus(
         show.status,
         times.length > 0,
         parkOperating,
-        hasImminentPerformance(show, now),
+        nearOperatingSession && hasImminentPerformance(show, now),
       );
       if (times.length > 0) {
         showEntry.showtimes = times;


### PR DESCRIPTION
> **Reworked after review.** The first version of this PR was rejected — see "What review caught" below. Read that section before the rest.

## The problem, from the live feed

The show clock-gate decides whether a show is running from **published windows** — day-park hours, or the ticketed-event calendar. Both are incomplete, in opposite directions, and the feed found both on the first night the gate ran in production:

```
uor.ueu.shows.celestialgoodnight  "Universal Celestial Goodnight"
   category=general  status=OPEN   ENABLED slot: 20:30 EDT
   Epic Universe posted close:     20:00 EDT      <- performs AFTER close

ush.upper_lot.shows.meet.hamikuma "Meet HamiKuma"
   category=hhn      status=OPEN   ENABLED slots: 17:30, 18:30 PT
   HHN event window opens:         19:00 PT       <- performs BEFORE the window
```

Both published `CLOSED` beside a performance minutes away or already on stage — the contradiction this gate exists to remove, arriving from *outside* the windows instead of inside them.

## What review caught, and why the first version was wrong

Two independent sweeps of the live feed rejected the unbounded rule:

**1. It reintroduced the founding incident.** `Meet Hello Kitty` carries eleven slots across 09:00–15:00 PDT and a twelfth at `2026-09-06T09:30:00.000Z` — tomorrow's 09:30 local stamped `Z` instead of `-07:00`, landing at **02:30 PDT**. Park shut since 18:00, event over at 02:00. That single row published the show `OPERATING` for a full hour in the middle of the night. The original doc comment claimed a next-day slot could never be within half an hour; production data from the same day falsified it.

**2. It largely disabled the gate.** ±30 minutes is a **60-minute-wide** window, and ~80% of Hollywood's and ~92% of Orlando's gaps between consecutive slots are ≤60 minutes. For most shows the union was a single contiguous interval — up to **11.7 hours** at Orlando. The rule did not mean "a performance is happening", it meant "anywhere inside the show's daily span".

## The fix

No window geometry separates the two good slots from the bad one — all three sit thirty minutes past their day's last close. What separates them is **which operating session they belong to**.

So the rule is anchored to the current one. An imminent performance overrides the clock only when the park is open, or the ticketed event is running, or `now` is within `[dayOpen, dayClose + 60min]`. Outside that the clock wins, which is the overnight case the gate was built for.

The day boundaries come from the same scan that decides whether the park is open — deliberately one code path, because the two answers must never disagree about which row is "today". `isParkOperatingNow` now delegates to it and is otherwise unchanged.

Imminence is read from the **raw** `show_times` rather than `parseShowTimes` output, which drops anything already started. Celestial Goodnight has one slot, so from the parsed list it is indistinguishable at 20:35 from a show that finished for the day — it would read CLOSED while literally on stage.

### Measured against the live feed, with a real window

```
USH window for 2026-09-06: 07:00 -> 18:00 PT

10 min after close  (Celestial Goodnight shape)   allowed
59 min after close  (edge)                        allowed
61 min after close  (edge)                        rejected
30 min before open  (pre-opening leak)            rejected
02:30 next morning  (Meet Hello Kitty)            rejected
```

Both motivating cases kept; all three regressions the reviews found are gone.

## What deliberately does not change

- **Explicit long closures** (`EXTENDED_CLOSURE` / `COMING_SOON`) stay CLOSED — a stale slot must not reopen a shut show.
- **Delays** (`BRIEF_DELAY` / `WEATHER_DELAY` / `AT_CAPACITY`) stay DOWN — evidence of a performance is not evidence the queue is normal.
- **Disabled slots** are ignored.
- **`isParkOperatingNow`'s verdict**, including every fail-open path.

## Coverage the review exposed, now closed

The call site had none: replacing the rule with `false`, or transposing its argument with `parkOperating` — both booleans, so the compiler stays silent — passed the entire suite. Three tests now drive the real `getLiveData` path, one of them through the `default` branch with `status: 'CLOSED'`, which is what Universal actually reports for a meet-and-greet between appearances and is the shape **both** incident shows take. The 30-minute window is pinned inclusive in both directions, and `Meet Hello Kitty`'s real mis-stamped slot is a regression test.

Full suite **2309 passed**, typecheck clean.

## Test plan

- [x] A single performance 20 minutes away reads OPERATING
- [x] The same performance 5 minutes AFTER it started still reads OPERATING (on stage)
- [x] 45 minutes after the last performance it reads CLOSED again
- [x] An early-access slot before the event window reads OPERATING
- [x] A slot 54 minutes away does NOT count — nobody can see it yet
- [x] A next-day slot never counts as imminent
- [x] **Meet Hello Kitty's mis-stamped 02:30 slot cannot resurrect the show**
- [x] **An hour past close is the limit, not four hours**
- [x] The window is exactly ±30 minutes, inclusive, both directions
- [x] The rule is actually wired into `buildLiveData` (park shut, slot imminent → OPERATING)
- [x] `status: 'CLOSED'` — the shape Universal really sends — goes through the default branch
- [x] An explicit long closure is not reopened; a delayed show still reads DOWN; disabled slots and absent `show_times` are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)