### PR TITLE
fix(cache): stop a class flush wiping the live-entity retirement record

### DIFF
--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -220,6 +220,65 @@ describe('Cache', () => {
       expect(deleted).toBe(0);
       expect(Cache.size()).toBe(1);
     });
+
+    // A flush means "refetch from upstream", never "forget what we have
+    // observed". The retirement record only ever gains entries for ids
+    // PRESENT in a feed, so sweeping it away leaves an already-absent id
+    // untracked for good and its stale row frozen — the opposite of what the
+    // tool doing the flushing was reached for.
+    test('steps over persistent retirement state while clearing real cache keys', () => {
+      Cache.clear();
+      Cache.set('TestPark:getToken:[]', 'tok');
+      Cache.set('TestPark:liveEntityRetirement', {show1: {seenAt: 1, misses: 0}});
+      Cache.set('TestPark:liveEntityRetirement:guard', {withheldAt: null, streak: 0});
+
+      const deleted = Cache.clearByClassName('TestPark');
+
+      expect(deleted).toBe(1);
+      expect(Cache.has('TestPark:getToken:[]')).toBe(false);
+      expect(Cache.has('TestPark:liveEntityRetirement')).toBe(true);
+      expect(Cache.has('TestPark:liveEntityRetirement:guard')).toBe(true);
+    });
+
+    test('includePersistent sweeps the retirement state too', () => {
+      Cache.clear();
+      Cache.set('TestPark:getToken:[]', 'tok');
+      Cache.set('TestPark:liveEntityRetirement', {show1: {seenAt: 1, misses: 0}});
+      Cache.set('TestPark:liveEntityRetirement:guard', {withheldAt: null, streak: 0});
+
+      const deleted = Cache.clearByClassName('TestPark', {includePersistent: true});
+
+      expect(deleted).toBe(3);
+      expect(Cache.has('TestPark:liveEntityRetirement')).toBe(false);
+      expect(Cache.has('TestPark:liveEntityRetirement:guard')).toBe(false);
+    });
+
+    // A destination overriding getCacheKeyPrefix() puts its retirement record
+    // under that prefix, which carries no class name and so falls outside the
+    // LIKE patterns today. Pinned so a future widening of those patterns
+    // cannot start sweeping it.
+    test('leaves prefixed retirement state intact', () => {
+      Cache.clear();
+      Cache.set('attractionsio:1:AttractionsIOV3:getParkConfig:[]', 'cfg');
+      Cache.set('attractionsio:1:liveEntityRetirement', {ride: {seenAt: 1, misses: 0}});
+
+      const deleted = Cache.clearByClassName('AttractionsIOV3');
+
+      expect(deleted).toBe(1);
+      expect(Cache.has('attractionsio:1:liveEntityRetirement')).toBe(true);
+    });
+
+    // Protection is per-fragment, not per-class: an unrelated destination's
+    // record must not be collateral of someone else's flush either.
+    test('does not touch another destination\'s retirement state', () => {
+      Cache.clear();
+      Cache.set('TestPark:getToken:[]', 'tok');
+      Cache.set('OtherPark:liveEntityRetirement', {show9: {seenAt: 1, misses: 0}});
+
+      Cache.clearByClassName('TestPark');
+
+      expect(Cache.has('OtherPark:liveEntityRetirement')).toBe(true);
+    });
   });
 
   describe('clearAll', () => {

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -14,12 +14,12 @@ afterEach(() => {
 describe('Cache', () => {
   beforeEach(() => {
     // Clear cache before each test
-    Cache.clear();
+    Cache.clear({includePersistent: true});
   });
 
   afterEach(() => {
     // Clean up after each test
-    Cache.clear();
+    Cache.clear({includePersistent: true});
   });
 
   describe('Basic Operations', () => {
@@ -130,7 +130,7 @@ describe('Cache', () => {
       
       expect(Cache.size()).toBe(3);
       
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       
       expect(Cache.size()).toBe(0);
       expect(Cache.get('key1')).toBeNull();
@@ -159,7 +159,7 @@ describe('Cache', () => {
       Cache.delete('key1');
       expect(Cache.size()).toBe(1);
       
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       expect(Cache.size()).toBe(0);
     });
 
@@ -183,7 +183,7 @@ describe('Cache', () => {
       Cache.set('TestPark:getToken:[]', 'tok1');
       Cache.set('TestPark:fetchPOI:["en"]', 'poi');
       Cache.set('OtherPark:getToken:[]', 'tok2');
-      Cache.clear(); // clear beforeEach leftovers first
+      Cache.clear({includePersistent: true}); // clear beforeEach leftovers first
 
       Cache.set('TestPark:getToken:[]', 'tok1');
       Cache.set('TestPark:fetchPOI:["en"]', 'poi');
@@ -198,7 +198,7 @@ describe('Cache', () => {
     });
 
     test('deletes prefixed prefix:ClassName:method:args keys', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       Cache.set('attractionsio:1:AttractionsIOV3:getParkConfig:[]', 'cfg');
       Cache.set('attractionsio:2:AttractionsIOV3:getParkConfig:[]', 'cfg2');
       Cache.set('SomethingElse:method:[]', 'other');
@@ -212,7 +212,7 @@ describe('Cache', () => {
     });
 
     test('returns 0 when no matching keys exist', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       Cache.set('UnrelatedPark:method:[]', 'val');
 
       const deleted = Cache.clearByClassName('NonExistentPark');
@@ -227,7 +227,7 @@ describe('Cache', () => {
     // untracked for good and its stale row frozen — the opposite of what the
     // tool doing the flushing was reached for.
     test('steps over persistent retirement state while clearing real cache keys', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       Cache.set('TestPark:getToken:[]', 'tok');
       Cache.set('TestPark:liveEntityRetirement', {show1: {seenAt: 1, misses: 0}});
       Cache.set('TestPark:liveEntityRetirement:guard', {withheldAt: null, streak: 0});
@@ -241,7 +241,7 @@ describe('Cache', () => {
     });
 
     test('includePersistent sweeps the retirement state too', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       Cache.set('TestPark:getToken:[]', 'tok');
       Cache.set('TestPark:liveEntityRetirement', {show1: {seenAt: 1, misses: 0}});
       Cache.set('TestPark:liveEntityRetirement:guard', {withheldAt: null, streak: 0});
@@ -253,37 +253,91 @@ describe('Cache', () => {
       expect(Cache.has('TestPark:liveEntityRetirement:guard')).toBe(false);
     });
 
-    // A destination overriding getCacheKeyPrefix() puts its retirement record
-    // under that prefix, which carries no class name and so falls outside the
-    // LIKE patterns today. Pinned so a future widening of those patterns
-    // cannot start sweeping it.
-    test('leaves prefixed retirement state intact', () => {
-      Cache.clear();
-      Cache.set('attractionsio:1:AttractionsIOV3:getParkConfig:[]', 'cfg');
-      Cache.set('attractionsio:1:liveEntityRetirement', {ride: {seenAt: 1, misses: 0}});
+    // The at-risk prefixed shape is a record whose prefix CONTAINS the class
+    // name, which the `%:ClassName:%` pattern matches. A record keyed under a
+    // prefix carrying no class name (`attractionsiov1:<id>:...`) was never a
+    // deletion candidate, so it proves nothing about the carve-out; this uses
+    // the shape that genuinely was being swept.
+    test('protects a retirement record sitting inside a prefixed key', () => {
+      Cache.clear({includePersistent: true});
+      Cache.set('seaworld:SeaWorldOrlando:getPOI:[]', 'poi');
+      Cache.set('seaworld:SeaWorldOrlando:liveEntityRetirement', {r1: {seenAt: 1, misses: 0}});
 
-      const deleted = Cache.clearByClassName('AttractionsIOV3');
+      const deleted = Cache.clearByClassName('SeaWorldOrlando');
 
       expect(deleted).toBe(1);
-      expect(Cache.has('attractionsio:1:liveEntityRetirement')).toBe(true);
+      expect(Cache.has('seaworld:SeaWorldOrlando:getPOI:[]')).toBe(false);
+      expect(Cache.has('seaworld:SeaWorldOrlando:liveEntityRetirement')).toBe(true);
     });
 
-    // Protection is per-fragment, not per-class: an unrelated destination's
-    // record must not be collateral of someone else's flush either.
-    test('does not touch another destination\'s retirement state', () => {
-      Cache.clear();
-      Cache.set('TestPark:getToken:[]', 'tok');
-      Cache.set('OtherPark:liveEntityRetirement', {show9: {seenAt: 1, misses: 0}});
+    // The catalogue holds more than the retirement record, and the exclusion
+    // is built by looping it. Pins a second, unrelated fragment so the N>1
+    // path is exercised rather than assumed.
+    test('protects a non-retirement fragment from the same catalogue', () => {
+      Cache.clear({includePersistent: true});
+      Cache.set('DisneylandParis:getPOI:[]', 'poi');
+      Cache.set('DisneylandParis:dlp:queueBearingHistory', ['a', 'b']);
+
+      const deleted = Cache.clearByClassName('DisneylandParis');
+
+      expect(deleted).toBe(1);
+      expect(Cache.has('DisneylandParis:dlp:queueBearingHistory')).toBe(true);
+    });
+
+    // SQL LIKE treats `_` as a single-character wildcard, so an unescaped
+    // fragment would protect keys it does not name.
+    test('escapes LIKE metacharacters when matching fragments', () => {
+      Cache.clear({includePersistent: true});
+      Cache.set('TestPark:dlpXqueueBearingHistory', 'decoy');
+      Cache.set('TestPark:dlp:queueBearingHistory', ['real']);
 
       Cache.clearByClassName('TestPark');
 
+      expect(Cache.has('TestPark:dlpXqueueBearingHistory')).toBe(false);
+      expect(Cache.has('TestPark:dlp:queueBearingHistory')).toBe(true);
+    });
+  });
+
+  // The broad flush gestures are the ones an operator reaches for when a
+  // symptom spans several destinations, which is exactly when discarding what
+  // we have observed does the most damage. They carve out the same keys.
+  describe('persistent state across the broad clear paths', () => {
+    test('clear() steps over persistent keys by default', () => {
+      Cache.clear({includePersistent: true});
+      Cache.set('TestPark:getToken:[]', 'tok');
+      Cache.set('TestPark:liveEntityRetirement', {s1: {seenAt: 1, misses: 0}});
+
+      Cache.clear();
+
+      expect(Cache.has('TestPark:getToken:[]')).toBe(false);
+      expect(Cache.has('TestPark:liveEntityRetirement')).toBe(true);
+    });
+
+    test('clearAll() steps over persistent keys by default', () => {
+      Cache.clear({includePersistent: true});
+      Cache.set('TestPark:getToken:[]', 'tok');
+      Cache.set('OtherPark:liveEntityRetirement', {s1: {seenAt: 1, misses: 0}});
+
+      const deleted = Cache.clearAll();
+
+      expect(deleted).toBe(1);
       expect(Cache.has('OtherPark:liveEntityRetirement')).toBe(true);
+    });
+
+    test('both wipe persistent keys when asked explicitly', () => {
+      Cache.clear({includePersistent: true});
+      Cache.set('TestPark:liveEntityRetirement', {s1: {seenAt: 1, misses: 0}});
+      expect(Cache.clearAll({includePersistent: true})).toBe(1);
+
+      Cache.set('TestPark:liveEntityRetirement', {s1: {seenAt: 1, misses: 0}});
+      Cache.clear({includePersistent: true});
+      expect(Cache.has('TestPark:liveEntityRetirement')).toBe(false);
     });
   });
 
   describe('clearAll', () => {
     test('removes all entries and returns count', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       Cache.set('ParkA:method:[]', 'a');
       Cache.set('ParkB:method:[]', 'b');
       Cache.set('ParkC:method:[]', 'c');
@@ -295,7 +349,7 @@ describe('Cache', () => {
     });
 
     test('returns 0 when cache is already empty', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
       expect(Cache.clearAll()).toBe(0);
     });
   });
@@ -914,7 +968,7 @@ describe('Cache', () => {
       // For a real test, we'd need to mock or reload the module
       // This test demonstrates the concept with enforceSizeLimit() calls
 
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Manually add entries and test enforceSizeLimit
       for (let i = 0; i < 3; i++) {
@@ -974,7 +1028,7 @@ describe('Cache', () => {
     });
 
     test('should start and stop automatic cleanup', async () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Start cleanup (note: interval is set at module load time)
       // This test just verifies the methods work without errors
@@ -1003,7 +1057,7 @@ describe('Cache', () => {
 
   describe('Cache Statistics', () => {
     test('should return accurate cache statistics', async () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Add active entries
       Cache.set('active1', 'value1', 60);
@@ -1022,7 +1076,7 @@ describe('Cache', () => {
     });
 
     test('should return zero stats for empty cache', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       const stats = Cache.stats();
 
@@ -1368,7 +1422,7 @@ describe('Cache', () => {
 
   describe('enforceSizeLimit Behavior', () => {
     test('should evict least-recently-accessed entries when over limit', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Insert entries with distinct lastAccess timestamps
       for (let i = 0; i < 5; i++) {
@@ -1401,7 +1455,7 @@ describe('Cache', () => {
     });
 
     test('get() updates lastAccess so entry survives eviction', async () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Insert entries with explicit lastAccess timestamps to avoid timing issues
       const stmt = database.prepare(
@@ -1429,7 +1483,7 @@ describe('Cache', () => {
 
   describe('Concurrent-like Access Patterns', () => {
     test('many rapid set/get operations should not corrupt data', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Simulate rapid concurrent-like writes (sequential but fast)
       const count = 200;
@@ -1448,7 +1502,7 @@ describe('Cache', () => {
     });
 
     test('interleaved set/get/delete should maintain consistency', () => {
-      Cache.clear();
+      Cache.clear({includePersistent: true});
 
       // Write 50 entries
       for (let i = 0; i < 50; i++) {

--- a/src/__tests__/cacheEviction.test.ts
+++ b/src/__tests__/cacheEviction.test.ts
@@ -1,0 +1,68 @@
+/**
+ * LRU eviction must honour the persistent-key carve-out.
+ *
+ * `enforceSizeLimit()` is the fourth way a row can leave the cache, and it
+ * does not read TTLs at all. Without an exemption the 400-day life of the
+ * retirement record is only as good as the size cap: a destination that stops
+ * being polled (disabled, out of season, upstream broken) stops having its row
+ * read, ages to the cold end of the LRU, and is evicted despite never having
+ * expired — losing exactly the destination whose entities are most likely to
+ * have gone missing.
+ *
+ * Its own file with its own database: MAX_CACHE_ENTRIES is read once at module
+ * load, so the cap can only be lowered by importing the module fresh with the
+ * env var already set. Vitest isolates the module registry per test file, so
+ * this file's lowered cap and throwaway database do not reach any other suite.
+ */
+
+import {describe, test, expect, beforeAll, afterAll, vi} from 'vitest';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {rmSync} from 'node:fs';
+
+const DB_PATH = join(tmpdir(), `parksapi-eviction-${process.pid}-${Date.now()}.sqlite`);
+
+let Cache: typeof import('../cache.js').CacheLib;
+let db: typeof import('../cache.js').database;
+
+beforeAll(async () => {
+  process.env.CACHE_DB_PATH = DB_PATH;
+  process.env.CACHE_MAX_ENTRIES = '5';
+  vi.resetModules();
+  const mod = await import('../cache.js');
+  Cache = mod.CacheLib;
+  db = mod.database;
+});
+
+afterAll(() => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      rmSync(`${DB_PATH}${suffix}`);
+    } catch {
+      // best effort; the temp dir is disposable
+    }
+  }
+});
+
+describe('enforceSizeLimit', () => {
+  test('evicts cold cache entries but never the persistent record', () => {
+    Cache.clear({includePersistent: true});
+
+    // The retirement record is the COLDEST row in the table, so a pure LRU
+    // would evict it first.
+    Cache.set('ColdPark:liveEntityRetirement', {show1: {seenAt: 1, misses: 2}}, 400 * 24 * 60 * 60);
+    db.prepare('UPDATE cache SET lastAccess = 0 WHERE key = ?').run('ColdPark:liveEntityRetirement');
+
+    for (let i = 0; i < 10; i += 1) {
+      Cache.set(`WarmPark:getPOI:[${i}]`, {i}, 3600);
+    }
+
+    expect(Cache.size()).toBeGreaterThan(5);
+    Cache.enforceSizeLimit();
+
+    expect(Cache.has('ColdPark:liveEntityRetirement')).toBe(true);
+    expect(Cache.get('ColdPark:liveEntityRetirement')).toEqual({show1: {seenAt: 1, misses: 2}});
+    // Eviction still did its job on the rows it is allowed to take.
+    expect(Cache.size()).toBeLessThanOrEqual(6);
+  });
+});

--- a/src/__tests__/cacheKeyPrefix.test.ts
+++ b/src/__tests__/cacheKeyPrefix.test.ts
@@ -7,11 +7,11 @@ import {Destination} from '../destination';
 
 describe('Cache Key Prefix', () => {
   beforeEach(() => {
-    CacheLib.clear();
+    CacheLib.clear({includePersistent: true});
   });
 
   afterAll(() => {
-    CacheLib.clear();
+    CacheLib.clear({includePersistent: true});
   });
 
   describe('getCacheKeyPrefix() method', () => {

--- a/src/__tests__/httpIntegration.test.ts
+++ b/src/__tests__/httpIntegration.test.ts
@@ -162,7 +162,7 @@ describe('HTTP Library Integration Tests', () => {
   beforeEach(() => {
     // Clear request log, cache, and in-flight dedup map before each test
     requestLog = [];
-    CacheLib.clear();
+    CacheLib.clear({includePersistent: true});
     clearHttpInflightMap();
   });
 

--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -126,6 +126,55 @@ describe('live entity retirement gate', () => {
     expect(live.find((d) => d.id === 'show1')).toEqual({id: 'show1', status: 'OPERATING'});
   });
 
+  /**
+   * The degraded-feed cooldown lives in a SECOND key beside the map
+   * (`…:liveEntityRetirement:guard`), and it is protected only because
+   * `:guard` is appended to a string that already carries the fragment.
+   * Nothing asserted that until now: renaming the guard key to anything
+   * outside the catalogue silently loses its protection, and a lost
+   * `withheldAt` fails OPEN, letting the gate retire inside exactly the
+   * untrusted window it exists to sit out.
+   *
+   * Exercised through behaviour rather than by naming the key, so a rename
+   * that drops the protection fails here.
+   */
+  test('a flush preserves the degraded-feed cooldown, not just the seen map', async () => {
+    vi.useFakeTimers();
+    const week = 7 * 24 * 60 * 60 * 1000;
+    const park = new RetiringTestDestination({retire: true, retirementMs: week});
+    const all = Array.from({length: 12}, (_, i) => `a${i + 1}`);
+
+    park.liveIds = [...all];
+    await park.getLiveData();
+
+    // Collapse the feed: 10 of 12 absent clears both minBulk (5) and
+    // maxFraction (0.5), and three consecutive such builds arm the cooldown.
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['a1', 'a2'];
+    await park.getLiveData();
+    await park.getLiveData();
+    await park.getLiveData();
+
+    CacheLib.clearByClassName('RetiringTestDestination');
+
+    // Feed recovers to all but one. That one is old enough and missed enough
+    // to retire, and would, were the cooldown not still running.
+    park.liveIds = all.filter((id) => id !== 'a12');
+    await park.getLiveData();
+    await park.getLiveData();
+    const cooling = await park.getLiveData();
+    expect(cooling.find((d) => d.id === 'a12')).toBeUndefined();
+
+    // Control: once the cooldown genuinely expires the same id does close, so
+    // the assertion above is the cooldown holding rather than a12 having been
+    // ineligible all along.
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    await park.getLiveData();
+    await park.getLiveData();
+    const after = await park.getLiveData();
+    expect(after.find((d) => d.id === 'a12')).toEqual({id: 'a12', status: 'CLOSED'});
+  });
+
   test('an entity that reappears before retiring is emitted normally, no synthetic row', async () => {
     vi.useFakeTimers();
     const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});

--- a/src/__tests__/liveEntityRetirement.test.ts
+++ b/src/__tests__/liveEntityRetirement.test.ts
@@ -39,7 +39,7 @@ class RetiringTestDestination extends Destination {
 
 describe('live entity retirement gate', () => {
   beforeEach(() => {
-    CacheLib.clearByClassName('RetiringTestDestination');
+    CacheLib.clearByClassName('RetiringTestDestination', {includePersistent: true});
   });
 
   afterEach(() => {
@@ -89,6 +89,40 @@ describe('live entity retirement gate', () => {
     const retired = live.find((d) => d.id === 'show2');
     expect(retired).toEqual({id: 'show2', status: 'CLOSED'});
     // show1 is untouched
+    expect(live.find((d) => d.id === 'show1')).toEqual({id: 'show1', status: 'OPERATING'});
+  });
+
+  /**
+   * Regression: a cache flush must not disarm the gate.
+   *
+   * `CacheLib.clearByClassName()` is how a caller forces a fresh upstream
+   * fetch, and it swept this record away with the cached responses. The
+   * record only ever gains entries for ids
+   * PRESENT in the feed, so an id that had ALREADY vanished was absent from
+   * the rebuilt map for good, could never accrue the misses that retire it,
+   * and its stale row froze permanently — precisely the failure those tools
+   * get reached for.
+   */
+  test('a cache flush mid-life does not stop a later absence retiring', async () => {
+    vi.useFakeTimers();
+    const park = new RetiringTestDestination({retire: true, retirementMs: 7 * 24 * 60 * 60 * 1000});
+
+    park.liveIds = ['show1', 'show2'];
+    await park.getLiveData();
+
+    // A decoy upstream entry proves the sweep still does its job, so a green
+    // assertion below cannot come from the flush quietly matching nothing.
+    CacheLib.set('RetiringTestDestination:getPOI:[]', 'upstream');
+    CacheLib.clearByClassName('RetiringTestDestination');
+    expect(CacheLib.has('RetiringTestDestination:getPOI:[]')).toBe(false);
+
+    vi.setSystemTime(Date.now() + 8 * 24 * 60 * 60 * 1000);
+    park.liveIds = ['show1'];
+    await park.getLiveData();
+    await park.getLiveData();
+    const live = await park.getLiveData();
+
+    expect(live.find((d) => d.id === 'show2')).toEqual({id: 'show2', status: 'CLOSED'});
     expect(live.find((d) => d.id === 'show1')).toEqual({id: 'show1', status: 'OPERATING'});
   });
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,5 @@
 import {DatabaseSync} from 'node:sqlite';
+import {persistentKeyExclusion} from './cacheKeys.js';
 
 const CACHE_DB_PATH = process.env.CACHE_DB_PATH || './cache.sqlite';
 const MAX_CACHE_ENTRIES = parseInt(process.env.CACHE_MAX_ENTRIES || '50000', 10);
@@ -7,32 +8,6 @@ const CLEANUP_INTERVAL_MS = parseInt(process.env.CACHE_CLEANUP_INTERVAL_MS || '3
 // the lock). No application-level retry needed.
 
 // Track if we're in temporary mode
-/**
- * Key fragment marking a destination's live-entity retirement state.
- *
- * Exported so `Destination` builds its key from the same constant that
- * protects it here, and the two cannot drift apart.
- */
-const LIVE_ENTITY_RETIREMENT_FRAGMENT = ':liveEntityRetirement';
-
-/**
- * Key fragments holding persistent operational state rather than cached
- * upstream data.
- *
- * `clearByClassName()` exists to force a fresh upstream fetch. It must never
- * also mean "forget what we have observed": the retirement map records
- * whether an id has ever been seen live, and only ever gains entries for ids
- * PRESENT in the current feed. Wipe it and an id that has already vanished
- * upstream is absent from the map for good, so it can never accrue the misses
- * that retire it, and its stale row freezes permanently. That is the opposite
- * of what the tool flushing the cache was reached for.
- *
- * Matched anywhere in the key, so a per-park or per-id suffix is fine. Extend
- * this list when adding state whose loss changes what we publish rather than
- * just costing a fetch.
- */
-const PERSISTENT_KEY_FRAGMENTS = [LIVE_ENTITY_RETIREMENT_FRAGMENT] as const;
-
 let isTemporaryMode = false;
 
 // Initialize database (can be re-initialized). Assigned below, once
@@ -291,10 +266,22 @@ class CacheLib {
     }
   }
 
-  static clear(): void {
+  /**
+   * Delete cached entries.
+   *
+   * Like {@link clearByClassName}, this is a re-fetch and steps over
+   * persistent operational state (see cacheKeys.ts). The broad gesture is the
+   * one an operator reaches for when a symptom spans several destinations,
+   * which is exactly when quietly discarding what we have observed does the
+   * most damage. Pass `includePersistent` for a genuine full wipe.
+   */
+  static clear({includePersistent = false}: {includePersistent?: boolean} = {}): void {
     try {
-      const stmt = database.prepare('DELETE FROM cache');
-      stmt.run();
+      const {clauses, params} = includePersistent
+        ? {clauses: [] as string[], params: [] as string[]}
+        : persistentKeyExclusion();
+      const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+      database.prepare(`DELETE FROM cache${where}`).run(...params);
     } catch (error) {
       console.error("Cache clear error:", error);
     }
@@ -372,12 +359,19 @@ class CacheLib {
       const currentSize = this.size();
       if (currentSize > MAX_CACHE_ENTRIES) {
         const entriesToRemove = currentSize - MAX_CACHE_ENTRIES;
+        // Persistent rows are exempt here too, or the 400-day TTL on the
+        // retirement record would only be as good as the size cap: a
+        // destination that stops being polled ages to the cold end of the LRU
+        // and would be evicted despite never expiring. They are bounded (a
+        // handful per destination) so exempting them cannot starve eviction.
+        const {clauses, params} = persistentKeyExclusion();
+        const filter = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
         const stmt = database.prepare(`
           DELETE FROM cache WHERE key IN (
-            SELECT key FROM cache ORDER BY lastAccess ASC LIMIT ?
+            SELECT key FROM cache${filter} ORDER BY lastAccess ASC LIMIT ?
           )
         `);
-        stmt.run(entriesToRemove);
+        stmt.run(...params, entriesToRemove);
       }
     } catch (error) {
       console.error("Cache size enforcement error:", error);
@@ -467,10 +461,9 @@ class CacheLib {
       const clauses = ['(key LIKE ? OR key LIKE ?)'];
       const params: string[] = [`${className}:%`, `%:${className}:%`];
       if (!includePersistent) {
-        for (const fragment of PERSISTENT_KEY_FRAGMENTS) {
-          clauses.push('key NOT LIKE ?');
-          params.push(`%${fragment}%`);
-        }
+        const exclusion = persistentKeyExclusion();
+        clauses.push(...exclusion.clauses);
+        params.push(...exclusion.params);
       }
       const stmt = database.prepare(`DELETE FROM cache WHERE ${clauses.join(' AND ')}`);
       const result = stmt.run(...params);
@@ -481,10 +474,19 @@ class CacheLib {
     }
   }
 
-  /** Delete every entry in the cache. Returns number deleted. */
-  static clearAll(): number {
+  /**
+   * Delete cached entries across every destination. Returns number deleted.
+   *
+   * Steps over persistent operational state for the same reason
+   * {@link clearByClassName} does; pass `includePersistent` for a full wipe.
+   */
+  static clearAll({includePersistent = false}: {includePersistent?: boolean} = {}): number {
     try {
-      const result = database.prepare("DELETE FROM cache").run();
+      const {clauses, params} = includePersistent
+        ? {clauses: [] as string[], params: [] as string[]}
+        : persistentKeyExclusion();
+      const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+      const result = database.prepare(`DELETE FROM cache${where}`).run(...params);
       return Number(result.changes || 0);
     } catch (error) {
       console.error("Cache clearAll error:", error);
@@ -594,4 +596,4 @@ export default function cacheDecorator({ttlSeconds = 60, callback, key, cacheVer
 }
 
 
-export {CacheLib, cacheDecorator as cache, LIVE_ENTITY_RETIREMENT_FRAGMENT, PERSISTENT_KEY_FRAGMENTS};
+export {CacheLib, cacheDecorator as cache};

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,6 +7,32 @@ const CLEANUP_INTERVAL_MS = parseInt(process.env.CACHE_CLEANUP_INTERVAL_MS || '3
 // the lock). No application-level retry needed.
 
 // Track if we're in temporary mode
+/**
+ * Key fragment marking a destination's live-entity retirement state.
+ *
+ * Exported so `Destination` builds its key from the same constant that
+ * protects it here, and the two cannot drift apart.
+ */
+const LIVE_ENTITY_RETIREMENT_FRAGMENT = ':liveEntityRetirement';
+
+/**
+ * Key fragments holding persistent operational state rather than cached
+ * upstream data.
+ *
+ * `clearByClassName()` exists to force a fresh upstream fetch. It must never
+ * also mean "forget what we have observed": the retirement map records
+ * whether an id has ever been seen live, and only ever gains entries for ids
+ * PRESENT in the current feed. Wipe it and an id that has already vanished
+ * upstream is absent from the map for good, so it can never accrue the misses
+ * that retire it, and its stale row freezes permanently. That is the opposite
+ * of what the tool flushing the cache was reached for.
+ *
+ * Matched anywhere in the key, so a per-park or per-id suffix is fine. Extend
+ * this list when adding state whose loss changes what we publish rather than
+ * just costing a fetch.
+ */
+const PERSISTENT_KEY_FRAGMENTS = [LIVE_ENTITY_RETIREMENT_FRAGMENT] as const;
+
 let isTemporaryMode = false;
 
 // Initialize database (can be re-initialized). Assigned below, once
@@ -426,11 +452,28 @@ class CacheLib {
    * Delete all cache entries whose key contains the given class name.
    * Matches both plain keys (`ClassName:method:args`) and prefixed keys (`prefix:ClassName:method:args`).
    * Returns the number of deleted entries.
+   *
+   * Keys carrying a {@link PERSISTENT_KEY_FRAGMENTS} fragment are stepped
+   * over: this call means "refetch from upstream", not "forget what we have
+   * observed". Pass `includePersistent` to sweep those too, which is a full
+   * reset of the destination rather than a flush, and is what test setup
+   * wants.
    */
-  static clearByClassName(className: string): number {
+  static clearByClassName(
+    className: string,
+    {includePersistent = false}: {includePersistent?: boolean} = {},
+  ): number {
     try {
-      const stmt = database.prepare("DELETE FROM cache WHERE key LIKE ? OR key LIKE ?");
-      const result = stmt.run(`${className}:%`, `%:${className}:%`);
+      const clauses = ['(key LIKE ? OR key LIKE ?)'];
+      const params: string[] = [`${className}:%`, `%:${className}:%`];
+      if (!includePersistent) {
+        for (const fragment of PERSISTENT_KEY_FRAGMENTS) {
+          clauses.push('key NOT LIKE ?');
+          params.push(`%${fragment}%`);
+        }
+      }
+      const stmt = database.prepare(`DELETE FROM cache WHERE ${clauses.join(' AND ')}`);
+      const result = stmt.run(...params);
       return Number(result.changes || 0);
     } catch (error) {
       console.error("Cache clearByClassName error:", error);
@@ -551,4 +594,4 @@ export default function cacheDecorator({ttlSeconds = 60, callback, key, cacheVer
 }
 
 
-export {CacheLib, cacheDecorator as cache};
+export {CacheLib, cacheDecorator as cache, LIVE_ENTITY_RETIREMENT_FRAGMENT, PERSISTENT_KEY_FRAGMENTS};

--- a/src/cacheKeys.ts
+++ b/src/cacheKeys.ts
@@ -1,0 +1,89 @@
+/**
+ * Catalogue of cache keys that hold persistent operational state rather than
+ * cached upstream data.
+ *
+ * The cache stores two different kinds of thing under one namespace. Most of
+ * it is a copy of an upstream response: disposable, and re-fetchable at the
+ * cost of one request. A little of it is a record of what we have OBSERVED
+ * over time, which no request can rebuild. Flushing the first is routine.
+ * Flushing the second changes what we publish.
+ *
+ * A flush means "re-fetch from upstream". It must never also mean "forget what
+ * we have observed", so the clear paths in cache.ts step over any key carrying
+ * a fragment listed here. Callers that genuinely want a destination reset
+ * rather than a re-fetch pass `includePersistent`.
+ *
+ * Fragments are matched anywhere in the key, so a per-park or per-id segment
+ * in the middle is fine. Kept in their own module, rather than in cache.ts, so
+ * a generic cache does not have to name domain concepts, and out of the
+ * package entry point so they stay internal.
+ */
+
+/**
+ * Whether an entity id has ever been seen live, plus the degraded-feed guard
+ * beside it. Only ever gains entries for ids PRESENT in the current feed, so
+ * losing it leaves an already-absent id unretireable for good and freezes its
+ * stale published row. See Destination.applyLiveEntityRetirement.
+ */
+export const LIVE_ENTITY_RETIREMENT_FRAGMENT = ':liveEntityRetirement';
+
+/**
+ * Every fragment marking persistent state.
+ *
+ * Frozen because `as const` is compile-time only: without it a JavaScript
+ * consumer of the built package could push onto the live array and change
+ * what every future flush protects.
+ *
+ * Add to this list when adding state whose loss changes what we publish, or
+ * costs someone other than us, rather than merely costing a fetch.
+ */
+export const PERSISTENT_KEY_FRAGMENTS = Object.freeze([
+  LIVE_ENTITY_RETIREMENT_FRAGMENT,
+
+  // Which DLP attractions bear a queue. The wait feed falls silent after park
+  // close, so rebuilding from it then classifies roughly a hundred rides as
+  // walkthroughs and publishes them with no `queue` object at all: STANDBY and
+  // SINGLE_RIDER vanish until the feed wakes the next morning.
+  ':dlp:queueBearingHistory',
+
+  // Which DLP attractions have recently advertised a single-rider line. Milder
+  // sibling of the above: SINGLE_RIDER drops off rides not currently
+  // advertising it, until re-observed.
+  ':dlp:singleRiderRecent',
+
+  // Fantawild's never-shrink roster baseline. Lose it inside the upstream
+  // overnight prune window and the shrunken roster becomes the new baseline,
+  // which truncates buildEntityList — entity deletion downstream, not a frozen
+  // row.
+  ':roster:v1:',
+
+  // Whether a Fantawild park has ever reported a real wait. Write-once by
+  // design; losing it re-suppresses live waits until one is next seen.
+  ':liveWaitsObserved:v1:',
+
+  // Long-lived upstream refresh tokens. Losing one is self-healing for us and
+  // not free for the operator: a park whose auth mints a fresh anonymous
+  // account per sign-up gets a permanent extra account every time we flush.
+  ':refreshToken',
+] as const);
+
+/**
+ * SQL `AND` clauses and bound parameters that exclude persistent keys from a
+ * DELETE or eviction SELECT.
+ *
+ * Returns clauses only, so the caller composes them into its own statement.
+ * The patterns are built with an explicit ESCAPE: `_` is a single-character
+ * wildcard in SQL LIKE, so an unescaped fragment would protect more than it
+ * names. An empty fragment is skipped rather than expanded to `%%`, which
+ * matches every key and would silently turn the whole DELETE into a no-op.
+ */
+export function persistentKeyExclusion(): {clauses: string[], params: string[]} {
+  const clauses: string[] = [];
+  const params: string[] = [];
+  for (const fragment of PERSISTENT_KEY_FRAGMENTS) {
+    if (!fragment) continue;
+    clauses.push("key NOT LIKE ? ESCAPE '\\'");
+    params.push(`%${fragment.replace(/[\\%_]/g, '\\$&')}%`);
+  }
+  return {clauses, params};
+}

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -4,7 +4,8 @@ import {reusable} from "./promiseReuse.js";
 import {loadProxyConfig, hasProxyConfig, type ProxyConfig} from "./proxy.js";
 import {inject} from "./injector.js";
 import {type HTTPObj, HttpQueue, http} from "./http.js";
-import {cache, CacheLib, LIVE_ENTITY_RETIREMENT_FRAGMENT} from "./cache.js";
+import {cache, CacheLib} from "./cache.js";
+import {LIVE_ENTITY_RETIREMENT_FRAGMENT} from "./cacheKeys.js";
 import {VQueueBuilder} from "./virtualQueue/builder.js";
 import {calculateReturnWindow} from "./virtualQueue/timeWindows.js";
 import {formatInTimezone} from "./datetime.js";
@@ -1132,7 +1133,11 @@ export abstract class Destination {
     } else {
       prefix = this.cacheKeyPrefix || this.constructor.name;
     }
-    return `${prefix}${LIVE_ENTITY_RETIREMENT_FRAGMENT}`;
+    // Fall back the way the `cacheKeyPrefix` branch and the @cache decorator
+    // already do. An override returning '' would otherwise yield the bare key
+    // `:liveEntityRetirement`, shared by every destination that did it, and
+    // the gate would close entities belonging to another park.
+    return `${prefix || this.constructor.name}${LIVE_ENTITY_RETIREMENT_FRAGMENT}`;
   }
 
   /**

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -4,7 +4,7 @@ import {reusable} from "./promiseReuse.js";
 import {loadProxyConfig, hasProxyConfig, type ProxyConfig} from "./proxy.js";
 import {inject} from "./injector.js";
 import {type HTTPObj, HttpQueue, http} from "./http.js";
-import {cache, CacheLib} from "./cache.js";
+import {cache, CacheLib, LIVE_ENTITY_RETIREMENT_FRAGMENT} from "./cache.js";
 import {VQueueBuilder} from "./virtualQueue/builder.js";
 import {calculateReturnWindow} from "./virtualQueue/timeWindows.js";
 import {formatInTimezone} from "./datetime.js";
@@ -1115,8 +1115,14 @@ export abstract class Destination {
   /**
    * Cache key for this destination's {@link retireMissingLiveEntities}
    * last-seen tracking. Reuses the same prefix resolution the `@cache`
-   * decorator applies, so it lands in the same namespace
-   * `CacheLib.clearByClassName()` already sweeps for this destination.
+   * decorator applies, so it lands in this destination's namespace.
+   *
+   * Built from {@link LIVE_ENTITY_RETIREMENT_FRAGMENT}, which is also what
+   * makes `CacheLib.clearByClassName()` step over it. This record is not a
+   * cache: it says whether an id has ever been seen live, and a flush that
+   * dropped it would leave every already-absent id unretireable, freezing
+   * exactly the stale rows a flush is usually reached for. One constant owns
+   * both halves so they cannot drift.
    */
   private async liveEntityRetirementCacheKey(): Promise<string> {
     let prefix: string;
@@ -1126,7 +1132,7 @@ export abstract class Destination {
     } else {
       prefix = this.cacheKeyPrefix || this.constructor.name;
     }
-    return `${prefix}:liveEntityRetirement`;
+    return `${prefix}${LIVE_ENTITY_RETIREMENT_FRAGMENT}`;
   }
 
   /**

--- a/src/parks/dlp/__tests__/parkHours.test.ts
+++ b/src/parks/dlp/__tests__/parkHours.test.ts
@@ -134,7 +134,7 @@ describe('DLP park-hours fallback for walkthroughs', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
-    CacheLib.clearByClassName('DisneylandParis');
+    CacheLib.clearByClassName('DisneylandParis', {includePersistent: true});
   });
 
   it('reports OPERATING inside its own park\'s published window', async () => {

--- a/src/parks/dlp/__tests__/showRetirement.test.ts
+++ b/src/parks/dlp/__tests__/showRetirement.test.ts
@@ -32,7 +32,7 @@ const SHOW = {
 describe('DLP show retirement', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    CacheLib.clearByClassName('DisneylandParis');
+    CacheLib.clearByClassName('DisneylandParis', {includePersistent: true});
   });
 
   afterEach(() => vi.useRealTimers());

--- a/src/parks/dlp/__tests__/singleRider.test.ts
+++ b/src/parks/dlp/__tests__/singleRider.test.ts
@@ -51,7 +51,7 @@ async function queueOf(park: DisneylandParis): Promise<any> {
 describe('DLP single rider', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    CacheLib.clearByClassName('DisneylandParis');
+    CacheLib.clearByClassName('DisneylandParis', {includePersistent: true});
   });
 
   it('emits the queue from the POI facet while the feed is asleep', async () => {

--- a/src/parks/dlp/disneylandparis.ts
+++ b/src/parks/dlp/disneylandparis.ts
@@ -340,9 +340,14 @@ export class DisneylandParis extends Destination {
   /**
    * All cache entries are namespaced under the class name so
    * `CacheLib.clearByClassName('DisneylandParis')` (used by the test
-   * harness `--clear-cache`) sweeps everything for this destination,
+   * harness `--clear-cache`) sweeps this destination's cached upstream data,
    * including methods that opt into a stable named cache key like the
    * `dlp:get*` keys below.
+   *
+   * Not quite everything: keys listed in cacheKeys.ts hold what we have
+   * OBSERVED rather than what we fetched, and a flush steps over them. For
+   * this destination that is the live-entity retirement record and the
+   * queue-bearing / single-rider history below.
    */
   getCacheKeyPrefix(): string {
     return 'DisneylandParis';

--- a/src/parks/energylandia/__tests__/energylandia.test.ts
+++ b/src/parks/energylandia/__tests__/energylandia.test.ts
@@ -221,8 +221,8 @@ describe('Energylandia — live data', () => {
     return p;
   }
 
-  beforeEach(() => CacheLib.clear());
-  afterEach(() => CacheLib.clear());
+  beforeEach(() => CacheLib.clear({includePersistent: true}));
+  afterEach(() => CacheLib.clear({includePersistent: true}));
 
   test('only active rides become ATTRACTIONs — a restaurant is not one, a retired ride is not published', async () => {
     const entities = await park().getEntities();
@@ -491,8 +491,8 @@ describe('Energylandia — attraction locations', () => {
     return p;
   }
 
-  beforeEach(() => CacheLib.clear());
-  afterEach(() => CacheLib.clear());
+  beforeEach(() => CacheLib.clear({includePersistent: true}));
+  afterEach(() => CacheLib.clear({includePersistent: true}));
 
   test('attaches coordinates via proximiioId', async () => {
     const e: any = (await park().getEntities()).find((x: any) => x.name === 'Pepsi Hyperion');
@@ -545,8 +545,8 @@ describe('Energylandia — pinned fallback coordinates', () => {
     return p;
   }
 
-  beforeEach(() => CacheLib.clear());
-  afterEach(() => CacheLib.clear());
+  beforeEach(() => CacheLib.clear({includePersistent: true}));
+  afterEach(() => CacheLib.clear({includePersistent: true}));
 
   test('fills in a ride whose proximiioId resolves to nothing', async () => {
     const e: any = (await parkWith([]).getEntities()).find((x: any) => x.entityType === 'ATTRACTION');
@@ -584,8 +584,8 @@ describe('Energylandia — failures must not be cached', () => {
     }}) as any;
   }
 
-  beforeEach(() => CacheLib.clear());
-  afterEach(() => CacheLib.clear());
+  beforeEach(() => CacheLib.clear({includePersistent: true}));
+  afterEach(() => CacheLib.clear({includePersistent: true}));
 
   test('a Proximiio outage is not persisted, so the next poll recovers', async () => {
     // The regression: the catch used to live INSIDE the @cache'd method, so the
@@ -714,8 +714,8 @@ describe('Energylandia — a wait-feed outage is visible', () => {
 describe('Energylandia — auth reuses one identity', () => {
   const CFG = {...BLANK_CONFIG, apiKey: 'k', projectId: 'p'};
 
-  beforeEach(() => CacheLib.clear());
-  afterEach(() => CacheLib.clear());
+  beforeEach(() => CacheLib.clear({includePersistent: true}));
+  afterEach(() => CacheLib.clear({includePersistent: true}));
 
   test('signs up once, then refreshes — it does not mint an account per token', async () => {
     // Anonymous sign-up creates a PERMANENT account in the park's Firebase
@@ -807,8 +807,8 @@ describe('Energylandia — auth reuses one identity', () => {
 });
 
 describe('Energylandia — an empty Firestore collection is a failure, not an empty park', () => {
-  beforeEach(() => CacheLib.clear());
-  afterEach(() => CacheLib.clear());
+  beforeEach(() => CacheLib.clear({includePersistent: true}));
+  afterEach(() => CacheLib.clear({includePersistent: true}));
 
   test('refuses to publish an empty catalogue', async () => {
     // Firestore answers 200 with {} for both "empty" and "does not exist", so
@@ -1131,12 +1131,12 @@ describe('Energylandia — shows end to end', () => {
   }
 
   beforeEach(() => {
-    CacheLib.clear();
+    CacheLib.clear({includePersistent: true});
     vi.useFakeTimers();
   });
   afterEach(() => {
     vi.useRealTimers();
-    CacheLib.clear();
+    CacheLib.clear({includePersistent: true});
   });
 
   test('publishes a SHOW per active show, and none for a retired one', async () => {

--- a/src/parks/parcasterix/__tests__/showRetirement.test.ts
+++ b/src/parks/parcasterix/__tests__/showRetirement.test.ts
@@ -41,7 +41,7 @@ const ATTRACTIONS = Array.from({length: 20}, (_, i) => latency(String(31303 + i)
 describe('Parc Asterix show retirement', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    CacheLib.clearByClassName('ParcAsterix');
+    CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
   });
 
   afterEach(() => vi.useRealTimers());

--- a/src/parks/shdr/__tests__/showRetirement.test.ts
+++ b/src/parks/shdr/__tests__/showRetirement.test.ts
@@ -21,7 +21,7 @@ const showWaitEntry = {id: 'show-birthday-bash', waitTime: {status: 'Operating'}
 describe('SHDR show retirement', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    CacheLib.clearByClassName('ShanghaiDisneylandResort');
+    CacheLib.clearByClassName('ShanghaiDisneylandResort', {includePersistent: true});
   });
 
   afterEach(() => vi.useRealTimers());

--- a/src/parks/universal/__tests__/hhnRetirement.test.ts
+++ b/src/parks/universal/__tests__/hhnRetirement.test.ts
@@ -68,14 +68,14 @@ async function poll(make: () => UniversalOrlando | UniversalStudios, times = 3) 
 describe('Universal HHN live-entity retirement', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    CacheLib.clearByClassName('UniversalOrlando');
-    CacheLib.clearByClassName('UniversalStudios');
+    CacheLib.clearByClassName('UniversalOrlando', {includePersistent: true});
+    CacheLib.clearByClassName('UniversalStudios', {includePersistent: true});
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    CacheLib.clearByClassName('UniversalOrlando');
-    CacheLib.clearByClassName('UniversalStudios');
+    CacheLib.clearByClassName('UniversalOrlando', {includePersistent: true});
+    CacheLib.clearByClassName('UniversalStudios', {includePersistent: true});
   });
 
   it('is enabled at both resorts that run the event', () => {

--- a/src/webServer.ts
+++ b/src/webServer.ts
@@ -401,7 +401,7 @@ app.delete('/api/cache', (req, res) => {
     CacheLib.clear();
     res.json({
       success: true,
-      message: 'Cache cleared successfully',
+      message: 'Cache cleared successfully (persistent operational state retained)',
     });
   } catch (error) {
     console.error('Error clearing cache:', error);


### PR DESCRIPTION
`CacheLib` clear paths mean "re-fetch from upstream". They were also silently
meaning "forget what we have observed".

## The bug

The cache stores two different kinds of thing under one namespace: copies of
upstream responses, which are disposable, and records of what we have observed
over time, which no request can rebuild. Every clear path treated them alike.

The live-entity retirement record is keyed `${prefix}:liveEntityRetirement`
with a `:guard` sibling, written with a 400-day TTL. It tracks whether an
entity id has ever been seen live, and **only ever gains entries for ids
present in the current feed**. So once it is wiped:

1. every currently-live id is re-learned harmlessly on the next build, but
2. an id that had **already vanished** upstream is never re-added, so it can
   never accrue the consecutive misses that make it eligible for the synthetic
   `CLOSED`.

Its stale published row then freezes permanently. A flush is normally reached
for precisely when rows look stuck, and nothing logged what it cost.

Every destination that enables the gate was exposed. The exposure comes from
the default prefix branch, so no override is needed to be affected.

## The fix

A catalogue in the new `src/cacheKeys.ts` names the fragments marking
persistent state. `clearByClassName()`, `clear()`, `clearAll()` and the LRU in
`enforceSizeLimit()` all step over keys carrying one. The retirement key is
built from the same constant that protects it, so format and protection cannot
drift apart.

All four paths matter. `clear()` is the web admin's `DELETE /api/cache` and
`clearAll()` is the harness flush when no destination is named — the broad
gesture an operator reaches for when a symptom spans several parks, which is
when this does the most damage. The eviction exemption matters independently:
without it the 400-day TTL was only as good as the 50,000-entry cap, and a
destination that stops being polled ages to the cold end of the LRU.

Callers wanting a genuine reset rather than a re-fetch pass
`{includePersistent: true}`. Per-key `delete()` is untouched, so explicit
recovery paths still work.

**No key is renamed.** A rename would read more cleanly but would inflict the
exact permanent-freeze harm above, once, on every destination at deploy, since
existing records would stop being found. Deployed state keeps its full life.

## Also protected

Same criterion, same sweep, found during review:

| record | consequence of losing it |
|---|---|
| DLP queue-bearing history | after park close the wait feed is silent, so ~100 attractions rebuild as walkthroughs and publish with **no queue object at all** — STANDBY and SINGLE_RIDER vanish for hours |
| Fantawild never-shrink roster | lost inside the upstream overnight prune, the shrunken roster becomes the new baseline and truncates `buildEntityList` — entity deletion downstream, not a frozen row |
| DLP single-rider history | SINGLE_RIDER drops off rides not currently advertising it |
| Fantawild live-waits flag | write-once; losing it re-suppresses live waits |
| long-lived refresh tokens | a flush otherwise mints a permanent anonymous account upstream every time. Still self-healing: a rejected token is dropped by an explicit per-key delete, which the exclusion does not touch |

## Tests

Six suites were using a clear path in setup *specifically* to reset persistent
state. They now say `includePersistent` and mean it. DLP's retirement suite
was missed on the first pass and had silently lost its isolation — it passed
only because each case happened to re-observe its entity first.

New coverage: the broad clear paths in both directions, the LRU exemption (its
own file, since the size cap is read once at module load), LIKE metacharacter
escaping, and a second fragment so the multi-fragment path is exercised rather
than assumed.

The guard record's protection was previously untested — renaming that key
passed 138 tests. It is now exercised through behaviour: arm the cooldown,
flush, assert retirement is still withheld, then let the cooldown expire and
assert the same id does close, so the assertion cannot pass by the id having
been ineligible all along.

## Verification

- Full suite: 110 files, 2373 tests, all passing. `npm run build` clean.
- **Mutation-tested, not assumed.** Disabling the exclusion fails 9 tests
  across three files; renaming the guard key fails the new cooldown test.
- The regression plants a decoy upstream key and asserts the flush still
  deletes it, so a green result cannot come from the sweep matching nothing.
- Both new constants stay off the package entry point; `src/index.ts` does
  `export *` from `cache.ts`, which would have made them public API.

## Known and deliberately not fixed here

- Records already destroyed by earlier flushes are unrecoverable and cannot be
  enumerated. Affected rows need a manual live-data correction.
- A flush can itself arm the 7-day cooldown, because cold re-fetches make
  partial builds likelier and three of those set `withheldAt`. That is the
  guard working as designed, not a defect, but it means "flush, then wait for
  the CLOSED" is not the whole story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)