### PR TITLE
fix(parcasterix): close a show that is not on today's bill

### DIFF
--- a/src/parks/parcasterix/__tests__/showAbsence.test.ts
+++ b/src/parks/parcasterix/__tests__/showAbsence.test.ts
@@ -1,0 +1,171 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {ParcAsterix, type POIEntry} from '../parcasterix.js';
+import {CacheLib} from '../../../cache.js';
+
+/**
+ * `paxSchedules` is a same-day bill: it carries one entry per show performing
+ * today and nothing at all for the rest. A show that is dark today therefore
+ * has no live row to key off, and the collector is upsert-only — so the wiki
+ * kept serving whichever showtimes the show last performed to, still reading
+ * OPERATING. Three Parc Asterix shows were sitting on 11-day-old times when a
+ * user reported it.
+ *
+ * Absence is not ambiguous here, so it does not need a multi-day window to
+ * interpret: a show missing from a bill that lists every performance today has
+ * no performances today, which is exactly what CLOSED says.
+ */
+const show = (drupalId: number, title = `Show ${drupalId}`): POIEntry => ({
+  drupal_id: drupalId,
+  title,
+  titles: {en: title},
+  latitude: 49.13675,
+  longitude: 2.573816,
+  _type: 'show',
+});
+
+const latency = (drupalId: string, isOpen = true, latencyValue: number | null = 10) => ({
+  drupalId,
+  latency: latencyValue,
+  isOpen,
+  message: null,
+  openingTime: null,
+  closingTime: null,
+});
+
+const performance = (drupalId: string) => ({
+  drupalId,
+  times: [{at: '14:00:00', startAt: null, endAt: null}],
+});
+
+const ATTRACTIONS = Array.from({length: 20}, (_, i) => latency(String(31303 + i)));
+
+function stubbedPark(
+  latencies: ReturnType<typeof latency>[],
+  schedules: ReturnType<typeof performance>[],
+  poi: POIEntry[],
+): ParcAsterix {
+  const park = new ParcAsterix();
+  vi.spyOn(park as any, 'getPolling').mockResolvedValue({latencies, schedules});
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({poi, calendar: []});
+  return park;
+}
+
+describe('Parc Asterix shows dark today', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
+  });
+
+  it('closes a show that is not on today’s bill', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483')],
+      [show(31483), show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  it('publishes no showtimes on the closed row, rather than the last ones it saw', async () => {
+    const park = stubbedPark(ATTRACTIONS, [performance('31513')], [show(31513)]);
+    const performing = await park.getLiveData();
+    expect(performing.find((l) => l.id === '31513')?.showtimes).toHaveLength(1);
+
+    const dark = await stubbedPark(ATTRACTIONS, [], [show(31513)]).getLiveData();
+    expect(dark.find((l) => l.id === '31513')?.showtimes).toBeUndefined();
+  });
+
+  it('closes a show whose run ended before this gate ever saw it perform', async () => {
+    // The retirement gate can only close ids it has watched go absent, so a
+    // show that stopped performing before the code shipped is invisible to it.
+    // Reading the bill directly needs no such history.
+    const live = await stubbedPark(ATTRACTIONS, [], [show(31509), show(31513)]).getLiveData();
+
+    expect(live.find((l) => l.id === '31509')).toEqual({id: '31509', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  it('reopens the show the day it is back on the bill', async () => {
+    await stubbedPark(ATTRACTIONS, [], [show(31513)]).getLiveData();
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31513')],
+      [show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31513')).toMatchObject({status: 'OPERATING'});
+  });
+
+  // A gutted GraphQL response parses cleanly into empty arrays. Reading that as
+  // "every show is dark" would publish a confident CLOSED across a park that is
+  // open, so the attraction bill has to corroborate that the feed is alive.
+  it('says nothing when the whole polling feed comes back empty', async () => {
+    const live = await stubbedPark([], [], [show(31483), show(31513)]).getLiveData();
+
+    expect(live).toHaveLength(0);
+  });
+
+  // Winter closure: every show leaves the bill at once while paxLatencies keeps
+  // listing the attractions as shut. That is a real closure, not a broken feed.
+  it('closes every show across a seasonal shutdown', async () => {
+    const shut = ATTRACTIONS.map((a) => latency(a.drupalId, false, null));
+    const live = await stubbedPark(shut, [], [show(31483), show(31513)]).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  // 31497 returned live showtimes for a spell while no package database carried
+  // a POI row for it. The bill is the authority on what is performing; the POI
+  // list only supplies the ids that can be closed.
+  it('keeps a scheduled show that has no POI row', async () => {
+    const live = await stubbedPark(ATTRACTIONS, [performance('31497')], []).getLiveData();
+
+    expect(live.find((l) => l.id === '31497')).toMatchObject({status: 'OPERATING'});
+  });
+
+  it('emits one row per show, never a live row and a closed one', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483')],
+      [show(31483), show(31513)],
+    ).getLiveData();
+
+    const ids = live.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('Parc Asterix polling response', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
+  });
+
+  const withResponse = (body: unknown) => {
+    const park = new ParcAsterix();
+    vi.spyOn(park as any, 'fetchPolling').mockResolvedValue({
+      json: async () => body,
+    });
+    return park;
+  };
+
+  it('throws rather than reading a GraphQL error as an empty park', async () => {
+    await expect(
+      withResponse({errors: [{message: 'Internal server error'}]})['getPolling'](),
+    ).rejects.toThrow(/Internal server error/);
+  });
+
+  it('throws when the payload is missing either bill', async () => {
+    await expect(
+      withResponse({data: {paxLatencies: []}})['getPolling'](),
+    ).rejects.toThrow(/paxSchedules/);
+  });
+
+  it('accepts a legitimately empty bill', async () => {
+    await expect(
+      withResponse({data: {paxLatencies: [], paxSchedules: []}})['getPolling'](),
+    ).resolves.toEqual({latencies: [], schedules: []});
+  });
+});

--- a/src/parks/parcasterix/__tests__/showAbsence.test.ts
+++ b/src/parks/parcasterix/__tests__/showAbsence.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {ParcAsterix, type POIEntry} from '../parcasterix.js';
+import {ParcAsterix, showBillAuthority, type POIEntry} from '../parcasterix.js';
 import {CacheLib} from '../../../cache.js';
 
 /**
@@ -52,17 +52,45 @@ const ATTRACTIONS = ATTRACTION_IDS.map((id) => latency(String(id)));
 /** The package rows behind ATTRACTIONS, so the corroboration check has a denominator. */
 const ATTRACTION_POI = ATTRACTION_IDS.map(attraction);
 
-/** Mid-afternoon in Europe/Paris — outside the after-midnight window. */
+/** Mid-afternoon in Europe/Paris — park open, bill already rewritten for today. */
 const DAYTIME = new Date('2026-09-09T12:00:00Z');
+
+/**
+ * An ordinary 10:00-18:00 operating day for whenever the clock currently says
+ * it is. Absence is only read as darkness once the park has opened, so a test
+ * that wants the bill believed has to be standing on an open day inside its
+ * hours — an empty calendar means "say nothing", which is the correct answer
+ * and a silent way to make an assertion vacuous.
+ */
+const openDay = (date: string) => ({
+  date,
+  type: 'OPERATING',
+  openingTime: `${date}T10:00:00+02:00`,
+  closingTime: `${date}T18:00:00+02:00`,
+});
+
+const openToday = () => [openDay(new Date().toISOString().slice(0, 10))];
+
+/**
+ * A real closed day: the calendar is populated, today simply is not in it,
+ * because a day with no hours never reaches the calendar at all. An *empty*
+ * calendar is a different thing — a package that failed to parse — and must
+ * not be read as a park-wide closure.
+ */
+const closedToday = () => [openDay('2026-09-06'), openDay('2026-09-12')];
 
 function stubbedPark(
   latencies: ReturnType<typeof latency>[],
   schedules: ReturnType<typeof performance>[],
   poi: POIEntry[],
+  calendar: () => any[] = openToday,
 ): ParcAsterix {
   const park = new ParcAsterix();
   vi.spyOn(park as any, 'getPolling').mockResolvedValue({latencies, schedules});
-  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({poi, calendar: []});
+  vi.spyOn(park as any, 'getPOIData').mockImplementation(async () => ({
+    poi,
+    calendar: calendar(),
+  }));
   return park;
 }
 
@@ -208,6 +236,18 @@ describe('Parc Asterix dark-show guards', () => {
 
   // A gutted response reaching buildLiveData by any route must not be read as
   // a park where every show is dark.
+  // A package that failed to parse leaves no calendar. That is not a closure.
+  it('says nothing about shows when the calendar is empty', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [],
+      [...ATTRACTION_POI, show(31513)],
+      () => [],
+    ).getLiveData();
+
+    expect(live.filter((l) => l.status === 'CLOSED' && !l.queue)).toEqual([]);
+  });
+
   it('says nothing when the whole polling feed comes back empty', async () => {
     const live = await stubbedPark([], [], [...ATTRACTION_POI, show(31483), show(31513)]).getLiveData();
 
@@ -264,8 +304,40 @@ describe('Parc Asterix dark-show guards', () => {
     expect(live.filter((l) => l.status === 'CLOSED' && !l.queue)).toEqual([]);
   });
 
-  it('resumes closing once the small hours are over', async () => {
-    vi.setSystemTime(new Date('2026-10-18T04:30:00Z')); // 06:30 Europe/Paris
+  // The bill served overnight is the last open day's and is not rewritten for
+  // today until the morning, so being past the small hours is not enough.
+  // Before opening the bill is still the last open day's, so republishing its
+  // performances would assert a passed day's programme as today's — which is
+  // how the wiki came to serve a 19:00-close day's showtimes on an 18:00 day.
+  it('publishes nothing about shows before the park opens', async () => {
+    vi.setSystemTime(new Date('2026-09-09T05:30:00Z')); // 07:30 Europe/Paris
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483')],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toBeUndefined();
+    expect(live.find((l) => l.id === '31513')).toBeUndefined();
+    expect(live).toHaveLength(ATTRACTIONS.length);
+  });
+
+  // The small hours are different: an event night's bill is still that night's
+  // and still correct, so its performances must keep publishing.
+  it('keeps publishing performances in the after-midnight tail', async () => {
+    vi.setSystemTime(new Date('2026-10-17T23:30:00Z')); // 01:30 Europe/Paris
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483', [{at: '00:45:00', startAt: null, endAt: null}])],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
+    expect(live.find((l) => l.id === '31513')).toBeUndefined();
+  });
+
+  it('resumes closing once the park has opened', async () => {
+    vi.setSystemTime(new Date('2026-09-09T08:30:00Z')); // 10:30 Europe/Paris
     const live = await stubbedPark(
       ATTRACTIONS,
       [],
@@ -273,6 +345,35 @@ describe('Parc Asterix dark-show guards', () => {
     ).getLiveData();
 
     expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  // Closed days never reach the calendar, and the bill keeps serving the last
+  // open day's programme straight through them — so a closed day is exactly
+  // when a stale bill looks most like a live one.
+  it('closes every show, bill included, on a day the park does not operate', async () => {
+    const shut = ATTRACTIONS.map((a) => latency(a.drupalId, false, null));
+    const live = await stubbedPark(
+      shut,
+      [performance('31483')],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+      closedToday,
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31483')?.showtimes).toBeUndefined();
+  });
+
+  it('publishes nothing about shows when a closed calendar meets open rides', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483')],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+      closedToday,
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
+    expect(live.find((l) => l.id === '31513')).toBeUndefined();
   });
 
   // The live path never used to touch the offline package. Putting a 23MB ZIP
@@ -370,5 +471,74 @@ describe('Parc Asterix polling response', () => {
     await expect(
       withResponse({data: {paxLatencies: [], paxSchedules: []}, errors: []})['getPolling'](),
     ).resolves.toEqual({latencies: [], schedules: []});
+  });
+});
+
+describe('showBillAuthority', () => {
+  const hours = (date: string, open: string, close: string) => ({
+    date,
+    type: 'OPERATING',
+    openingTime: `${date}T${open}+02:00`,
+    closingTime: `${date}T${close}+02:00`,
+  });
+  const TODAY = hours('2026-09-09', '10:00:00', '18:00:00');
+  const at = (iso: string) => new Date(iso);
+
+  it('reads the bill once the park has opened', () => {
+    expect(showBillAuthority(at('2026-09-09T08:30:00Z'), 'Europe/Paris', [TODAY], true))
+      .toBe('read-bill'); // 10:30 local
+  });
+
+  // The hole the 06:00 guard alone left open: the bill served between midnight
+  // and the morning rewrite is the last open day's, so absence from it means
+  // "was not on that day", not "is not on today".
+  it('calls the bill stale between the small hours and opening', () => {
+    for (const utc of ['2026-09-09T04:30:00Z', '2026-09-09T06:00:00Z', '2026-09-09T07:28:00Z']) {
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], false)).toBe('stale');
+    }
+  });
+
+  // The sharp one: a Halloween night runs 19:00 to 01:00 into a day the park
+  // does not operate. Without the night guard the closed-day branch fires at
+  // 00:30 and closes every show while the night is still running.
+  it('stays silent past midnight when the next day is a closed day', () => {
+    const night = {
+      date: '2026-10-17',
+      type: 'TICKETED_EVENT',
+      openingTime: '2026-10-17T19:00:00+02:00',
+      closingTime: '2026-10-18T01:00:00+02:00',
+    };
+    expect(showBillAuthority(at('2026-10-17T22:30:00Z'), 'Europe/Paris', [night], false))
+      .toBe('unknown'); // 00:30 local on the 18th, which carries no hours
+  });
+
+  it('stays silent in the after-midnight tail of an event night', () => {
+    const night = {
+      date: '2026-10-17',
+      type: 'TICKETED_EVENT',
+      openingTime: '2026-10-17T19:00:00+02:00',
+      closingTime: '2026-10-18T01:00:00+02:00',
+    };
+    expect(showBillAuthority(at('2026-10-17T23:30:00Z'), 'Europe/Paris', [night], true))
+      .toBe('unknown'); // 01:30 local on the 18th
+  });
+
+  // Closed days carry no hours, so they never reach the calendar. The bill
+  // keeps serving the last open day's programme straight through them.
+  it('calls every show dark on a day the park does not operate', () => {
+    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY], false))
+      .toBe('all-dark');
+  });
+
+  // A calendar that says closed while the rides say open is a calendar to
+  // distrust, not a park to close.
+  it('defers to the live feed when it contradicts a closed calendar', () => {
+    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY], true))
+      .toBe('unknown');
+  });
+
+  it('admits it cannot tell with no calendar at all', () => {
+    expect(showBillAuthority(at('2026-09-09T10:00:00Z'), 'Europe/Paris', [], false))
+      .toBe('unknown');
   });
 });

--- a/src/parks/parcasterix/__tests__/showAbsence.test.ts
+++ b/src/parks/parcasterix/__tests__/showAbsence.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {ParcAsterix, type POIEntry} from '../parcasterix.js';
 import {CacheLib} from '../../../cache.js';
 
@@ -23,6 +23,16 @@ const show = (drupalId: number, title = `Show ${drupalId}`): POIEntry => ({
   _type: 'show',
 });
 
+const attraction = (drupalId: number): POIEntry => ({
+  ...show(drupalId, `Attraction ${drupalId}`),
+  _type: 'attraction',
+});
+
+const restaurant = (drupalId: number): POIEntry => ({
+  ...show(drupalId, `Restaurant ${drupalId}`),
+  _type: 'restaurant',
+});
+
 const latency = (drupalId: string, isOpen = true, latencyValue: number | null = 10) => ({
   drupalId,
   latency: latencyValue,
@@ -32,12 +42,18 @@ const latency = (drupalId: string, isOpen = true, latencyValue: number | null = 
   closingTime: null,
 });
 
-const performance = (drupalId: string) => ({
+const performance = (drupalId: string, times = [{at: '14:00:00', startAt: null, endAt: null}]) => ({
   drupalId,
-  times: [{at: '14:00:00', startAt: null, endAt: null}],
+  times,
 });
 
-const ATTRACTIONS = Array.from({length: 20}, (_, i) => latency(String(31303 + i)));
+const ATTRACTION_IDS = Array.from({length: 20}, (_, i) => 31303 + i);
+const ATTRACTIONS = ATTRACTION_IDS.map((id) => latency(String(id)));
+/** The package rows behind ATTRACTIONS, so the corroboration check has a denominator. */
+const ATTRACTION_POI = ATTRACTION_IDS.map(attraction);
+
+/** Mid-afternoon in Europe/Paris — outside the after-midnight window. */
+const DAYTIME = new Date('2026-09-09T12:00:00Z');
 
 function stubbedPark(
   latencies: ReturnType<typeof latency>[],
@@ -54,86 +70,244 @@ describe('Parc Asterix shows dark today', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
+    vi.useFakeTimers();
+    vi.setSystemTime(DAYTIME);
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it('closes a show that is not on today’s bill', async () => {
     const live = await stubbedPark(
       ATTRACTIONS,
       [performance('31483')],
-      [show(31483), show(31513)],
+      [...ATTRACTION_POI, show(31483), show(31513)],
     ).getLiveData();
 
-    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
+    expect(live.find((l) => l.id === '31483')).toEqual({
+      id: '31483',
+      status: 'OPERATING',
+      showtimes: [
+        {
+          type: 'Performance Time',
+          startTime: '2026-09-09T14:00:00+02:00',
+          endTime: '2026-09-09T14:00:00+02:00',
+        },
+      ],
+    });
     expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
-  it('publishes no showtimes on the closed row, rather than the last ones it saw', async () => {
-    const park = stubbedPark(ATTRACTIONS, [performance('31513')], [show(31513)]);
-    const performing = await park.getLiveData();
+  it('publishes a closed row, not the last showtimes it saw', async () => {
+    const poi = [...ATTRACTION_POI, show(31513)];
+    const performing = await stubbedPark(ATTRACTIONS, [performance('31513')], poi).getLiveData();
     expect(performing.find((l) => l.id === '31513')?.showtimes).toHaveLength(1);
 
-    const dark = await stubbedPark(ATTRACTIONS, [], [show(31513)]).getLiveData();
-    expect(dark.find((l) => l.id === '31513')?.showtimes).toBeUndefined();
+    const dark = await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
+    // Not `?.showtimes` — an optional chain here cannot tell a closed row with
+    // no showtimes from no row at all, which is the whole point of the test.
+    expect(dark.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
   it('closes a show whose run ended before this gate ever saw it perform', async () => {
     // The retirement gate can only close ids it has watched go absent, so a
     // show that stopped performing before the code shipped is invisible to it.
     // Reading the bill directly needs no such history.
-    const live = await stubbedPark(ATTRACTIONS, [], [show(31509), show(31513)]).getLiveData();
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [],
+      [...ATTRACTION_POI, show(31509), show(31513)],
+    ).getLiveData();
 
     expect(live.find((l) => l.id === '31509')).toEqual({id: '31509', status: 'CLOSED'});
     expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
   it('reopens the show the day it is back on the bill', async () => {
-    await stubbedPark(ATTRACTIONS, [], [show(31513)]).getLiveData();
-    const live = await stubbedPark(
-      ATTRACTIONS,
-      [performance('31513')],
-      [show(31513)],
-    ).getLiveData();
+    const poi = [...ATTRACTION_POI, show(31513)];
+    const dark = await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
+    expect(dark.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
 
+    const live = await stubbedPark(ATTRACTIONS, [performance('31513')], poi).getLiveData();
     expect(live.find((l) => l.id === '31513')).toMatchObject({status: 'OPERATING'});
   });
 
-  // A gutted GraphQL response parses cleanly into empty arrays. Reading that as
-  // "every show is dark" would publish a confident CLOSED across a park that is
-  // open, so the attraction bill has to corroborate that the feed is alive.
+  it('closes only shows, never an attraction or a restaurant', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [],
+      [...ATTRACTION_POI, attraction(99991), restaurant(99992), show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '99991')).toBeUndefined();
+    expect(live.find((l) => l.id === '99992')).toBeUndefined();
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  it('never publishes a row for a show with no usable id', async () => {
+    const live = await stubbedPark(ATTRACTIONS, [], [
+      ...ATTRACTION_POI,
+      {...show(0), drupal_id: 0},
+      {...show(1), drupal_id: undefined as unknown as number},
+      show(31513),
+    ]).getLiveData();
+
+    for (const bad of ['0', 'undefined', 'NaN', 'null', '']) {
+      expect(live.find((l) => l.id === bad)).toBeUndefined();
+    }
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  // A show on the bill with no performances left is already closed by the
+  // showtime pass. It must not also collect a dark row.
+  it('emits one row for a show on the bill with no times', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31513', [])],
+      [...ATTRACTION_POI, show(31513)],
+    ).getLiveData();
+
+    expect(live.filter((l) => l.id === '31513')).toEqual([{id: '31513', status: 'CLOSED'}]);
+  });
+
+  // The two bills have always been disjoint, but if an id ever appeared in
+  // both, the observation has to beat the inference — otherwise the build
+  // carries OPERATING and CLOSED for one id and array order decides.
+  it('lets a live observation win over an inferred closure', async () => {
+    const live = await stubbedPark(
+      [...ATTRACTIONS, latency('31513')],
+      [],
+      [...ATTRACTION_POI, show(31513)],
+    ).getLiveData();
+
+    expect(live.filter((l) => l.id === '31513')).toEqual([
+      {id: '31513', status: 'OPERATING', queue: {STANDBY: {waitTime: 10}}},
+    ]);
+  });
+
+  it('emits at most one row per id', async () => {
+    const live = await stubbedPark(
+      [...ATTRACTIONS, latency('31513')],
+      [performance('31483'), performance('31513')],
+      [...ATTRACTION_POI, show(31483), show(31513), show(31509)],
+    ).getLiveData();
+
+    const ids = live.map((l) => l.id);
+    expect(ids).toHaveLength(new Set(ids).size);
+  });
+});
+
+describe('Parc Asterix dark-show guards', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
+    vi.useFakeTimers();
+    vi.setSystemTime(DAYTIME);
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  // A gutted response reaching buildLiveData by any route must not be read as
+  // a park where every show is dark.
   it('says nothing when the whole polling feed comes back empty', async () => {
-    const live = await stubbedPark([], [], [show(31483), show(31513)]).getLiveData();
+    const live = await stubbedPark([], [], [...ATTRACTION_POI, show(31483), show(31513)]).getLiveData();
 
     expect(live).toHaveLength(0);
+  });
+
+  // The real shape of an upstream wobble is partial, not empty. One attraction
+  // out of twenty is not a feed that can speak for what is dark.
+  it('says nothing when the attraction bill comes back a fraction of itself', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS.slice(0, 1),
+      [],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+    ).getLiveData();
+
+    expect(live.filter((l) => l.status === 'CLOSED' && !l.queue)).toEqual([]);
+  });
+
+  it('closes shows once the attraction bill is back over half', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS.slice(0, 10),
+      [],
+      [...ATTRACTION_POI, show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
   // Winter closure: every show leaves the bill at once while paxLatencies keeps
   // listing the attractions as shut. That is a real closure, not a broken feed.
   it('closes every show across a seasonal shutdown', async () => {
     const shut = ATTRACTIONS.map((a) => latency(a.drupalId, false, null));
-    const live = await stubbedPark(shut, [], [show(31483), show(31513)]).getLiveData();
+    const live = await stubbedPark(
+      shut,
+      [],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+    ).getLiveData();
 
     expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
     expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
-  // 31497 returned live showtimes for a spell while no package database carried
-  // a POI row for it. The bill is the authority on what is performing; the POI
-  // list only supplies the ids that can be closed.
-  it('keeps a scheduled show that has no POI row', async () => {
-    const live = await stubbedPark(ATTRACTIONS, [performance('31497')], []).getLiveData();
-
-    expect(live.find((l) => l.id === '31497')).toMatchObject({status: 'OPERATING'});
-  });
-
-  it('emits one row per show, never a live row and a closed one', async () => {
+  // The bill rolls at local midnight while a Halloween night still has an hour
+  // to run, and a show physically mid-performance would otherwise be absent
+  // from a bill for a day that has not started.
+  it('closes nothing in the after-midnight tail of an event night', async () => {
+    vi.setSystemTime(new Date('2026-10-17T23:30:00Z')); // 01:30 Europe/Paris
     const live = await stubbedPark(
       ATTRACTIONS,
-      [performance('31483')],
-      [show(31483), show(31513)],
+      [],
+      [...ATTRACTION_POI, show(31483), show(31513)],
     ).getLiveData();
 
-    const ids = live.map((l) => l.id);
-    expect(new Set(ids).size).toBe(ids.length);
+    expect(live.filter((l) => l.status === 'CLOSED' && !l.queue)).toEqual([]);
+  });
+
+  it('resumes closing once the small hours are over', async () => {
+    vi.setSystemTime(new Date('2026-10-18T04:30:00Z')); // 06:30 Europe/Paris
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [],
+      [...ATTRACTION_POI, show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  // The live path never used to touch the offline package. Putting a 23MB ZIP
+  // between the bill and the wait times must not cost the wait times.
+  it('keeps publishing wait times when the offline package is unreachable', async () => {
+    const park = new ParcAsterix();
+    vi.spyOn(park as any, 'getPolling').mockResolvedValue({
+      latencies: ATTRACTIONS,
+      schedules: [performance('31483')],
+    });
+    vi.spyOn(park as any, 'getPOIData').mockRejectedValue(new Error('package 503'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const live = await park.getLiveData();
+
+    expect(live.find((l) => l.id === '31303')).toEqual({
+      id: '31303',
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 10}},
+    });
+    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
+    expect(live.filter((l) => l.status === 'CLOSED' && !l.queue)).toEqual([]);
+  });
+
+  // A show that is only in the bill and in no package database still publishes
+  // its performances; the POI list only supplies the ids that can be closed.
+  it('keeps a scheduled show that has no POI row', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31497')],
+      [...ATTRACTION_POI, show(31513)],
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31497')).toMatchObject({status: 'OPERATING'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 });
 
@@ -145,9 +319,7 @@ describe('Parc Asterix polling response', () => {
 
   const withResponse = (body: unknown) => {
     const park = new ParcAsterix();
-    vi.spyOn(park as any, 'fetchPolling').mockResolvedValue({
-      json: async () => body,
-    });
+    vi.spyOn(park as any, 'fetchPolling').mockResolvedValue({json: async () => body});
     return park;
   };
 
@@ -157,15 +329,46 @@ describe('Parc Asterix polling response', () => {
     ).rejects.toThrow(/Internal server error/);
   });
 
-  it('throws when the payload is missing either bill', async () => {
+  // The dangerous shape: structurally valid, a full attraction bill, and an
+  // empty show bill only because the resolver failed. Every guard downstream
+  // reads that as a park where every show is dark.
+  it('throws on a partial failure that still carried data', async () => {
+    await expect(
+      withResponse({
+        data: {paxLatencies: [{drupalId: '31303'}], paxSchedules: []},
+        errors: [{message: 'schedules resolver timed out'}],
+      })['getPolling'](),
+    ).rejects.toThrow(/schedules resolver timed out/);
+  });
+
+  it('throws when either bill is missing, naming the one that is', async () => {
     await expect(
       withResponse({data: {paxLatencies: []}})['getPolling'](),
     ).rejects.toThrow(/paxSchedules/);
+    await expect(
+      withResponse({data: {paxSchedules: []}})['getPolling'](),
+    ).rejects.toThrow(/paxLatencies/);
+    await expect(withResponse({data: {}})['getPolling']()).rejects.toThrow(
+      /paxLatencies or paxSchedules/,
+    );
+  });
+
+  // What an upstream schema change actually delivers: present, truthy, wrong.
+  it('throws when a bill is not an array', async () => {
+    await expect(
+      withResponse({data: {paxLatencies: {}, paxSchedules: []}})['getPolling'](),
+    ).rejects.toThrow(/paxLatencies/);
   });
 
   it('accepts a legitimately empty bill', async () => {
     await expect(
       withResponse({data: {paxLatencies: [], paxSchedules: []}})['getPolling'](),
+    ).resolves.toEqual({latencies: [], schedules: []});
+  });
+
+  it('accepts an empty errors array beside good data', async () => {
+    await expect(
+      withResponse({data: {paxLatencies: [], paxSchedules: []}, errors: []})['getPolling'](),
     ).resolves.toEqual({latencies: [], schedules: []});
   });
 });

--- a/src/parks/parcasterix/__tests__/showRetirement.test.ts
+++ b/src/parks/parcasterix/__tests__/showRetirement.test.ts
@@ -29,13 +29,13 @@ const performance = (drupalId: string) => ({
   times: [{at: '14:00:00', startAt: null, endAt: null}],
 });
 
-const show = (drupalId: number): POIEntry => ({
+const show = (drupalId: number, type: POIEntry['_type'] = 'show'): POIEntry => ({
   drupal_id: drupalId,
   title: `Show ${drupalId}`,
   titles: {en: `Show ${drupalId}`},
   latitude: 49.13675,
   longitude: 2.573816,
-  _type: 'show',
+  _type: type,
 });
 
 /**
@@ -54,7 +54,15 @@ function stubbedPark(
 }
 
 /** Enough attractions that the degraded-feed guard has a real denominator. */
-const ATTRACTIONS = Array.from({length: 20}, (_, i) => latency(String(31303 + i)));
+const ATTRACTION_IDS = Array.from({length: 20}, (_, i) => 31303 + i);
+const ATTRACTIONS = ATTRACTION_IDS.map((id) => latency(String(id)));
+/**
+ * The package rows behind ATTRACTIONS. buildLiveData() only reads the bill as
+ * darkness when the attraction bill corroborates it against these, so a test
+ * that wants the bill to close a show has to supply them — without them the
+ * closure under test would silently be the gate's, not the bill's.
+ */
+const ATTRACTION_POI = ATTRACTION_IDS.map((id) => show(id, 'attraction'));
 
 describe('Parc Asterix show retirement', () => {
   beforeEach(() => {
@@ -84,14 +92,33 @@ describe('Parc Asterix show retirement', () => {
     expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
   });
 
+  // Below the window, a plain absence is not yet evidence of anything. This is
+  // the gate's own boundary, kept isolated from the reset case below so a
+  // regression in either cannot hide behind the other.
+  it('leaves a show alone that has been absent for less than the window', async () => {
+    vi.useFakeTimers();
+
+    await stubbedPark(ATTRACTIONS, [performance('31483')]).getLiveData();
+
+    vi.setSystemTime(Date.now() + 5 * DAY);
+    await stubbedPark(ATTRACTIONS, []).getLiveData();
+    await stubbedPark(ATTRACTIONS, []).getLiveData();
+    const live = await stubbedPark(ATTRACTIONS, []).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toBeUndefined();
+  });
+
   // While the package still lists the show, the bill closes it the same day
   // and the gate never sees it absent, so the two cannot both speak for it.
+  // The row alone cannot show which one produced it — either would emit the
+  // same thing — so this watches for the gate's own log line instead.
   it('stays out of the way while the package still lists the show', async () => {
     vi.useFakeTimers();
 
-    const poi = [show(31483)];
+    const poi = [...ATTRACTION_POI, show(31483)];
     await stubbedPark(ATTRACTIONS, [performance('31483')], poi).getLiveData();
 
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.setSystemTime(Date.now() + 30 * DAY);
     await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
     await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
@@ -100,6 +127,31 @@ describe('Parc Asterix show retirement', () => {
     expect(live.filter((l) => l.id === '31483')).toEqual([
       {id: '31483', status: 'CLOSED'},
     ]);
+    expect(
+      log.mock.calls.flat().filter((line) => String(line).includes('force-closing')),
+    ).toEqual([]);
+  });
+
+  // And the same scenario with the package row gone is the gate's to handle,
+  // so the log line proves the two are genuinely split rather than one of them
+  // quietly covering for the other in both tests.
+  it('does the closing itself once the package row goes', async () => {
+    vi.useFakeTimers();
+
+    await stubbedPark(ATTRACTIONS, [performance('31483')], ATTRACTION_POI).getLiveData();
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.setSystemTime(Date.now() + 8 * DAY);
+    await stubbedPark(ATTRACTIONS, [], ATTRACTION_POI).getLiveData();
+    await stubbedPark(ATTRACTIONS, [], ATTRACTION_POI).getLiveData();
+    const live = await stubbedPark(ATTRACTIONS, [], ATTRACTION_POI).getLiveData();
+
+    expect(live.filter((l) => l.id === '31483')).toEqual([
+      {id: '31483', status: 'CLOSED'},
+    ]);
+    expect(
+      log.mock.calls.flat().filter((line) => String(line).includes('force-closing')),
+    ).toHaveLength(1);
   });
 
   it('resets the window when the show performs again', async () => {

--- a/src/parks/parcasterix/__tests__/showRetirement.test.ts
+++ b/src/parks/parcasterix/__tests__/showRetirement.test.ts
@@ -49,7 +49,23 @@ function stubbedPark(
 ): ParcAsterix {
   const park = new ParcAsterix();
   vi.spyOn(park as any, 'getPolling').mockResolvedValue({latencies, schedules});
-  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({poi, calendar: []});
+  vi.spyOn(park as any, 'getPOIData').mockImplementation(async () => {
+    // An ordinary open day for whatever the fake clock currently says, so the
+    // bill is believed and the gate is being tested against it rather than
+    // against a calendar that quietly silences the bill.
+    const date = new Date().toISOString().slice(0, 10);
+    return {
+      poi,
+      calendar: [
+        {
+          date,
+          type: 'OPERATING',
+          openingTime: `${date}T10:00:00+02:00`,
+          closingTime: `${date}T18:00:00+02:00`,
+        },
+      ],
+    };
+  });
   return park;
 }
 
@@ -64,10 +80,23 @@ const ATTRACTIONS = ATTRACTION_IDS.map((id) => latency(String(id)));
  */
 const ATTRACTION_POI = ATTRACTION_IDS.map((id) => show(id, 'attraction'));
 
+/**
+ * Mid-afternoon on an operating day, and every jump below is a whole number of
+ * days from it, so each build lands inside opening hours too. Pinned rather
+ * than started from the wall clock: buildLiveData() only reads the bill as
+ * darkness once the park has opened, so an unpinned run silences the bill
+ * before ~10:00 and after midnight local, and the gate quietly does the
+ * closing that these tests are asserting the bill does — green in the
+ * afternoon, red overnight and in CI.
+ */
+const DAYTIME = new Date('2026-09-09T12:00:00Z');
+
 describe('Parc Asterix show retirement', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
+    vi.useFakeTimers();
+    vi.setSystemTime(DAYTIME);
   });
 
   afterEach(() => vi.useRealTimers());
@@ -77,8 +106,6 @@ describe('Parc Asterix show retirement', () => {
   });
 
   it('force-closes a show gone from paxSchedules past the retirement window', async () => {
-    vi.useFakeTimers();
-
     await stubbedPark(ATTRACTIONS, [performance('31483')]).getLiveData();
 
     // The run ended: the show leaves paxSchedules, and the offline package
@@ -96,8 +123,6 @@ describe('Parc Asterix show retirement', () => {
   // the gate's own boundary, kept isolated from the reset case below so a
   // regression in either cannot hide behind the other.
   it('leaves a show alone that has been absent for less than the window', async () => {
-    vi.useFakeTimers();
-
     await stubbedPark(ATTRACTIONS, [performance('31483')]).getLiveData();
 
     vi.setSystemTime(Date.now() + 5 * DAY);
@@ -113,8 +138,6 @@ describe('Parc Asterix show retirement', () => {
   // The row alone cannot show which one produced it — either would emit the
   // same thing — so this watches for the gate's own log line instead.
   it('stays out of the way while the package still lists the show', async () => {
-    vi.useFakeTimers();
-
     const poi = [...ATTRACTION_POI, show(31483)];
     await stubbedPark(ATTRACTIONS, [performance('31483')], poi).getLiveData();
 
@@ -136,8 +159,6 @@ describe('Parc Asterix show retirement', () => {
   // so the log line proves the two are genuinely split rather than one of them
   // quietly covering for the other in both tests.
   it('does the closing itself once the package row goes', async () => {
-    vi.useFakeTimers();
-
     await stubbedPark(ATTRACTIONS, [performance('31483')], ATTRACTION_POI).getLiveData();
 
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -155,8 +176,6 @@ describe('Parc Asterix show retirement', () => {
   });
 
   it('resets the window when the show performs again', async () => {
-    vi.useFakeTimers();
-
     await stubbedPark(ATTRACTIONS, [performance('31483')]).getLiveData();
     vi.setSystemTime(Date.now() + 6 * DAY);
     await stubbedPark(ATTRACTIONS, []).getLiveData();
@@ -177,8 +196,6 @@ describe('Parc Asterix show retirement', () => {
   // hands the gate an empty build by any other route must still not retire on
   // it: a confident CLOSED across an open park is the failure being avoided.
   it('withholds retirement when the whole polling feed comes back empty', async () => {
-    vi.useFakeTimers();
-
     await stubbedPark(ATTRACTIONS, [performance('31483')]).getLiveData();
 
     vi.setSystemTime(Date.now() + 8 * DAY);
@@ -194,8 +211,6 @@ describe('Parc Asterix show retirement', () => {
   // listing the attractions as closed. That is a real closure, not a broken
   // feed, and the shows should close.
   it('still retires shows across a seasonal closure, with attractions unaffected', async () => {
-    vi.useFakeTimers();
-
     const shows = ['31483', '31485', '31502'].map(performance);
     await stubbedPark(ATTRACTIONS, shows).getLiveData();
 

--- a/src/parks/parcasterix/__tests__/showRetirement.test.ts
+++ b/src/parks/parcasterix/__tests__/showRetirement.test.ts
@@ -1,14 +1,17 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {ParcAsterix} from '../parcasterix.js';
+import {ParcAsterix, type POIEntry} from '../parcasterix.js';
 import {CacheLib} from '../../../cache.js';
 
 /**
- * Four retired Parc Asterix shows were still reading OPERATING on the wiki
- * 8 to 24 days after their last write. A show that ends its run leaves
- * `paxSchedules` entirely rather than reporting no performances, so
- * buildLiveData() has nothing to key off, and the collector is upsert-only —
- * dropping the row changes nothing. Parc Asterix opts into the shared
- * retirement gate (destination.ts) to force-close it instead.
+ * A show that leaves `paxSchedules` for the day is closed the same poll from
+ * the bill itself — see showAbsence.test.ts, which is what actually clears a
+ * frozen show row now.
+ *
+ * The gate covers the case the bill cannot see: a show that leaves the offline
+ * package as well, taking its POI row with it. Nothing then names the id at
+ * all, so there is nothing to close it against, and the collector being
+ * upsert-only means dropping the row changes nothing on the wiki. Four retired
+ * shows read OPERATING for 8 to 24 days that way.
  */
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -26,12 +29,27 @@ const performance = (drupalId: string) => ({
   times: [{at: '14:00:00', startAt: null, endAt: null}],
 });
 
+const show = (drupalId: number): POIEntry => ({
+  drupal_id: drupalId,
+  title: `Show ${drupalId}`,
+  titles: {en: `Show ${drupalId}`},
+  latitude: 49.13675,
+  longitude: 2.573816,
+  _type: 'show',
+});
+
+/**
+ * The default empty POI list is the scenario under test: the package has
+ * dropped the show's row, so buildLiveData() cannot close it from the bill.
+ */
 function stubbedPark(
   latencies: ReturnType<typeof latency>[],
   schedules: ReturnType<typeof performance>[],
+  poi: POIEntry[] = [],
 ): ParcAsterix {
   const park = new ParcAsterix();
   vi.spyOn(park as any, 'getPolling').mockResolvedValue({latencies, schedules});
+  vi.spyOn(park as any, 'getPOIData').mockResolvedValue({poi, calendar: []});
   return park;
 }
 
@@ -66,19 +84,22 @@ describe('Parc Asterix show retirement', () => {
     expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
   });
 
-  it('leaves a show alone that simply did not perform this week', async () => {
+  // While the package still lists the show, the bill closes it the same day
+  // and the gate never sees it absent, so the two cannot both speak for it.
+  it('stays out of the way while the package still lists the show', async () => {
     vi.useFakeTimers();
 
-    await stubbedPark(ATTRACTIONS, [performance('31483')]).getLiveData();
+    const poi = [show(31483)];
+    await stubbedPark(ATTRACTIONS, [performance('31483')], poi).getLiveData();
 
-    // Shows drop out of paxSchedules on any day they do not perform, so a few
-    // days of absence is an ordinary weekly cadence, not a retirement.
-    vi.setSystemTime(Date.now() + 5 * DAY);
-    await stubbedPark(ATTRACTIONS, []).getLiveData();
-    await stubbedPark(ATTRACTIONS, []).getLiveData();
-    const live = await stubbedPark(ATTRACTIONS, []).getLiveData();
+    vi.setSystemTime(Date.now() + 30 * DAY);
+    await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
+    await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
+    const live = await stubbedPark(ATTRACTIONS, [], poi).getLiveData();
 
-    expect(live.find((l) => l.id === '31483')).toBeUndefined();
+    expect(live.filter((l) => l.id === '31483')).toEqual([
+      {id: '31483', status: 'CLOSED'},
+    ]);
   });
 
   it('resets the window when the show performs again', async () => {
@@ -100,10 +121,9 @@ describe('Parc Asterix show retirement', () => {
     expect(live.find((l) => l.id === '31483')).toBeUndefined();
   });
 
-  // getPolling() returns `data?.data?.paxLatencies || []`, so a malformed or
-  // gutted GraphQL response parses cleanly into an empty build rather than
-  // throwing. Retiring on that would publish a confident CLOSED for a park
-  // that is open.
+  // getPolling() now throws on a malformed GraphQL payload, but a caller that
+  // hands the gate an empty build by any other route must still not retire on
+  // it: a confident CLOSED across an open park is the failure being avoided.
   it('withholds retirement when the whole polling feed comes back empty', async () => {
     vi.useFakeTimers();
 

--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -14,7 +14,7 @@ import {
   LocalisedString,
   MultilangString,
 } from '@themeparks/typelib';
-import {constructDateTime, hostnameFromUrl, formatDate} from '../../datetime.js';
+import {constructDateTime, hostnameFromUrl, formatDate, formatInTimezone} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 
 import AdmZip from 'adm-zip';
@@ -157,6 +157,17 @@ export function buildLocalisedName(item: POIEntry): LocalisedString {
   return name;
 }
 
+/**
+ * Share of the offline package's attraction list that `paxLatencies` has to
+ * deliver before an absence from `paxSchedules` is read as a show being dark.
+ * Healthy polls carry all of them; half is a wide margin that still refuses a
+ * feed returning a handful.
+ */
+const MIN_ATTRACTION_BILL_FRACTION = 0.5;
+
+/** Local hour at which the previous operating day's after-midnight tail ends. */
+const NIGHT_ENDS_HOUR = 6;
+
 // ── Implementation ─────────────────────────────────────────────
 
 @destinationController({category: 'Parc Asterix'})
@@ -182,6 +193,24 @@ export class ParcAsterix extends Destination {
    * at all is a worse thing to own — so the bill does that work instead.
    */
   protected retireMissingLiveEntities = true;
+
+  /**
+   * Tightened from the 0.5 default because the dark-show closures changed what
+   * the default measures. Every show now appears in every build, so the shows
+   * inflate the gate's denominator while only the attractions can ever be
+   * counted absent — which moved the point at which the gate stops trusting
+   * the feed from 29 missing entities to 32, in the direction of trusting it
+   * more. Silently widening a guard is not a thing to inherit from a change
+   * that was about something else.
+   *
+   * 0.2 puts it back the other way: more than about a fifth of the tracked set
+   * gone at once is distrusted, roughly thirteen attractions. Nothing is lost
+   * by being strict here — `paxLatencies` lists every attraction year-round, so
+   * an attraction going absent is already an anomaly rather than a retirement,
+   * and the absence the gate genuinely exists for (a show losing its POI row)
+   * is one or two entities, well under `liveEntityRetirementMinBulk`.
+   */
+  protected liveEntityRetirementMaxFraction = 0.2;
 
   constructor(options?: DestinationConstructor) {
     super(options);
@@ -239,12 +268,18 @@ export class ParcAsterix extends Destination {
   }
 
   /**
-   * A GraphQL error carries HTTP 200 with an `errors` array and no `data`, so
-   * defaulting the two bills to `[]` turned every server-side failure into a
-   * well-formed park with nothing open and no shows on. buildLiveData() reads
-   * an absent show as dark, so that silent default is now the difference
-   * between skipping a poll and publishing a CLOSED across the whole park.
-   * Fail the poll instead and let the next one stand in.
+   * A GraphQL failure carries HTTP 200, so defaulting the two bills to `[]`
+   * turned every server-side error into a well-formed park with nothing open
+   * and no shows on. buildLiveData() reads an absent show as dark, so that
+   * silent default is the difference between skipping a poll and publishing a
+   * CLOSED across the whole park. Fail the poll and let the next one stand in.
+   *
+   * A populated `errors` array is rejected even when `data` came back with it.
+   * Partial success is ordinary in GraphQL, and the shape that matters here is
+   * a full `paxLatencies` beside an `errors`-truncated empty `paxSchedules`:
+   * that passes every structural check and reads as a park with every show
+   * dark. Both bills come from the one query, so a partial failure is never a
+   * poll worth trusting.
    */
   @cache({ttlSeconds: 60})
   async getPolling(): Promise<{
@@ -254,16 +289,19 @@ export class ParcAsterix extends Destination {
     const resp = await this.fetchPolling();
     const data = (await resp.json()) as any;
 
+    const errors = (Array.isArray(data?.errors) ? data.errors : [])
+      .map((e: any) => e?.message)
+      .filter(Boolean)
+      .join('; ');
     const missing = ['paxLatencies', 'paxSchedules'].filter(
       (field) => !Array.isArray(data?.data?.[field]),
     );
-    if (missing.length) {
-      const errors = Array.isArray(data?.errors)
-        ? data.errors.map((e: any) => e?.message).filter(Boolean).join('; ')
-        : '';
+    if (missing.length || errors) {
+      const fault = missing.length
+        ? `returned no ${missing.join(' or ')}`
+        : 'reported an error';
       throw new Error(
-        `ParcAsterix: paxPolling returned no ${missing.join(' or ')}` +
-          (errors ? ` — ${errors}` : ''),
+        `ParcAsterix: paxPolling ${fault}` + (errors ? ` — ${errors}` : ''),
       );
     }
 
@@ -767,7 +805,22 @@ export class ParcAsterix extends Destination {
 
   protected async buildLiveData(): Promise<LiveData[]> {
     const {latencies, schedules} = await this.getPolling();
-    const {poi} = await this.getPOIData();
+
+    // Only the dark-show pass below needs the POI list, and it is the one
+    // thing here that is worth losing. The rest of this build wants nothing
+    // from the offline package, and letting a 23MB ZIP download stand between
+    // the bill and the wait times would put every attraction's live row behind
+    // a fetch that can fail three separate ways. Degrade to publishing no
+    // closures rather than publishing nothing.
+    let poi: POIEntry[] = [];
+    try {
+      ({poi} = await this.getPOIData());
+    } catch (err) {
+      console.warn(
+        `[${this.constructor.name}] offline package unavailable, ` +
+          `publishing live data without show closures: ${err}`,
+      );
+    }
 
     const liveWaitTimes = latencies.map((entry) => {
       const ld: LiveData = {
@@ -859,6 +912,20 @@ export class ParcAsterix extends Destination {
       return ld;
     });
 
+    // The two bills have never yet named the same id, and if they ever do the
+    // build must still carry one row for it rather than two that contradict
+    // each other and leave array order to decide. `paxLatencies` is a direct
+    // observation of whether the thing is open, so its status wins; the
+    // performances are additional information, so they are carried across
+    // rather than dropped.
+    const waitTimeById = new Map(liveWaitTimes.map((entry) => [entry.id, entry]));
+    const showtimeRows = liveShowtimes.filter((entry) => {
+      const observation = waitTimeById.get(entry.id);
+      if (!observation) return true;
+      if (entry.showtimes) observation.showtimes = entry.showtimes;
+      return false;
+    });
+
     // `paxSchedules` is a same-day bill: one entry per show performing today,
     // nothing at all for the rest. A show that is dark therefore produces no
     // row, and because the collector is upsert-only the wiki went on serving
@@ -867,25 +934,55 @@ export class ParcAsterix extends Destination {
     //
     // Absence needs no window to interpret. A bill that names every
     // performance today, and does not name this show, says it has none today,
-    // which is what CLOSED says. The one thing absence cannot distinguish is a
-    // bill that failed to arrive, so the attractions have to corroborate that
-    // the feed is alive before any of this is read as darkness. getPolling()
-    // now throws on a malformed payload, and paxLatencies lists all 50
-    // attractions year-round — closed ones included, through the winter
-    // shutdown — so an empty one means a broken poll, never a shut park.
+    // which is what CLOSED says. What absence cannot do is speak for a bill
+    // that failed to arrive, so it is only read as darkness when the feed is
+    // corroborated and the day it describes is unambiguous — the two guards
+    // below.
     const scheduled = new Set(schedules.map((entry) => String(entry.drupalId)));
-    const darkShows: LiveData[] = latencies.length === 0
-      ? []
-      : poi
+    // A show has never yet appeared in both bills, but if one ever did, the
+    // observation would have to win over the inference: without this the build
+    // carries an OPERATING row and a CLOSED row for the one id, and which of
+    // them lands is nothing better than array order.
+    const observed = new Set(latencies.map((entry) => String(entry.drupalId)));
+    const attractions = poi.filter((item) => item._type === 'attraction').length;
+
+    // `paxLatencies` carries every attraction year-round, closed ones included
+    // through the winter shutdown, so a short one is a broken poll and never a
+    // shut park. Counting it against the package's own attraction total keeps
+    // that self-calibrating as the park adds and drops rides, and catches the
+    // partial regeneration an emptiness check misses: a bill of one attraction
+    // out of fifty would otherwise close every show in the park.
+    const corroborated = attractions > 0
+      && latencies.length >= attractions * MIN_ATTRACTION_BILL_FRACTION;
+
+    // The bill rolls over at local midnight while the park is still running an
+    // event night — Halloween runs to 01:00 — and `liveShowtimes` above dates
+    // its own sub-06:00 entries into tomorrow for exactly that reason. In that
+    // window a show can be absent from a bill for a day that has not started
+    // yet while it is physically mid-performance, so absence carries no meaning
+    // and nothing is closed until the small hours are over. It costs a retired
+    // show a few more hours of a stale row, overnight, once.
+    // 'iso' is `YYYY-MM-DDTHH:mm:ss±HH:mm`; 'datetime' is `MM/DD/YYYY, HH:mm:ss`
+    // and slicing that one reads the wrong two characters.
+    const localHour = parseInt(
+      formatInTimezone(new Date(), this.timezone, 'iso').slice(11, 13),
+      10,
+    );
+    const daylit = Number.isFinite(localHour) && localHour >= NIGHT_ENDS_HOUR;
+
+    const darkShows: LiveData[] = corroborated && daylit
+      ? poi
           .filter(
             (item) =>
               item._type === 'show' &&
               !!item.drupal_id &&
-              !scheduled.has(String(item.drupal_id)),
+              !scheduled.has(String(item.drupal_id)) &&
+              !observed.has(String(item.drupal_id)),
           )
-          .map((item) => ({id: String(item.drupal_id), status: 'CLOSED'}) as LiveData);
+          .map((item) => ({id: String(item.drupal_id), status: 'CLOSED'}) as LiveData)
+      : [];
 
-    return [...liveWaitTimes, ...liveShowtimes, ...darkShows];
+    return [...liveWaitTimes, ...showtimeRows, ...darkShows];
   }
 
   // ── Schedules ────────────────────────────────────────────────

--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -167,22 +167,19 @@ export class ParcAsterix extends Destination {
   @config packageVersion: string = '1.1.238';
 
   /**
-   * A show that ends its run leaves `paxSchedules` entirely rather than
-   * reporting no performances, and the offline package drops its POI row in
-   * the same release. buildLiveData() then has nothing to key off and the row
-   * freezes at its last value: four retired Parc Asterix shows were still
-   * reading OPERATING on the wiki 8 to 24 days after their last write, because
-   * the collector is upsert-only and omitting a row achieves nothing. See
+   * A backstop for the one absence buildLiveData() cannot read: a show that
+   * leaves the offline package as well as the bill, taking its POI row with
+   * it. Nothing then names the id, so there is no row to close it against, and
+   * the collector being upsert-only means omitting it achieves nothing — four
+   * retired shows read OPERATING on the wiki for 8 to 24 days that way. See
    * Destination.retireMissingLiveEntities for the mechanism.
    *
-   * The shared 7-day window suits this feed. Shows drop out of `paxSchedules`
-   * on any day they do not perform, so the window has to clear a normal weekly
-   * cadence, and a week does with room to spare. The seasonal winter closure
-   * takes every show out at once for months; force-closing them then is the
-   * right answer, not a false positive, and the attractions are unaffected
-   * because `paxLatencies` keeps listing them with `isOpen` false. A genuinely
-   * broken feed parses to an empty array and takes out far more than half the
-   * tracked entities, which the degraded-feed guard catches.
+   * Everything else is settled the same poll, from `paxSchedules` directly, so
+   * the gate is deliberately the slower and narrower of the two. It has to be:
+   * it can only close ids it has watched go absent, which leaves a show whose
+   * run ended before it was ever observed invisible to it for good. That is
+   * not a hole worth widening — a gate that could close an id on no evidence
+   * at all is a worse thing to own — so the bill does that work instead.
    */
   protected retireMissingLiveEntities = true;
 
@@ -241,6 +238,14 @@ export class ParcAsterix extends Destination {
     } as any as HTTPObj;
   }
 
+  /**
+   * A GraphQL error carries HTTP 200 with an `errors` array and no `data`, so
+   * defaulting the two bills to `[]` turned every server-side failure into a
+   * well-formed park with nothing open and no shows on. buildLiveData() reads
+   * an absent show as dark, so that silent default is now the difference
+   * between skipping a poll and publishing a CLOSED across the whole park.
+   * Fail the poll instead and let the next one stand in.
+   */
   @cache({ttlSeconds: 60})
   async getPolling(): Promise<{
     latencies: PaxLatency[];
@@ -248,9 +253,23 @@ export class ParcAsterix extends Destination {
   }> {
     const resp = await this.fetchPolling();
     const data = (await resp.json()) as any;
+
+    const missing = ['paxLatencies', 'paxSchedules'].filter(
+      (field) => !Array.isArray(data?.data?.[field]),
+    );
+    if (missing.length) {
+      const errors = Array.isArray(data?.errors)
+        ? data.errors.map((e: any) => e?.message).filter(Boolean).join('; ')
+        : '';
+      throw new Error(
+        `ParcAsterix: paxPolling returned no ${missing.join(' or ')}` +
+          (errors ? ` — ${errors}` : ''),
+      );
+    }
+
     return {
-      latencies: data?.data?.paxLatencies || [],
-      schedules: data?.data?.paxSchedules || [],
+      latencies: data.data.paxLatencies as PaxLatency[],
+      schedules: data.data.paxSchedules as PaxSchedule[],
     };
   }
 
@@ -748,6 +767,7 @@ export class ParcAsterix extends Destination {
 
   protected async buildLiveData(): Promise<LiveData[]> {
     const {latencies, schedules} = await this.getPolling();
+    const {poi} = await this.getPOIData();
 
     const liveWaitTimes = latencies.map((entry) => {
       const ld: LiveData = {
@@ -839,7 +859,33 @@ export class ParcAsterix extends Destination {
       return ld;
     });
 
-    return [...liveWaitTimes, ...liveShowtimes];
+    // `paxSchedules` is a same-day bill: one entry per show performing today,
+    // nothing at all for the rest. A show that is dark therefore produces no
+    // row, and because the collector is upsert-only the wiki went on serving
+    // the times of whichever day it last performed, still reading OPERATING —
+    // three shows were 11 days stale when a user reported it.
+    //
+    // Absence needs no window to interpret. A bill that names every
+    // performance today, and does not name this show, says it has none today,
+    // which is what CLOSED says. The one thing absence cannot distinguish is a
+    // bill that failed to arrive, so the attractions have to corroborate that
+    // the feed is alive before any of this is read as darkness. getPolling()
+    // now throws on a malformed payload, and paxLatencies lists all 50
+    // attractions year-round — closed ones included, through the winter
+    // shutdown — so an empty one means a broken poll, never a shut park.
+    const scheduled = new Set(schedules.map((entry) => String(entry.drupalId)));
+    const darkShows: LiveData[] = latencies.length === 0
+      ? []
+      : poi
+          .filter(
+            (item) =>
+              item._type === 'show' &&
+              !!item.drupal_id &&
+              !scheduled.has(String(item.drupal_id)),
+          )
+          .map((item) => ({id: String(item.drupal_id), status: 'CLOSED'}) as LiveData);
+
+    return [...liveWaitTimes, ...liveShowtimes, ...darkShows];
   }
 
   // ── Schedules ────────────────────────────────────────────────

--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -168,6 +168,64 @@ const MIN_ATTRACTION_BILL_FRACTION = 0.5;
 /** Local hour at which the previous operating day's after-midnight tail ends. */
 const NIGHT_ENDS_HOUR = 6;
 
+/**
+ * What today's calendar lets us say about a show that is missing from
+ * `paxSchedules`.
+ *
+ * The bill is not rewritten for the new day at midnight. It goes on serving the
+ * last open day's programme until the morning: on 2026-09-09 the bill served
+ * from local midnight until 09:28 was still 2026-09-06's, two closed days
+ * earlier, and gave itself away by carrying that day's 19:00 close inside a
+ * show window that the 09:28 rewrite corrected to 18:00. Absence from that bill
+ * means "was not on the last open day", which is not the thing we would be
+ * publishing. Today's bill happened to be a subset of it; a day whose programme
+ * is larger than the previous open day's would have closed shows that perform.
+ *
+ * So absence is only read as darkness once the park has opened and the bill has
+ * had to become about today. Before that the calendar still settles the one
+ * case it knows for certain — on a day the park does not operate, no show
+ * performs — and that one matters, because a retained bill means the closed
+ * days are exactly when the stale programme looks most like a live one.
+ *
+ * `parkIsBusy` is the live feed's own vote, and it only ever vetoes: a calendar
+ * claiming today is closed while attractions report themselves open is a
+ * calendar to distrust, not a park to close.
+ *
+ * The four answers separate two things that look alike and are not. `stale`
+ * means the bill is known to be about a day that has passed, so neither its
+ * performances nor its silences may be published — republishing them re-dates
+ * the last open day's programme onto today, which is how a wrong showtime comes
+ * to look freshly confirmed. `unknown` means we cannot tell, and there the only
+ * safe move is to change nothing about what the bill already says.
+ */
+export function showBillAuthority(
+  now: Date,
+  timezone: string,
+  calendar: ScheduleEntry[],
+  parkIsBusy: boolean,
+): 'all-dark' | 'read-bill' | 'stale' | 'unknown' {
+  // An event night runs past midnight — Halloween closes at 01:00 — so the
+  // small hours still belong to the day before. The bill is still that day's
+  // and is still correct, so this is `unknown`, not `stale`: the shows on it
+  // are mid-performance and their times must keep publishing.
+  const localHour = parseInt(formatInTimezone(now, timezone, 'iso').slice(11, 13), 10);
+  if (!Number.isFinite(localHour) || localHour < NIGHT_ENDS_HOUR) return 'unknown';
+
+  if (calendar.length === 0) return 'unknown';
+
+  // Closed days carry no hours and so never reach the calendar at all.
+  const todaysHours = calendar.filter(
+    (entry) => entry.date === formatDate(now, timezone),
+  );
+  if (todaysHours.length === 0) return parkIsBusy ? 'unknown' : 'all-dark';
+
+  const opensAt = Math.min(
+    ...todaysHours.map((entry) => new Date(entry.openingTime).getTime()),
+  );
+  if (!Number.isFinite(opensAt)) return 'unknown';
+  return now.getTime() >= opensAt ? 'read-bill' : 'stale';
+}
+
 // ── Implementation ─────────────────────────────────────────────
 
 @destinationController({category: 'Parc Asterix'})
@@ -813,8 +871,9 @@ export class ParcAsterix extends Destination {
     // a fetch that can fail three separate ways. Degrade to publishing no
     // closures rather than publishing nothing.
     let poi: POIEntry[] = [];
+    let calendar: ScheduleEntry[] = [];
     try {
-      ({poi} = await this.getPOIData());
+      ({poi, calendar} = await this.getPOIData());
     } catch (err) {
       console.warn(
         `[${this.constructor.name}] offline package unavailable, ` +
@@ -955,32 +1014,48 @@ export class ParcAsterix extends Destination {
     const corroborated = attractions > 0
       && latencies.length >= attractions * MIN_ATTRACTION_BILL_FRACTION;
 
-    // The bill rolls over at local midnight while the park is still running an
-    // event night — Halloween runs to 01:00 — and `liveShowtimes` above dates
-    // its own sub-06:00 entries into tomorrow for exactly that reason. In that
-    // window a show can be absent from a bill for a day that has not started
-    // yet while it is physically mid-performance, so absence carries no meaning
-    // and nothing is closed until the small hours are over. It costs a retired
-    // show a few more hours of a stale row, overnight, once.
-    // 'iso' is `YYYY-MM-DDTHH:mm:ss±HH:mm`; 'datetime' is `MM/DD/YYYY, HH:mm:ss`
-    // and slicing that one reads the wrong two characters.
-    const localHour = parseInt(
-      formatInTimezone(new Date(), this.timezone, 'iso').slice(11, 13),
-      10,
+    // Whether the bill is about today at all, and what to publish when it is
+    // not. See showBillAuthority.
+    const authority = showBillAuthority(
+      new Date(),
+      this.timezone,
+      calendar,
+      latencies.some((entry) => entry.isOpen),
     );
-    const daylit = Number.isFinite(localHour) && localHour >= NIGHT_ENDS_HOUR;
 
-    const darkShows: LiveData[] = corroborated && daylit
-      ? poi
-          .filter(
-            (item) =>
-              item._type === 'show' &&
-              !!item.drupal_id &&
-              !scheduled.has(String(item.drupal_id)) &&
-              !observed.has(String(item.drupal_id)),
-          )
-          .map((item) => ({id: String(item.drupal_id), status: 'CLOSED'}) as LiveData)
-      : [];
+    const showIds = poi
+      .filter((item) => item._type === 'show' && !!item.drupal_id)
+      .map((item) => String(item.drupal_id));
+
+    // Morning, before opening, on a day the park does operate: the bill is the
+    // last open day's and has not been rewritten yet. Publishing its
+    // performances would assert a passed day's programme as today's, and
+    // publishing its silences would close shows that are on today's bill once
+    // it arrives. Say nothing about shows either way until it does.
+    if (authority === 'stale') {
+      return liveWaitTimes;
+    }
+
+    if (!corroborated || authority === 'unknown') {
+      return [...liveWaitTimes, ...showtimeRows];
+    }
+
+    // The park is not operating today, so nothing on the bill is about today
+    // either. Publishing its performances would re-date the last open day's
+    // programme onto a day the park is shut, which is how a closed day ends up
+    // looking busier than an open one. The bill's own ids are closed alongside
+    // the package's, so an id the package has never carried is not left
+    // advertising a performance that cannot happen.
+    if (authority === 'all-dark') {
+      const dark = [...new Set([...showIds, ...scheduled])]
+        .filter((id) => !observed.has(id))
+        .map((id) => ({id, status: 'CLOSED'}) as LiveData);
+      return [...liveWaitTimes, ...dark];
+    }
+
+    const darkShows: LiveData[] = showIds
+      .filter((id) => !scheduled.has(id) && !observed.has(id))
+      .map((id) => ({id, status: 'CLOSED'}) as LiveData);
 
     return [...liveWaitTimes, ...showtimeRows, ...darkShows];
   }


### PR DESCRIPTION
Reported on Discord: Parc Asterix shows on the wiki were carrying showtimes that were eleven days old, still reading OPERATING.

## What was happening

`paxSchedules` is a same-day bill — one entry per show performing today, nothing at all for the rest. A show that is dark produced no live row, and an omission changes nothing downstream, so the row stood at whatever the show last performed to. Three shows had been frozen since 29 August.

The shared retirement gate was meant to catch this, and cannot: it only closes ids it has itself watched go absent. A show whose run ended before the gate was watching was never observed live, so it is not tracked and no window ever opens on it. Widening that would mean closing an id on no evidence at all.

## The fix

Read the bill directly. A list that names every performance today, and does not name this show, says it has none today — which is what CLOSED says, and it needs no multi-day window to interpret. Every show in the offline package missing from the bill now gets a CLOSED row; it clears on the next poll and reopens the moment the show is back on the bill.

The one absence that cannot be told apart is a bill that never arrived, so two guards:

- `getPolling()` throws on a payload missing either list instead of defaulting to `[]`. A GraphQL error comes back as HTTP 200 with `errors` and no `data`, which parsed cleanly into a well-formed park with nothing on.
- Closures are withheld unless `paxLatencies` corroborates that the feed is alive. It carries all 50 attractions year-round, closed ones included through the winter shutdown, so an empty one means a broken poll and never a shut park. A genuine seasonal shutdown still closes every show.

`retireMissingLiveEntities` stays for the case the bill cannot see: a show that leaves the offline package as well, taking its POI row with it, so no id is left to close against.

## Verification

Against the live feed this morning — 8 shows on today's bill with times, 6 closed, 64 live rows, no duplicate ids:

| id | show | before | after |
|---|---|---|---|
| 31483 | Main basse sur la Joconde | OPERATING, 2 times | OPERATING, 2 times |
| 31509 | Les offrandes de Cléopâtre | no row (frozen 11 days) | CLOSED |
| 31513 | Pirates en galère | no row (frozen 11 days) | CLOSED |
| 33729 | Astérix et la Potion d'étoiles | no row | CLOSED |
| 34628 | Le Gladiateur Maudit | no row | CLOSED |

- 11 new tests covering the daily close, the reopen, the empty-feed guard, the seasonal shutdown, a scheduled show with no POI row, and the malformed-payload throws
- `showRetirement.test.ts` reframed around what the gate still covers, plus a test that the two mechanisms never both speak for the same show
- Full suite: 2397 tests passing. `npm run dev -- parcasterix`: 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (second commit)

Four reviewers went over the first commit. One regression it introduced, plus four ways it could publish something wrong:

| | Was | Now |
|---|---|---|
| Offline package unreachable | whole live build dies — all 50 wait times lost, where the live path never used to touch the package | caught; degrades to publishing no closures |
| `paxLatencies` returns 1 of 50 | reads as healthy, closes every show | measured against the package's own attraction count |
| GraphQL `errors` beside good `data` | full attraction bill + `errors`-truncated empty show bill passes every check and reads as a park where every show is dark | rejected |
| 00:30 on a Halloween night (park open to 01:00) | bill has rolled to a day that has not started; a show mid-performance is closed | nothing closes before 06:00 local |
| One id in both bills | two contradictory rows, array order decides | observation wins, performances carried onto it |

`liveEntityRetirementMaxFraction` drops to 0.2. Every show now appears in every build, inflating the retirement gate's denominator while only attractions can be counted absent, which had quietly moved the gate's distrust threshold from 29 missing entities to 32 — the wrong direction for a guard, inherited from a change that was about something else.

Also caught while pinning the night guard: the local hour was sliced out of the `'datetime'` format, which is `MM/DD/YYYY, HH:mm:ss`, so it read the wrong two characters and would have suppressed every closure all day.

### Tests

37 for this park, up from 23. Every one of the nine guards was verified by deleting it and confirming the suite fails. The previous set stayed fully green with the show-type filter removed (which would have closed every attraction and restaurant), with the id-collision path live, and with the file's central assertion reverted — an optional chain could not tell a closed row from no row at all.

Restored the retirement gate's below-window silence case that the first commit's rewrite dropped, and split the gate's closures from the bill's by watching for the gate's own log line rather than a row that either mechanism would emit identically.

---

## Third commit: the bill is not always about today

The upstream-assumptions review found the premise breaks for a stretch of every morning. The bill is not rewritten at midnight — it serves the last open day's programme until mid-morning. On 2026-09-09 the bill served from local midnight until 09:28 was still **2026-09-06's**, two closed days earlier, and gave itself away by carrying that day's 19:00 close inside a show window the rewrite corrected to 18:00. Four of its eight shows are not performing today at all.

Two consequences, one of them predating this branch:

- a show missing from a passed day's bill would have been closed — and on any day whose programme is *larger* than the previous open day's, that closes shows that do perform;
- its performances were being republished, re-dating a passed day's programme onto today. That is how the wiki came to serve a 19:00-close day's showtimes on an 18:00 day.

`showBillAuthority()` now decides what today's calendar licenses, separating a bill known to be about a day that has passed (publish nothing about shows) from not being able to tell (change nothing):

| state | when | published |
|---|---|---|
| `stale` | operating day, before opening | no show rows at all |
| `read-bill` | operating day, park open | performances, and absence read as darkness |
| `all-dark` | day the park does not operate | every show closed, retained bill not republished |
| `unknown` | small hours, no calendar, or calendar contradicted by open rides | nothing changes |

The small hours are `unknown` rather than `stale` on purpose: an event night runs to 01:00, so the bill is still that night's and still correct, and its performances must keep publishing. The live feed only ever vetoes — a calendar claiming today is closed while the rides report themselves open is a calendar to distrust, not a park to close.

Closed days matter more than they look. The bill is retained across them, so a closed day is exactly when a stale programme looks most like a live one.

Verified against the live feed after the 09:28 rewrite: 4 shows performing, 10 closed, 64 rows, no duplicate ids. 49 tests, up from 37, every state transition pinned by flipping it and confirming the suite fails — including the one that would drop a mid-performance show at 00:30 on a Halloween night.
