### PR TITLE
feat(universal): read HHN early access and publish it as its own entry

### DIFF
--- a/src/parks/universal/__tests__/hhnSchedule.test.ts
+++ b/src/parks/universal/__tests__/hhnSchedule.test.ts
@@ -68,7 +68,7 @@ describe("parseUniversalEventCalendar", () => {
     });
   });
 
-  test("finds Hollywood's bounded event window after its early-access block", () => {
+  test("reads the early-access time as well as the bounded event window", () => {
     const hollywood = {
       ComponentPresentations: [{
         Component: {
@@ -118,6 +118,7 @@ describe("parseUniversalEventCalendar", () => {
       openingTime: "19:00",
       closingTime: "01:00",
       closesNextDay: true,
+      earlyAccessTime: "17:30",
     }]);
   });
 
@@ -655,5 +656,100 @@ describe("event calendar fetch discipline", () => {
       console.warn = original;
     }
     expect(warnings.join("\n")).toMatch(/event calendar unavailable/i);
+  });
+});
+
+describe('early access is read and published separately', () => {
+  // Hollywood's calendar carries three block shapes in a date group, and only
+  // a time pattern tells them apart:
+  //   heading='… Early Access'      eyebrow='5:30pm'             <- a lone TIME
+  //   heading='Halloween Horror …'  eyebrow='7:00 PM - 2:00 AM'  <- a RANGE
+  //   heading='No Event Today'      eyebrow='Halloween Horror …' <- NO time
+  // The parser required a range and skipped the rest, discarding early access
+  // and "No Event Today" alike — right for the second, wrong for the first.
+  const group = (blocks: any[], dates = ["2026-09-05T00:00:00"]) => ({
+    ComponentPresentations: [{
+      Component: {
+        Schema: {RootElementName: "GDSCalendar"},
+        Fields: {calendarData: {LinkedComponentValues: [{Fields: {calendarConfig: {
+          EmbeddedValues: [{
+            eventDates: {DateTimeValues: dates},
+            blockData: {LinkedComponentValues: [{Fields: {blocksData: {
+              LinkedComponentValues: blocks.map((b) => ({Fields: {
+                heading: {Values: [b.heading]}, eyebrow: {Values: [b.eyebrow]},
+              }})),
+            }}}]},
+          }],
+        }}}]}},
+      },
+    }],
+  });
+
+  test("a lone time is read as early access, the range stays the event", () => {
+    const [night] = parseUniversalEventCalendar(group([
+      {heading: "Halloween Horror Nights Early Access", eyebrow: "5:30pm"},
+      {heading: "Halloween Horror Nights", eyebrow: "7:00 PM - 2:00 AM"},
+    ]));
+    expect(night.openingTime).toBe("19:00");      // the advertised start, unchanged
+    expect(night.earlyAccessTime).toBe("17:30");
+    expect(night.closingTime).toBe("02:00");
+  });
+
+  test('"No Event Today" is still discarded — it has no time at all', () => {
+    // The skip this change had to preserve: a block with no hours is not an
+    // event, and must not become a night.
+    expect(parseUniversalEventCalendar(group([
+      {heading: "No Event Today", eyebrow: "Halloween Horror Nights"},
+    ]))).toEqual([]);
+  });
+
+  test("a lone time with no event block creates no night", () => {
+    // Early access alone cannot invent an event: the range is what makes a
+    // night, and the early time only rides along on one.
+    expect(parseUniversalEventCalendar(group([
+      {heading: "Halloween Horror Nights Early Access", eyebrow: "5:30pm"},
+    ]))).toEqual([]);
+  });
+
+  test("a lone time at or after the opening is not early access", () => {
+    const [night] = parseUniversalEventCalendar(group([
+      {heading: "Something", eyebrow: "9:00pm"},
+      {heading: "Halloween Horror Nights", eyebrow: "7:00 PM - 2:00 AM"},
+    ]));
+    expect(night.earlyAccessTime).toBeUndefined();
+  });
+
+  test("a range in the same block cannot be read as a lone time", () => {
+    // The pre-pass skips any block carrying a range, so the event block's own
+    // labels can never supply an early-access time. Without that guard a block
+    // holding both shapes would take its early time from itself.
+    const [night] = parseUniversalEventCalendar(group([
+      {heading: "5:30pm", eyebrow: "7:00 PM - 2:00 AM"},
+    ]));
+    expect(night?.earlyAccessTime).toBeUndefined();
+  });
+
+  test("THE POINT OF THIS CHANGE: the gate admits from early access", () => {
+    // An hhn-tagged show is gated on the event calendar, so before this the
+    // 19:00 window made a 17:30 performance read CLOSED while it ran. The
+    // window used for gating now opens at admission.
+    const nights = parseUniversalEventCalendar(group([
+      {heading: "Halloween Horror Nights Early Access", eyebrow: "5:30pm"},
+      {heading: "Halloween Horror Nights", eyebrow: "7:00 PM - 2:00 AM"},
+    ]));
+    const tz = "America/Los_Angeles";
+    const at = (iso: string) => isUniversalEventOperatingNow(nights, new Date(iso), tz);
+    expect(at("2026-09-06T00:20:00.000Z")).toBe(false); // 17:20 PT — before admission
+    expect(at("2026-09-06T00:40:00.000Z")).toBe(true);  // 17:40 PT — early access
+    expect(at("2026-09-06T03:00:00.000Z")).toBe(true);  // 20:00 PT — main event
+    expect(at("2026-09-06T10:00:00.000Z")).toBe(false); // 03:00 PT — closed
+  });
+
+  test("block order does not matter", () => {
+    const [night] = parseUniversalEventCalendar(group([
+      {heading: "Halloween Horror Nights", eyebrow: "7:00 PM - 2:00 AM"},
+      {heading: "Halloween Horror Nights Early Access", eyebrow: "5:30pm"},
+    ]));
+    expect(night.earlyAccessTime).toBe("17:30");
   });
 });

--- a/src/parks/universal/universal.ts
+++ b/src/parks/universal/universal.ts
@@ -872,7 +872,14 @@ export function universalEventWindowAt(
     let openingMs: number;
     let closingMs: number;
     try {
-      openingMs = new Date(constructDateTime(night.date, night.openingTime, timezone)).getTime();
+      // Admission, not the advertised start: guests are inside during early
+      // access, so an hhn-tagged show performing then is genuinely running.
+      // The published TICKETED_EVENT window is untouched — early access is a
+      // separate INFO entry in buildSchedules.
+      const admitsFrom = night.earlyAccessTime && night.earlyAccessTime < night.openingTime
+        ? night.earlyAccessTime
+        : night.openingTime;
+      openingMs = new Date(constructDateTime(night.date, admitsFrom, timezone)).getTime();
       const closingDate = night.closesNextDay ? shiftDateString(night.date, 1) : night.date;
       closingMs = new Date(constructDateTime(closingDate, night.closingTime, timezone)).getTime();
     } catch {
@@ -2301,6 +2308,33 @@ class Universal extends Destination {
               type: 'TICKETED_EVENT' as const,
               description: night.name,
             });
+            // Early access as its OWN entry, not by widening the window above.
+            // The event genuinely starts when it advertises; early access is a
+            // separately sold perk, and folding it in would tell every
+            // consumer that general admission begins ninety minutes earlier
+            // than it does. INFO because it is an advertised admission time
+            // rather than the park's own operating hours.
+            //
+            // Its close is inferred from the event's opening — the calendar
+            // block carries a start and no end — so it is only emitted when
+            // that produces a real, forward window.
+            if (night.earlyAccessTime) {
+              try {
+                const earlyOpening = constructDateTime(night.date, night.earlyAccessTime, this.timezone);
+                const earlyMs = new Date(earlyOpening).getTime();
+                if (Number.isFinite(earlyMs) && earlyMs < openingMs) {
+                  schedule.push({
+                    date: night.date,
+                    openingTime: earlyOpening,
+                    closingTime: openingTime,
+                    type: 'INFO' as const,
+                    description: `${night.name} Early Access`,
+                  });
+                }
+              } catch {
+                console.warn(`[${this.constructor.name}] skipping malformed early-access hours for ${placeId} on ${night.date}`);
+              }
+            }
           } catch {
             console.warn(`[${this.constructor.name}] skipping malformed ticketed-event hours for ${placeId} on ${night.date}`);
           }
@@ -2336,6 +2370,17 @@ export interface UniversalEventNight {
   closingTime: string;
   /** True when the close falls on the day after `date`. */
   closesNextDay: boolean;
+  /**
+   * Early admission, HH:mm, when the calendar advertises one — HHN sells
+   * early access ahead of the advertised event start.
+   *
+   * Kept separate from `openingTime` rather than folded into it: the event
+   * genuinely starts when it says it does, and widening the published window
+   * would tell every consumer that general admission begins ninety minutes
+   * early. It is published as its own INFO entry and used to decide whether
+   * guests are actually inside, which are two different questions.
+   */
+  earlyAccessTime?: string;
 }
 
 /**
@@ -2343,6 +2388,26 @@ export interface UniversalEventNight {
  * en dash in others, in the same document, so both are accepted.
  */
 const EVENT_HOURS = /(\d{1,2}):(\d{2})\s*(AM|PM)\s*[-–—]\s*(\d{1,2}):(\d{2})\s*(AM|PM)/i;
+
+/**
+ * A LONE time with no range — "5:30pm" — which is how the calendar advertises
+ * early access.
+ *
+ * A date group carries up to three block shapes, and only these two patterns
+ * tell them apart:
+ *
+ *   heading='Halloween Horror Nights Early Access'  eyebrow='5:30pm'
+ *   heading='Halloween Horror Nights'               eyebrow='7:00 PM - 2:00 AM'
+ *   heading='No Event Today'                        eyebrow='Halloween Horror Nights'
+ *
+ * The parser previously required a RANGE and skipped everything else, which
+ * discarded early access and "No Event Today" alike — correct for the second,
+ * wrong for the first, and the reason an hhn-tagged show performing at 17:30
+ * was gated against a 19:00 window and published CLOSED while it ran.
+ *
+ * Anchored at both ends so it cannot match one half of a range.
+ */
+const EVENT_SINGLE_TIME = /^\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)\s*$/i;
 
 /** 12-hour clock to HH:mm. 12 AM is 00, 12 PM is 12. */
 function to24Hour(hour: string, minute: string, meridiem: string): string {
@@ -2405,6 +2470,23 @@ export function parseUniversalEventCalendar(payload: unknown): UniversalEventNig
       ?.blocksData?.LinkedComponentValues;
     if (!Array.isArray(blocks)) continue;
 
+    // Early access is advertised in its own block, as a lone time, and applies
+    // to every date in the group. Read it first so the event block below can
+    // carry it — the calendar puts early access FIRST and the real window
+    // second, but do not rely on that ordering.
+    let earlyAccessTime: string | undefined;
+    for (const block of blocks) {
+      const fields = block?.Fields;
+      const labels = [tridionValue(fields?.heading), tridionValue(fields?.eyebrow)]
+        .filter((text): text is string => !!text);
+      // Skip anything carrying a RANGE — that is the event block itself.
+      if (labels.some((text) => EVENT_HOURS.test(text))) continue;
+      const lone = labels
+        .map((text) => text.match(EVENT_SINGLE_TIME))
+        .find((match) => match !== null);
+      if (lone) earlyAccessTime = to24Hour(lone[1], lone[2] ?? '00', lone[3]);
+    }
+
     for (const block of blocks) {
       const fields = block?.Fields;
       const heading = tridionValue(fields?.heading);
@@ -2442,6 +2524,13 @@ export function parseUniversalEventCalendar(payload: unknown): UniversalEventNig
           openingTime,
           closingTime,
           closesNextDay: closingTime <= openingTime,
+          // Only when it genuinely precedes the advertised start. A lone time
+          // at or after the opening is not early access, and a group with a
+          // lone time but no range never reaches here at all — the event block
+          // is what creates the night.
+          ...(earlyAccessTime !== undefined && earlyAccessTime < openingTime
+            ? {earlyAccessTime}
+            : {}),
         });
       }
     }


### PR DESCRIPTION
## The gap

Hollywood's Halloween Horror Nights calendar carries three block shapes in a date group, and only a time pattern tells them apart:

```
heading='Halloween Horror Nights Early Access'  eyebrow='5:30pm'             <- a lone TIME
heading='Halloween Horror Nights'               eyebrow='7:00 PM - 2:00 AM'  <- a RANGE
heading='No Event Today'                        eyebrow='Halloween Horror Nights'  <- NO time
```

The parser required a **range** and skipped everything else. That skip is load-bearing — it is how "No Event Today" is excluded rather than published as a night — but it discarded early access along with it. A lone time and no time at all are different shapes, and are now told apart.

## What it cost, live

An `hhn`-tagged show is gated against the event calendar rather than day-park hours. `Meet HamiKuma` performs at **15:30, 16:30, 17:30 and 18:30** against a window parsed as starting at **19:00**:

```
category: hhn
status  : OPEN
slots   : 15:30  16:30  17:30  18:30  20:00  21:00  PT
```

Four of its six performances fell outside the window, so it published `CLOSED` while the character was out meeting guests. This fired as a `CLOSED_WITH_LIVE_SHOWTIME` alert repeatedly between 17:30 and 19:00 PT during the 2026-09-05 event.

## The output

Early access is published as its **own INFO entry**, not by widening the event:

```
EXTRA_HOURS     07:00 - 08:00
OPERATING       08:00 - 18:00
INFO            17:30 - 19:00   Halloween Horror Nights Early Access
TICKETED_EVENT  19:00 - 02:00   Halloween Horror Nights
```

Universal advertises the event as starting at seven; early access is a separately sold perk. Folding it into `openingTime` would tell every consumer that general admission begins ninety minutes earlier than it does, and would invent a second meaning for `TICKETED_EVENT` hours that nothing else uses. The shape mirrors what `buildSchedules` already emits for day-park early entry (`EXTRA_HOURS` before `OPERATING`).

**Gating uses admission, not the advertised start** — guests are inside during early access, so a show performing then is genuinely running. Verified against the live calendar: all 42 nights now carry an early-access time, and the gate reads `17:20 -> closed`, `17:40 -> open`, `20:00 -> open`, `03:00 -> closed`.

## Fails safe

The early-access block has a start and **no end**, so its close is inferred from the event's opening. It is therefore only emitted when that yields a real forward window, a lone time at or after the opening is not treated as early access, and a group carrying a lone time with **no** range creates no night at all — early access cannot invent an event.

## Verification

- Full suite **2322 passed**, typecheck clean.
- Verified against the live calendar with a cold cache. Worth noting: `getEventNights` is `@cache`d for 12h, so the first check silently reported "0 nights with early access" while serving the pre-change parse.
- Four mutations verified to fail a test: never parsing the lone time; dropping the guard that stops an event block supplying its own early time; removing the check that early access precedes the opening; ignoring it when gating.

## Test plan

- [x] A lone time is read as early access; the range stays the event; `openingTime` unchanged
- [x] "No Event Today" is still discarded — the skip this change had to preserve
- [x] A lone time with no event block creates no night
- [x] A lone time at or after the opening is not early access
- [x] Block order does not matter
- [x] A range in the same block cannot be read as a lone time
- [x] The gate admits from early access — closed at 17:20, open at 17:40 and 20:00, closed at 03:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)