### PR TITLE
fix(parcasterix): stop republishing yesterday's bill overnight

### DIFF
--- a/src/parks/parcasterix/__tests__/showAbsence.test.ts
+++ b/src/parks/parcasterix/__tests__/showAbsence.test.ts
@@ -541,4 +541,62 @@ describe('showBillAuthority', () => {
     expect(showBillAuthority(at('2026-09-09T10:00:00Z'), 'Europe/Paris', [], false))
       .toBe('unknown');
   });
+
+  /**
+   * The window a fixed 06:00 cutoff left open. Between local midnight and 06:00
+   * the bill is still the last open day's, and treating that as authoritative
+   * republished a passed day's programme under tonight's date — which is what
+   * the wiki was serving at 00:20 on 2026-09-09, times and all.
+   *
+   * The park's own hours answer it exactly: nothing is running, so there is
+   * nothing to say.
+   */
+  it('calls the bill stale in the small hours of an ordinary open day', () => {
+    // 00:30 and 03:00 local on the 9th, a day that opens at 10:00.
+    for (const utc of ['2026-09-08T22:30:00Z', '2026-09-09T01:00:00Z']) {
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], false)).toBe('stale');
+    }
+  });
+
+  /**
+   * The same hours on a closed day. The bill is retained across closures, so
+   * before this the small hours published the last open day's performances
+   * re-dated onto a day the park never opens.
+   */
+  it('calls every show dark from midnight on a closed day', () => {
+    // 00:30 local on the 10th; the calendar has the 9th and stops.
+    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY], false))
+      .toBe('all-dark');
+  });
+
+  it('still lets the live feed veto a closed calendar in the small hours', () => {
+    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY], true))
+      .toBe('unknown');
+  });
+
+  /**
+   * A finished day is not a running one. Yesterday's row is in the calendar
+   * now, so the mid-session test has to key off its closing time rather than
+   * its mere presence.
+   */
+  it('does not treat a day that has already closed as still running', () => {
+    const yesterday = hours('2026-09-08', '10:00:00', '18:00:00');
+    expect(showBillAuthority(at('2026-09-08T22:30:00Z'), 'Europe/Paris', [yesterday, TODAY], false))
+      .toBe('stale'); // 00:30 on the 9th, the 8th shut six hours ago
+  });
+
+  /** The boundary: the session's own closing minute is the last one it owns. */
+  it('stops trusting the bill the moment the night closes', () => {
+    const night = {
+      date: '2026-10-17',
+      type: 'TICKETED_EVENT',
+      openingTime: '2026-10-17T19:00:00+02:00',
+      closingTime: '2026-10-18T01:00:00+02:00',
+    };
+    const nextDayOpen = hours('2026-10-18', '10:00:00', '18:00:00');
+    expect(showBillAuthority(at('2026-10-17T22:59:00Z'), 'Europe/Paris', [night, nextDayOpen], false))
+      .toBe('unknown'); // 00:59 local, one minute of the night left
+    expect(showBillAuthority(at('2026-10-17T23:01:00Z'), 'Europe/Paris', [night, nextDayOpen], false))
+      .toBe('stale');   // 01:01 local, the night is over and the 18th opens at 10:00
+  });
 });

--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -14,7 +14,7 @@ import {
   LocalisedString,
   MultilangString,
 } from '@themeparks/typelib';
-import {constructDateTime, hostnameFromUrl, formatDate, formatInTimezone} from '../../datetime.js';
+import {addDays, constructDateTime, hostnameFromUrl, formatDate} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 
 import AdmZip from 'adm-zip';
@@ -165,8 +165,6 @@ export function buildLocalisedName(item: POIEntry): LocalisedString {
  */
 const MIN_ATTRACTION_BILL_FRACTION = 0.5;
 
-/** Local hour at which the previous operating day's after-midnight tail ends. */
-const NIGHT_ENDS_HOUR = 6;
 
 /**
  * What today's calendar lets us say about a show that is missing from
@@ -204,19 +202,26 @@ export function showBillAuthority(
   calendar: ScheduleEntry[],
   parkIsBusy: boolean,
 ): 'all-dark' | 'read-bill' | 'stale' | 'unknown' {
-  // An event night runs past midnight — Halloween closes at 01:00 — so the
-  // small hours still belong to the day before. The bill is still that day's
-  // and is still correct, so this is `unknown`, not `stale`: the shows on it
-  // are mid-performance and their times must keep publishing.
-  const localHour = parseInt(formatInTimezone(now, timezone, 'iso').slice(11, 13), 10);
-  if (!Number.isFinite(localHour) || localHour < NIGHT_ENDS_HOUR) return 'unknown';
-
   if (calendar.length === 0) return 'unknown';
 
-  // Closed days carry no hours and so never reach the calendar at all.
-  const todaysHours = calendar.filter(
-    (entry) => entry.date === formatDate(now, timezone),
+  const today = formatDate(now, timezone);
+
+  // An event night runs past midnight — Halloween closes at 01:00 — so the
+  // small hours can still belong to the day before, whose session is still
+  // running and whose bill is therefore still the current one. Ask the
+  // calendar which day we are in rather than guessing at an hour: a fixed
+  // cutoff has to be late enough for the longest event night, and every hour
+  // it buys for that is an hour of re-publishing yesterday's programme as
+  // today's on all the ordinary days. The entry is dated by the day the
+  // session opened, so it sorts before today while running past midnight.
+  const midSession = calendar.some(
+    (entry) =>
+      entry.date < today && new Date(entry.closingTime).getTime() > now.getTime(),
   );
+  if (midSession) return 'unknown';
+
+  // Closed days carry no hours and so never reach the calendar at all.
+  const todaysHours = calendar.filter((entry) => entry.date === today);
   if (todaysHours.length === 0) return parkIsBusy ? 'unknown' : 'all-dark';
 
   const opensAt = Math.min(
@@ -566,12 +571,22 @@ export class ParcAsterix extends Destination {
         )
         .all() as unknown as SqliteShow[];
 
-      // Query calendar
+      // Query calendar.
+      //
+      // From yesterday, not today: an event night that runs past midnight is
+      // stored under the day it opened, so at 00:30 the session actually in
+      // progress is on yesterday's row. Dropping it is what left the small
+      // hours unable to tell a running event night from a finished day.
+      // showBillAuthority reads the extra row; buildSchedules trims it back
+      // off, so what gets published is unchanged.
+      //
+      // The date is the park's own: on a server running ahead of Paris,
+      // formatDate(now) can already be tomorrow and take today's row with it.
       const now = new Date();
-      const today = formatDate(now);
+      const from = formatDate(addDays(now, -1), this.timezone);
       const calendarItems = db
         .prepare('SELECT day, type FROM calendar_items WHERE day >= ?')
-        .all(today) as unknown as SqliteCalendarItem[];
+        .all(from) as unknown as SqliteCalendarItem[];
 
       const labels = db
         .prepare(
@@ -1069,10 +1084,16 @@ export class ParcAsterix extends Destination {
       return [];
     }
 
+    // getPOIData reaches back one day so showBillAuthority can see an event
+    // night still running past midnight. That extra day is not ours to
+    // publish: yesterday's hours are not a forecast.
+    const today = formatDate(new Date(), this.timezone);
+    const upcoming = calendar.filter((entry) => entry.date >= today);
+
     return [
       {
         id: 'parcasterixpark',
-        schedule: calendar.map((entry) => ({
+        schedule: upcoming.map((entry) => ({
           date: entry.date,
           type: entry.type,
           openingTime: entry.openingTime,


### PR DESCRIPTION
Follow-up to #553, found by a review of that PR's upstream assumptions across 186 samples of the live feed.

## The hole

`showBillAuthority` treated the bill as authoritative from local midnight until a fixed `NIGHT_ENDS_HOUR = 6`. The reasoning was event nights: Halloween closes at 01:00, the shows on the bill are mid-performance, and their times must keep publishing.

That is right for an event night and wrong for every ordinary night. The bill is not rewritten at midnight — on 2026-09-09 it was rewritten at **09:28**, and the tell was a show's window reading `12:00-19:00` before it and `12:00-18:00` after: the 19:00 close belonged to the previous open day. So between midnight and 06:00 the code re-dated a passed day's performances onto today and published them as tonight's.

On a closed day it is worse, because the bill is retained wholesale: those hours advertise performances for a park that never opens. The next two closed days were tomorrow and Friday.

A fixed hour cannot separate the two cases. It has to be late enough for the longest event night, and every hour it buys for that is an hour of republishing on all the ordinary days.

## The fix

The calendar already answers the question exactly. An entry is dated by the day its session opened and carries a real closing time, so a session running past midnight sorts before today with a closing time still ahead of now:

```ts
const midSession = calendar.some(
  (entry) => entry.date < today && new Date(entry.closingTime).getTime() > now.getTime(),
);
if (midSession) return 'unknown';
```

If a session is running, the bill is that session's and stands. If none is, nothing is running and there is nothing to say until the park opens, which the existing `stale` branch already handles by publishing no show rows at all.

Two supporting corrections in the calendar query:

- It selected `day >= today`, so the row holding a still-running event night was dropped exactly when it was needed. It now reaches back one day, and `buildSchedules` trims that day off again. Yesterday's hours are not a forecast, and published schedules are unchanged at 59 days.
- The cutoff date was computed in server-local time via `formatDate(now)` with no timezone. On a server running ahead of Paris that can already be tomorrow, taking today's row with it. It now uses the park's own date.

## Verification

- 2443 tests pass. Five new assertions covering the small hours of an ordinary open day, the small hours of a closed day, the live-feed veto still applying there, a day that has already closed not reading as still running, and the exact closing minute of an event night.
- Four of the five **fail against the previous implementation**, which is the point of them.
- Live run: 79 entities, 64 live rows, **59 schedule days, unchanged**, confirming the extra calendar day does not reach published output.

## Not adopted

The review suggested gating on `paxConfiguration.updatedAt`. It read `07:51:42` on a day the bill was not rewritten until `09:28`, so it would have certified a stale bill as fresh. It tracks the config, not the bill.

One residual stays open and is not addressed here: `read-bill` begins at opening, and the bill was rewritten 32 minutes before opening on the day observed. If upstream is ever late past opening, that window would close shows that do perform. No counter-example in 186 samples, so there is nothing yet to write a fix against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
