### PR TITLE
fix(attractionsio): stop dropping operating days that close on the half hour

### DIFF
--- a/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
+++ b/src/parks/attractionsio/__tests__/attractionsiov1.test.ts
@@ -98,6 +98,16 @@ class Probe extends AttractionsIOV1 {
   live(): Promise<any[]> {
     return (this as any).buildLiveData();
   }
+
+  _calendar: any = {Locations: [{days: []}]};
+
+  override async fetchCalendar(): Promise<any> {
+    return {json: async () => this._calendar};
+  }
+
+  schedules(): Promise<any[]> {
+    return (this as any)._buildCalendarSchedules();
+  }
 }
 
 beforeEach(() => {
@@ -240,5 +250,67 @@ describe('parseLiveOpeningTimes', () => {
   test('skips a range whose bounds are missing or non-string', () => {
     expect(parseLiveOpeningTimes('{"type":"range","start":123,"end":456}', TZ)).toEqual([]);
     expect(parseLiveOpeningTimes('{"type":"range","start":"bad","end":"also-bad"}', TZ)).toEqual([]);
+  });
+});
+
+
+describe('_buildCalendarSchedules', () => {
+  /** Build a probe whose calendar returns exactly these day rows. */
+  function withDays(days: Array<{key: string; openingHours: string}>) {
+    const p = new Probe();
+    p._calendar = {Locations: [{days}]};
+    return p;
+  }
+
+  test('keeps a day whose closing time carries minutes (issue #545)', async () => {
+    // Verbatim rows from the LEGOLAND Windsor calendar for September 2026.
+    // The "4:30pm" days were previously dropped, so the API returned only
+    // Friday-Sunday for the rest of the month.
+    const [{schedule}] = await withDays([
+      {key: '20260906', openingHours: '10am - 6pm'},
+      {key: '20260907', openingHours: '10am - 4:30pm'},
+      {key: '20260908', openingHours: '10am - 4:30pm'},
+      {key: '20260911', openingHours: '10am - 5pm'},
+    ]).schedules();
+
+    expect(schedule.map((s: any) => s.date)).toEqual([
+      '2026-09-06',
+      '2026-09-07',
+      '2026-09-08',
+      '2026-09-11',
+    ]);
+    const sept7 = schedule.find((s: any) => s.date === '2026-09-07');
+    expect(sept7.type).toBe('OPERATING');
+    expect(sept7.openingTime).toContain('T10:00:00');
+    expect(sept7.closingTime).toContain('T16:30:00');
+  });
+
+  test('still drops a genuinely unparseable day, and warns about it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const [{schedule}] = await withDays([
+        {key: '20260906', openingHours: '10am - 6pm'},
+        {key: '20260907', openingHours: 'Closed'},
+        {key: '20260908', openingHours: 'Closed'},
+      ]).schedules();
+
+      expect(schedule.map((s: any) => s.date)).toEqual(['2026-09-06']);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0][0] as string;
+      expect(msg).toContain('dropped 2 calendar day(s)');
+      expect(msg).toContain('2x "Closed"');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('does not warn when every day parses', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withDays([{key: '20260906', openingHours: '10am - 6pm'}]).schedules();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/parks/attractionsio/__tests__/entityStore.test.ts
+++ b/src/parks/attractionsio/__tests__/entityStore.test.ts
@@ -8,6 +8,7 @@
 
 import {describe, test, expect, beforeEach} from 'vitest';
 import {database} from '../../../cache.js';
+import {parseOpeningHours} from '../attractionsiov1.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -636,46 +637,6 @@ describe('extractName', () => {
 });
 
 describe('parseOpeningHours', () => {
-  // Same approach — test the equivalent logic inline since it's module-scoped
-
-  function parseOpeningHours(raw: string) {
-    const fmt1 = /^(\d{1,2}):(\d{2})([ap]m)\s*-\s*(\d{1,2})([ap]m)$/i.exec(raw.trim());
-    if (fmt1) {
-      let openH = parseInt(fmt1[1], 10);
-      const openM = parseInt(fmt1[2], 10);
-      let closeH = parseInt(fmt1[4], 10);
-      if (fmt1[3].toLowerCase() === 'pm' && openH !== 12) openH += 12;
-      if (fmt1[5].toLowerCase() === 'pm' && closeH !== 12) closeH += 12;
-      if (fmt1[3].toLowerCase() === 'am' && openH === 12) openH = 0;
-      if (fmt1[5].toLowerCase() === 'am' && closeH === 12) closeH = 0;
-      return {
-        openTime: `${String(openH).padStart(2, '0')}:${String(openM).padStart(2, '0')}`,
-        closeTime: `${String(closeH).padStart(2, '0')}:00`,
-      };
-    }
-    const fmt2 = /^(\d{1,2})([ap]m)\s*-\s*(\d{1,2})([ap]m)$/i.exec(raw.trim());
-    if (fmt2) {
-      let openH = parseInt(fmt2[1], 10);
-      let closeH = parseInt(fmt2[3], 10);
-      if (fmt2[2].toLowerCase() === 'pm' && openH !== 12) openH += 12;
-      if (fmt2[4].toLowerCase() === 'pm' && closeH !== 12) closeH += 12;
-      if (fmt2[2].toLowerCase() === 'am' && openH === 12) openH = 0;
-      if (fmt2[4].toLowerCase() === 'am' && closeH === 12) closeH = 0;
-      return {
-        openTime: `${String(openH).padStart(2, '0')}:00`,
-        closeTime: `${String(closeH).padStart(2, '0')}:00`,
-      };
-    }
-    const fmt3 = /^(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/.exec(raw.trim());
-    if (fmt3) {
-      return {
-        openTime: `${String(parseInt(fmt3[1])).padStart(2, '0')}:${fmt3[2]}`,
-        closeTime: `${String(parseInt(fmt3[3])).padStart(2, '0')}:${fmt3[4]}`,
-      };
-    }
-    return null;
-  }
-
   test('parses "9:30am - 7pm"', () => {
     expect(parseOpeningHours('9:30am - 7pm')).toEqual({openTime: '09:30', closeTime: '19:00'});
   });
@@ -704,5 +665,61 @@ describe('parseOpeningHours', () => {
 
   test('handles leading/trailing whitespace', () => {
     expect(parseOpeningHours('  10am - 5pm  ')).toEqual({openTime: '10:00', closeTime: '17:00'});
+  });
+
+  // ── Regressions: half-hour closing times (issue #545) ────────────────────
+  //
+  // Both of these appear verbatim in live Merlin calendar feeds and were
+  // silently dropped, taking the whole operating day with them.
+
+  test('parses "10am - 4:30pm" (LEGOLAND Windsor term-time days)', () => {
+    expect(parseOpeningHours('10am - 4:30pm')).toEqual({openTime: '10:00', closeTime: '16:30'});
+  });
+
+  test('parses "10:30am - 4:30pm" (LEGOLAND California)', () => {
+    expect(parseOpeningHours('10:30am - 4:30pm')).toEqual({openTime: '10:30', closeTime: '16:30'});
+  });
+
+  test('keeps minutes on the closing time of a 12-hour range', () => {
+    // The old format-1 branch hardcoded ":00" for the closing minutes.
+    expect(parseOpeningHours('9:30am - 7:45pm')).toEqual({openTime: '09:30', closeTime: '19:45'});
+  });
+
+  // ── Separator and spacing tolerance ──────────────────────────────────────
+
+  test('accepts a missing space around the separator', () => {
+    expect(parseOpeningHours('10am-5pm')).toEqual({openTime: '10:00', closeTime: '17:00'});
+  });
+
+  test('accepts en dash and em dash separators', () => {
+    expect(parseOpeningHours('10am \u2013 5pm')).toEqual({openTime: '10:00', closeTime: '17:00'});
+    expect(parseOpeningHours('10am \u2014 5pm')).toEqual({openTime: '10:00', closeTime: '17:00'});
+  });
+
+  test('accepts "a.m."/"p.m." punctuation and uppercase', () => {
+    expect(parseOpeningHours('10A.M. - 4:30P.M.')).toEqual({openTime: '10:00', closeTime: '16:30'});
+  });
+
+  test('accepts a mixed 24-hour and 12-hour range', () => {
+    expect(parseOpeningHours('10:00 - 5pm')).toEqual({openTime: '10:00', closeTime: '17:00'});
+  });
+
+  test('accepts an overnight range without reordering it', () => {
+    expect(parseOpeningHours('10am - 1am')).toEqual({openTime: '10:00', closeTime: '01:00'});
+  });
+
+  // ── Out-of-range values must stay null, not wrap into nonsense ───────────
+
+  test('rejects out-of-range hours and minutes', () => {
+    expect(parseOpeningHours('25:00 - 26:00')).toBeNull();
+    expect(parseOpeningHours('10:75 - 17:00')).toBeNull();
+    expect(parseOpeningHours('13pm - 5pm')).toBeNull();
+    expect(parseOpeningHours('0pm - 5pm')).toBeNull();
+  });
+
+  test('rejects ranges with a missing or extra side', () => {
+    expect(parseOpeningHours('10am -')).toBeNull();
+    expect(parseOpeningHours('10am')).toBeNull();
+    expect(parseOpeningHours('10am - 5pm - 9pm')).toBeNull();
   });
 });

--- a/src/parks/attractionsio/attractionsiov1.ts
+++ b/src/parks/attractionsio/attractionsiov1.ts
@@ -185,59 +185,61 @@ type InstallationResponse = {
 type TimeParseResult = {openTime: string; closeTime: string} | null;
 
 /**
- * Parse a raw "openingHours" string such as "9:30am - 7pm" or "10:00 - 17:00"
- * into a pair of HH:mm strings.  Returns null when the format is unrecognised.
+ * Parse one side of an opening-hours range ("10am", "4:30pm", "17:00", "9:30")
+ * into minutes-since-midnight.  Returns null when the token is unrecognised or
+ * out of range.
+ *
+ * A token without a meridiem is read as 24-hour clock time.
  */
-function parseOpeningHours(raw: string): TimeParseResult {
-  // Format 1: 9:30am - 7pm
-  const fmt1 = /^(\d{1,2}):(\d{2})([ap]m)\s*-\s*(\d{1,2})([ap]m)$/i.exec(raw.trim());
-  if (fmt1) {
-    let openH = parseInt(fmt1[1], 10);
-    const openM = parseInt(fmt1[2], 10);
-    let closeH = parseInt(fmt1[4], 10);
-    const amPmOpen = fmt1[3].toLowerCase();
-    const amPmClose = fmt1[5].toLowerCase();
-    if (amPmOpen === 'pm' && openH !== 12) openH += 12;
-    if (amPmClose === 'pm' && closeH !== 12) closeH += 12;
-    if (amPmOpen === 'am' && openH === 12) openH = 0;
-    if (amPmClose === 'am' && closeH === 12) closeH = 0;
-    return {
-      openTime: `${String(openH).padStart(2, '0')}:${String(openM).padStart(2, '0')}`,
-      closeTime: `${String(closeH).padStart(2, '0')}:00`,
-    };
+function parseTimeToken(raw: string): {hour: number; minute: number} | null {
+  const m = /^(\d{1,2})(?::(\d{2}))?\s*(?:([ap])\.?m\.?)?$/i.exec(raw.trim());
+  if (!m) return null;
+
+  let hour = parseInt(m[1], 10);
+  const minute = m[2] === undefined ? 0 : parseInt(m[2], 10);
+  const meridiem = m[3]?.toLowerCase();
+
+  if (minute > 59) return null;
+
+  if (meridiem) {
+    // 12-hour clock: only 1-12 are meaningful, so "0pm"/"13pm" are rejected
+    // rather than silently wrapped into a plausible-looking time.
+    if (hour < 1 || hour > 12) return null;
+    if (meridiem === 'p' && hour !== 12) hour += 12;
+    if (meridiem === 'a' && hour === 12) hour = 0;
+  } else if (hour > 23) {
+    return null;
   }
 
-  // Format 2: 10am - 5pm
-  const fmt2 = /^(\d{1,2})([ap]m)\s*-\s*(\d{1,2})([ap]m)$/i.exec(raw.trim());
-  if (fmt2) {
-    let openH = parseInt(fmt2[1], 10);
-    let closeH = parseInt(fmt2[3], 10);
-    const amPmOpen = fmt2[2].toLowerCase();
-    const amPmClose = fmt2[4].toLowerCase();
-    if (amPmOpen === 'pm' && openH !== 12) openH += 12;
-    if (amPmClose === 'pm' && closeH !== 12) closeH += 12;
-    if (amPmOpen === 'am' && openH === 12) openH = 0;
-    if (amPmClose === 'am' && closeH === 12) closeH = 0;
-    return {
-      openTime: `${String(openH).padStart(2, '0')}:00`,
-      closeTime: `${String(closeH).padStart(2, '0')}:00`,
-    };
-  }
+  return {hour, minute};
+}
 
-  // Format 3: 10:00 - 17:00
-  const fmt3 = /^(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/.exec(raw.trim());
-  if (fmt3) {
-    const openH = parseInt(fmt3[1], 10);
-    const openM = parseInt(fmt3[2], 10);
-    const closeH = parseInt(fmt3[3], 10);
-    const closeM = parseInt(fmt3[4], 10);
-    return {
-      openTime: `${String(openH).padStart(2, '0')}:${String(openM).padStart(2, '0')}`,
-      closeTime: `${String(closeH).padStart(2, '0')}:${String(closeM).padStart(2, '0')}`,
-    };
-  }
+/**
+ * Parse a raw "openingHours" string such as "9:30am - 7pm", "10am - 4:30pm" or
+ * "10:00 - 17:00" into a pair of HH:mm strings.  Returns null when the format
+ * is unrecognised.
+ *
+ * Each side of the range is parsed independently, so every combination of
+ * 12-hour/24-hour and with/without minutes is accepted. Feeds mix these
+ * freely: LEGOLAND Windsor publishes "10am - 4:30pm" for term-time days and
+ * "10am - 6pm" for weekends, in the same calendar.
+ *
+ * The range is never reordered - a closing time earlier than the opening time
+ * is a legitimate past-midnight close.
+ */
+export function parseOpeningHours(raw: string): TimeParseResult {
+  // Hyphen, en dash or em dash, and exactly two sides.
+  const parts = raw.trim().split(/\s*[-\u2013\u2014]\s*/);
+  if (parts.length !== 2) return null;
 
-  return null;
+  const open = parseTimeToken(parts[0]);
+  const close = parseTimeToken(parts[1]);
+  if (!open || !close) return null;
+
+  const fmt = (t: {hour: number; minute: number}) =>
+    `${String(t.hour).padStart(2, '0')}:${String(t.minute).padStart(2, '0')}`;
+
+  return {openTime: fmt(open), closeTime: fmt(close)};
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1317,12 +1319,22 @@ class AttractionsIOV1 extends Destination {
       closingTime: string;
     }> = [];
 
+    // An unparseable day is dropped, which silently removes a real operating
+    // day from the schedule. Collect the offending formats and warn once, so a
+    // new upstream wording is visible instead of just quietly shrinking the
+    // calendar.
+    const unparsed = new Map<string, number>();
+
     for (const day of days) {
       const dateStr = parseYYYYMMDD(day.key); // "20260330" → "2026-03-30"
       if (!dateStr) continue;
 
       const times = parseOpeningHours(day.openingHours);
-      if (!times) continue;
+      if (!times) {
+        const raw = String(day.openingHours ?? '');
+        unparsed.set(raw, (unparsed.get(raw) ?? 0) + 1);
+        continue;
+      }
 
       schedule.push({
         date: dateStr,
@@ -1330,6 +1342,16 @@ class AttractionsIOV1 extends Destination {
         openingTime: constructDateTime(dateStr, times.openTime, this.timezone),
         closingTime: constructDateTime(dateStr, times.closeTime, this.timezone),
       });
+    }
+
+    if (unparsed.size) {
+      const summary = [...unparsed.entries()]
+        .map(([raw, count]) => `${count}x ${JSON.stringify(raw)}`)
+        .join(', ');
+      console.warn(
+        `[${this.constructor.name}] dropped ${[...unparsed.values()].reduce((a, b) => a + b, 0)} ` +
+        `calendar day(s) with unrecognised openingHours: ${summary}`,
+      );
     }
 
     return [{id: this.parkId, schedule}];


### PR DESCRIPTION
Closes #545

## What was happening

`_buildCalendarSchedules()` parsed each day's `openingHours` with three
whole-string regexes. None of them accepted a 12-hour range whose **closing**
time carries minutes:

| Format | Old result |
|---|---|
| `10am - 6pm` | ✅ parsed |
| `9:30am - 7pm` | ✅ parsed |
| `10:00 - 17:00` | ✅ parsed |
| `10am - 4:30pm` | ❌ null → day silently skipped |
| `10:30am - 4:30pm` | ❌ null → day silently skipped |

A null meant `continue`, with no log, so the day just disappeared. A missing day
is indistinguishable from a day the park is genuinely closed, which is why this
read as an upstream gap rather than a parser bug.

## Impact, measured against the live feeds

LEGOLAND Windsor publishes `10am - 4:30pm` for term-time midweek days:

- **19 of 73** calendar days dropped, so the schedule showed only Fri–Sun for
  most of September.

Sweeping the calendar feed of every park that uses this builder found a second
park hit by the same gap:

- **LEGOLAND California**: `10:30am - 4:30pm`, **31 of 110** days dropped.

The other 12 parks on this builder were unaffected.

## The fix

Parse each side of the range independently rather than matching the whole
string. Every combination of 12-hour/24-hour and with/without minutes is now
accepted, plus en/em dash separators and `a.m.`/`p.m.` punctuation.

Out-of-range values are now rejected instead of being emitted as nonsense: the
old 24-hour branch turned `25:00 - 26:00` into an actual schedule entry.

An unrecognised format now logs a warning naming the format and how many days
were lost, so the next unseen wording surfaces instead of quietly shrinking the
calendar.

## Verification

Differential run of the old and new parser over every `openingHours` string in
all 14 live feeds:

```
distinct strings=30  unchanged=27  recovered=3  altered=0
```

The change is purely additive — no string that parsed before parses differently
now.

LEGOLAND Windsor schedule after the fix, September 2026 — all 11 days named in
the issue are back at 10:00–16:30, and the Wednesdays from the 9th stay absent
because the park really is closed:

```
2026-09-07 OPERATING 10:00+01:00 -> 16:30+01:00
2026-09-08 OPERATING 10:00+01:00 -> 16:30+01:00
2026-09-10 OPERATING 10:00+01:00 -> 16:30+01:00
2026-09-14/15/17/21/22/24/28/29  likewise
```

Day counts through the harness: Windsor 54 → 73, California 79 → 110.

## Tests

- `parseOpeningHours` is now **exported and tested directly**. The previous
  tests re-implemented a copy of the parser inline, which is exactly why they
  stayed green while the shipped parser dropped a quarter of Windsor's calendar.
- Regression cases for both real-world formats, plus separator/punctuation
  tolerance, overnight ranges, and out-of-range rejection.
- Builder-level tests covering the recovered day, the warning on a genuinely
  unparseable day, and no warning when everything parses.

Full suite: 110 files, 2386 tests passing. `npm run dev` passes 4/4 for both
affected parks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)