### PR TITLE
fix: refuse to publish an entity list with nothing in it

### DIFF
--- a/src/__tests__/destinationInit.test.ts
+++ b/src/__tests__/destinationInit.test.ts
@@ -15,6 +15,10 @@ describe('Destination init() lifecycle', () => {
         initCalled = true;
       }
 
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
+
       protected async buildEntityList(): Promise<Entity[]> {
         buildEntitiesCalled = true;
         expect(initCalled).toBe(true); // init should be called first
@@ -57,6 +61,10 @@ describe('Destination init() lifecycle', () => {
         initCalled = true;
       }
 
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
+
       protected async buildEntityList(): Promise<Entity[]> {
         return [];
       }
@@ -92,6 +100,10 @@ describe('Destination init() lifecycle', () => {
         initCalled = true;
       }
 
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
+
       protected async buildEntityList(): Promise<Entity[]> {
         return [];
       }
@@ -126,6 +138,10 @@ describe('Destination init() lifecycle', () => {
         initCallCount++;
         await new Promise(resolve => setTimeout(resolve, 10));
       }
+
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
 
       protected async buildEntityList(): Promise<Entity[]> {
         return [
@@ -173,6 +189,10 @@ describe('Destination init() lifecycle', () => {
         initCallCount++;
         await new Promise(resolve => setTimeout(resolve, 50));
       }
+
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
 
       protected async buildEntityList(): Promise<Entity[]> {
         return [
@@ -222,6 +242,10 @@ describe('Destination init() lifecycle', () => {
         setupValue = 'initialized';
       }
 
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
+
       protected async buildEntityList(): Promise<Entity[]> {
         // Should have access to initialized state
         expect(this.value).toBe('initialized');
@@ -259,6 +283,10 @@ describe('Destination init() lifecycle', () => {
 
   it('should work when _init() is not overridden', async () => {
     class TestDestination extends Destination {
+      // No content on purpose: these doubles exercise init(), not the
+      // entity list, and getEntities() otherwise refuses a collapsed one.
+      protected allowEmptyEntityList = true;
+
       protected async buildEntityList(): Promise<Entity[]> {
         return [
           {

--- a/src/__tests__/entityIdRegression.test.ts
+++ b/src/__tests__/entityIdRegression.test.ts
@@ -277,6 +277,10 @@ describe('Destination ID patterns', () => {
     }});
     // Stub the live HTTP layer so buildEntityList doesn't network during the test.
     (dest as unknown as {getItems: () => Promise<unknown[]>}).getItems = async () => [];
+    // That stub leaves every park with no rides, which getEntities() otherwise
+    // refuses to publish. This test is about the two surfaces agreeing on
+    // destination IDs, not about the list being publishable.
+    (dest as unknown as {allowEmptyEntityList: boolean}).allowEmptyEntityList = true;
     const [destinations, entities] = await Promise.all([
       dest.getDestinations(),
       dest.getEntities(),

--- a/src/__tests__/entityListCollapse.test.ts
+++ b/src/__tests__/entityListCollapse.test.ts
@@ -1,0 +1,101 @@
+import {describe, it, expect} from 'vitest';
+import {Destination} from '../destination.js';
+import {Entity} from '@themeparks/typelib';
+
+/**
+ * A destination's DESTINATION and PARK rows are built from constants, so they
+ * survive an upstream failure that took every real entity with it. What is left
+ * parses cleanly, validates, and reports success.
+ *
+ * Two destinations reached that state on 2026-09-09 by different routes: one
+ * whose POI endpoint answered 200 with an empty list, one whose rides pages
+ * began redirecting into a scraper that treats a failed page as an empty one.
+ * The second had been publishing 3 entities against 76 for long enough that
+ * every missing ride had queued for deletion downstream — and the test harness
+ * called it a pass every time.
+ */
+const DESTINATION: Entity = {
+  id: 'dest', name: 'Test Resort', entityType: 'DESTINATION', timezone: 'Europe/London',
+} as Entity;
+const PARK: Entity = {
+  id: 'park', name: 'Test Park', entityType: 'PARK', parentId: 'dest', destinationId: 'dest',
+  timezone: 'Europe/London',
+} as Entity;
+const RIDE: Entity = {
+  id: 'ride', name: 'Test Coaster', entityType: 'ATTRACTION', parentId: 'park',
+  destinationId: 'dest', timezone: 'Europe/London',
+} as Entity;
+
+class TestPark extends Destination {
+  constructor(private readonly entities: Entity[], allowEmpty = false) {
+    super();
+    (this as any).allowEmptyEntityList = allowEmpty;
+  }
+  async getDestinations(): Promise<Entity[]> { return [DESTINATION]; }
+  protected async buildEntityList(): Promise<Entity[]> { return this.entities; }
+  protected async buildLiveData(): Promise<any[]> { return []; }
+  protected async buildSchedules(): Promise<any[]> { return []; }
+}
+
+describe('collapsed entity list', () => {
+  it('publishes a list that has content', async () => {
+    const entities = await new TestPark([PARK, RIDE]).getEntities();
+    expect(entities.map((e) => e.id).sort()).toEqual(['dest', 'park', 'ride']);
+  });
+
+  // The exact shape Mid-America Parks published: DESTINATION + PARKs, nothing else.
+  it('refuses a list of nothing but structure', async () => {
+    await expect(new TestPark([PARK]).getEntities()).rejects.toThrow(
+      /no attractions, restaurants or shows/,
+    );
+  });
+
+  // An empty build is not an empty list: getDestinations() still contributes
+  // the DESTINATION row, which is exactly why the collapse is invisible.
+  it('refuses an empty build, which still carries the destination row', async () => {
+    await expect(new TestPark([]).getEntities()).rejects.toThrow(
+      /no attractions, restaurants or shows — only DESTINATION/,
+    );
+  });
+
+  it('refuses a destination that produced literally nothing', async () => {
+    class Silent extends TestPark {
+      async getDestinations(): Promise<Entity[]> { return []; }
+    }
+    await expect(new Silent([]).getEntities()).rejects.toThrow(/nothing at all/);
+  });
+
+  it('names the destination and what it did produce', async () => {
+    await expect(new TestPark([PARK]).getEntities()).rejects.toThrow(/TestPark/);
+    await expect(new TestPark([PARK]).getEntities()).rejects.toThrow(/DESTINATION, PARK/);
+  });
+
+  it('lets a destination opt out when it genuinely has no content', async () => {
+    const entities = await new TestPark([PARK], true).getEntities();
+    expect(entities.map((e) => e.id).sort()).toEqual(['dest', 'park']);
+  });
+
+  // One real entity of any visitable type is enough — the guard is a floor
+  // against total collapse, not a quality bar on how much a park publishes.
+  it.each(['ATTRACTION', 'RESTAURANT', 'SHOW', 'HOTEL'])(
+    'accepts a list whose only content is a %s',
+    async (entityType) => {
+      const one = {...RIDE, entityType} as Entity;
+      const entities = await new TestPark([PARK, one]).getEntities();
+      expect(entities).toHaveLength(3);
+    },
+  );
+
+  // Throwing is the point: the collector is upsert-only, so a truncated list
+  // does not under-report, it proposes deleting everything missing from it.
+  // An error skips the poll and leaves the last good list standing.
+  it('throws rather than returning the truncated list', async () => {
+    let returned: Entity[] | undefined;
+    try {
+      returned = await new TestPark([PARK]).getEntities();
+    } catch {
+      // expected
+    }
+    expect(returned).toBeUndefined();
+  });
+});

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -202,6 +202,19 @@ export abstract class Destination {
   hasLiveStream: boolean = false;
 
   /**
+   * Opt out of the collapsed-entity-list guard in {@link getEntities}.
+   *
+   * Only for a destination that legitimately publishes no attractions,
+   * restaurants or shows — a listing that exists to carry opening hours, say.
+   * A destination that normally has content and simply lost it upstream must
+   * NOT set this: the whole point of the guard is that losing everything looks
+   * identical to having nothing.
+   *
+   * @default false
+   */
+  protected allowEmptyEntityList: boolean = false;
+
+  /**
    * Opt-in: force-close a previously-live entity once it has been absent
    * from a full buildLiveData() snapshot for longer than
    * {@link liveEntityRetirementMs}.
@@ -1023,6 +1036,8 @@ export abstract class Destination {
     const merged = [...destinations.filter(d => !entityIds.has(d.id)), ...entities];
     const resolved = this.resolveEntityHierarchy(merged);
 
+    this.assertEntityListNotCollapsed(resolved);
+
     // Default attractionType for ATTRACTION entities that don't specify one
     for (const entity of resolved) {
       if (entity.entityType === 'ATTRACTION' && !(entity as any).attractionType) {
@@ -1053,6 +1068,44 @@ export abstract class Destination {
 
     for (const entity of resolved) stripUndefinedDeep(entity);
     return resolved;
+  }
+
+  /**
+   * Refuse to publish an entity list that contains nothing a guest can visit.
+   *
+   * DESTINATION and PARK rows describe the shape of a resort; they are built
+   * from constants in `getDestinations()` and a handful of literals in
+   * `buildEntityList()`, so they survive an upstream failure that took every
+   * real entity with it. What is left parses cleanly, validates, and reports
+   * success — the harness passed a park showing 3 entities and no live data
+   * for weeks, while every ride it could no longer see queued for deletion
+   * downstream. Two destinations reached that state by different routes on
+   * the same day: one whose POI endpoint answered 200 with an empty list, one
+   * whose rides pages began redirecting and were dropped by a scraper that
+   * treats a failed page as an empty one.
+   *
+   * Throwing is the point. The collector is upsert-only with no delete path of
+   * its own, so a truncated list does not quietly under-report — it proposes
+   * deleting everything missing from it. An error means the poll is skipped and
+   * the last good list stands, which is always the better of the two.
+   *
+   * A destination that genuinely has no content sets
+   * {@link allowEmptyEntityList}.
+   */
+  private assertEntityListNotCollapsed(resolved: Entity[]): void {
+    if (this.allowEmptyEntityList) return;
+    const structural = new Set(['DESTINATION', 'PARK']);
+    if (resolved.some((entity) => !structural.has(entity.entityType as string))) return;
+
+    const shape = resolved.length
+      ? resolved.map((e) => e.entityType).sort().join(', ')
+      : 'nothing at all';
+    throw new Error(
+      `${this.constructor.name}: buildEntityList() produced no attractions, ` +
+      `restaurants or shows — only ${shape}. Refusing to publish a list that ` +
+      `would read as every entity having been removed. Set ` +
+      `allowEmptyEntityList if this destination genuinely has no content.`,
+    );
   }
 
   /**

--- a/src/parks/enchantedparks/__tests__/enchantedparks.test.ts
+++ b/src/parks/enchantedparks/__tests__/enchantedparks.test.ts
@@ -1,5 +1,5 @@
 import {describe, test, expect} from 'vitest';
-import {parseTribeEvents, type TribeEventsResponse, EnchantedParks} from '../enchantedparks.js';
+import {EnchantedParks, parseTribeEvents, scrapeTtl, type TribeEventsResponse} from '../enchantedparks.js';
 import {parseICalFeed} from '../enchantedparks.js';
 import {parseAttractionsPage} from '../enchantedparks.js';
 import {parseShowsPage} from '../enchantedparks.js';
@@ -565,5 +565,44 @@ describe('buildLiveData wiring (stubbed network)', () => {
       {name: 'WOF - Mamba', siteId: 'test-site', operationalStatus: 'Open'},
     ];
     expect(await (park as any).buildLiveData()).toEqual([]);
+  });
+});
+
+describe('scrapeTtl', () => {
+  const DAY = 60 * 60 * 24;
+  const HALF_DAY = 60 * 60 * 12;
+
+  /**
+   * The scrapers swallow a page failure and return `[]` so one missing page
+   * cannot take out a whole destination. Remembering that for a full TTL is
+   * what turned a single failed fetch into Mid-America Parks publishing 3
+   * entities against 76 — and why correcting the host did not take effect
+   * until the cache expired. Observed the same day on the schedule scrape:
+   * the destination served 0 operating days until an empty entry was dropped,
+   * then 60.
+   */
+  it('holds an empty result for minutes, not the full TTL', () => {
+    expect(scrapeTtl(DAY)([])).toBe(60 * 15);
+    expect(scrapeTtl(HALF_DAY)([])).toBe(60 * 15);
+  });
+
+  it('keeps a real listing for the caller\'s own TTL', () => {
+    const rows = [{slug: 'american-thunder', name: 'American Thunder'}];
+    expect(scrapeTtl(DAY)(rows)).toBe(DAY);
+    expect(scrapeTtl(HALF_DAY)(rows)).toBe(HALF_DAY);
+  });
+
+  it('treats a single row as a real answer — one ride is an answer', () => {
+    expect(scrapeTtl(DAY)([{slug: 'a', name: 'A'}])).toBe(DAY);
+  });
+
+  /**
+   * Empty is not always broken: a park out of season publishes no calendar,
+   * and a waterpark has no shows. Verified 2026-09-09 — michigansadventure and
+   * galvestonislandwaterpark both return 0 schedule days from a clean fetch. So an
+   * empty answer is still cached, just briefly.
+   */
+  it('still caches an empty result, rather than refetching every call', () => {
+    expect(scrapeTtl(DAY)([])).toBeGreaterThan(0);
   });
 });

--- a/src/parks/enchantedparks/enchantedparks.ts
+++ b/src/parks/enchantedparks/enchantedparks.ts
@@ -328,6 +328,34 @@ export type ParkConfig = {
 const LIST_FEATURES_QUERY =
   'query($nextToken:String){ listFeatures(limit:300, nextToken:$nextToken){ nextToken items{ name parentAssignmentId operationalStatus } } }';
 
+/**
+ * How long an empty scrape is worth remembering.
+ *
+ * Long enough to spare a genuinely empty page a refetch on every build, short
+ * enough that recovering from a broken one is a coffee break rather than a
+ * day.
+ */
+const EMPTY_SCRAPE_TTL_SECONDS = 60 * 15;
+
+/**
+ * TTL for a scraped result: the caller's own TTL for a real answer, fifteen
+ * minutes for an empty one.
+ *
+ * Every scraper here swallows a page failure and returns `[]`, so that one
+ * missing page cannot take out a whole destination. Cached at full length,
+ * that turns a single bad fetch into a day of pretending the page is empty.
+ * It is how Mid-America Parks came to publish 3 entities against 76 once its
+ * rides pages began redirecting, and why re-pointing the host did not take
+ * effect until the entries expired — the cache key is built from the method
+ * arguments, so changing the subdomain does not change the key.
+ *
+ * Empty is not always a failure: a park out of season really does publish no
+ * calendar, and a waterpark really does have no shows. So an empty answer is
+ * kept, briefly, and treated as provisional rather than as the day's truth.
+ */
+export const scrapeTtl = (fullTtlSeconds: number) =>
+  (rows: unknown[]) => (rows.length ? fullTtlSeconds : EMPTY_SCRAPE_TTL_SECONDS);
+
 class EnchantedParks extends Destination {
   /** Subdomain root, e.g. `https://valleyfair.enchantedparks.com` (no trailing slash) */
   @config subdomain: string = '';
@@ -470,7 +498,7 @@ class EnchantedParks extends Destination {
    *
    * Cached 1h.
    */
-  @cache({ttlSeconds: 60 * 60 * 12})
+  @cache({callback: scrapeTtl(60 * 60 * 12)})
   async scrapeSchedule(category: string): Promise<ScheduleEntry[]> {
     const today = new Date();
     const end = new Date(today.getTime() + 90 * 24 * 60 * 60 * 1000);
@@ -521,7 +549,7 @@ class EnchantedParks extends Destination {
    * fetch fails so a missing waterpark page doesn't take out the whole
    * destination.
    */
-  @cache({ttlSeconds: 60 * 60 * 24})
+  @cache({callback: scrapeTtl(60 * 60 * 24)})
   async scrapeAttractions(ridesPath: string): Promise<AttractionStub[]> {
     try {
       const resp = await this.fetchAttractionsPage(ridesPath);
@@ -539,7 +567,7 @@ class EnchantedParks extends Destination {
    * dining category and linking back to `/rides-and-experiences/dining/…`
    * detail pages instead of `/attractions/…`.
    */
-  @cache({ttlSeconds: 60 * 60 * 24})
+  @cache({callback: scrapeTtl(60 * 60 * 24)})
   async scrapeDining(diningPath: string): Promise<AttractionStub[]> {
     try {
       const resp = await this.fetchAttractionsPage(diningPath);
@@ -555,7 +583,7 @@ class EnchantedParks extends Destination {
    * {@link parseShowsPage} for why this needs its own parser rather than
    * reusing {@link parseAttractionsPage}.
    */
-  @cache({ttlSeconds: 60 * 60 * 24})
+  @cache({callback: scrapeTtl(60 * 60 * 24)})
   async scrapeShows(showsPath: string): Promise<AttractionStub[]> {
     try {
       const resp = await this.fetchAttractionsPage(showsPath);


### PR DESCRIPTION
## The failure

A `DESTINATION` row and its `PARK` rows are built from constants, so they survive an upstream failure that took every real entity with it. What is left parses cleanly, validates, and reports success.

Two destinations reached that state on the same day by different routes:

- one whose POI endpoint answered `200` with an empty list
- one whose rides pages began redirecting, and were dropped by a scraper that treats a failed page as an empty one

The second published **3 entities against 76**, for long enough that every missing ride queued for deletion downstream. `npm run dev` reported **4/4 PASS** on every one of those runs.

## The guard

`getEntities()` now throws if the resolved list contains nothing a guest can visit. One entity of any visitable type (attraction, restaurant, show, hotel) satisfies it; a destination that genuinely publishes none sets `allowEmptyEntityList`.

Throwing is deliberate. The collector is upsert-only with no delete path, so a truncated list does not quietly under-report, it proposes removing everything absent from it. An error skips the poll and leaves the last good list standing, which is always the better of the two.

It is a floor against total collapse, not a proportional check. A park that loses 90% of its rides but keeps one still publishes.

## The other half: cached emptiness

The Enchanted Parks scrapers swallow a page failure and return `[]` so that one missing page cannot take out a whole destination. That empty result was then cached for the method's full TTL, turning a single bad fetch into a day of pretending the page was empty. It is also why correcting the host did not take effect until the entry expired: the cache key is built from the method arguments, so changing the subdomain does not change the key.

`scrapeTtl` now keeps a real answer for the caller's own TTL and an empty one for fifteen minutes:

```ts
export const scrapeTtl = (fullTtlSeconds: number) =>
  (rows: unknown[]) => (rows.length ? fullTtlSeconds : EMPTY_SCRAPE_TTL_SECONDS);
```

Empty is not always broken: a park out of season publishes no calendar and a waterpark has no shows, both verified against live feeds today. So an empty result is still cached, just treated as provisional rather than as the day's truth.

This extends to `scrapeSchedule`, which had the same problem on a 12h TTL and was found serving **0 operating days for a destination that has 60** — the only difference was a cached empty.

## Verification

- 2438 unit tests pass. 14 new: 11 covering the collapse guard (the exact observed shape, the empty build that still carries a `DESTINATION` row, a destination producing literally nothing, the opt-out, each content type satisfying it, and that it throws rather than returning the truncated list), 4 on `scrapeTtl`, 3 removed.
- All 81 destinations run through the harness: **77 pass, 4 fail, none from this change**. The four are a local config gap (Nigloland has no `apiBase` configured on this machine), an `Invalid time value` in Ocean Park HK's live data, Port Aventura's 403s, and SHDR's unsafe entity id. All four pre-date this branch and each has its own issue.
- Six Enchanted Parks destinations re-run individually. The one that had collapsed goes from 3 entities / 0 schedule days to **69 entities / 60 schedule days**.
- Confirmed the new TTL lands as written: empty schedule scrapes now expire in 15m, populated ones in 12h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
