### PR TITLE
fix(oceanpark): stop a range timeSlot taking down all live data

### DIFF
--- a/src/__tests__/datetime.test.ts
+++ b/src/__tests__/datetime.test.ts
@@ -542,6 +542,15 @@ describe('DateTime Utilities', () => {
   });
 
   describe('constructDateTime()', () => {
+    test('throws a message naming the offending input, not a bare "Invalid time value"', () => {
+      // A park feed handing over a range rather than a start time used to
+      // surface as an unattributable RangeError from deep inside Intl.
+      expect(() => constructDateTime('2026-09-10', '11:00:00-17:00:00', 'Asia/Hong_Kong'))
+        .toThrow(/invalid date\/time.*11:00:00-17:00:00.*Asia\/Hong_Kong/);
+      expect(() => constructDateTime('2026-09-10', 'not a time', 'Asia/Hong_Kong'))
+        .toThrow(RangeError);
+    });
+
     test('should construct ISO datetime from date + time + timezone', () => {
       const result = constructDateTime('2024-07-15', '10:00', 'Europe/Amsterdam');
       // Summer CEST = UTC+2

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -268,6 +268,16 @@ export function constructDateTime(dateStr: string, timeStr: string, tz: string):
   // (non-existent) input. Park APIs don't report times during gap hours in
   // practice, so this edge case is documented rather than special-cased.
   let ms = new Date(`${target}Z`).getTime();
+  // Park feeds occasionally publish something that isn't a clock time at all
+  // (a range, a note, an empty string). Without this guard the first
+  // formatToParts() below throws a bare "Invalid time value" with no clue
+  // which park, date or field produced it — an expensive thing to diagnose
+  // from a collector log.
+  if (!Number.isFinite(ms)) {
+    throw new RangeError(
+      `constructDateTime: invalid date/time (date="${dateStr}", time="${timeStr}", timezone="${tz}")`,
+    );
+  }
   for (let i = 0; i < 3; i++) {
     const wc = wallClockIn(ms);
     if (wc === target) break;

--- a/src/parks/oceanpark/__tests__/oceanpark.test.ts
+++ b/src/parks/oceanpark/__tests__/oceanpark.test.ts
@@ -16,6 +16,7 @@ import {
   slugify,
   groupShowsBySlug,
   parseQueueMinutes,
+  parseShowTimeSlot,
   parseHourRange,
   addDaysToDateString,
   computeAffineTransform,
@@ -262,6 +263,50 @@ describe('parseHourRange', () => {
     // 24h. Rolling the close time to the next calendar date is buildSchedules'
     // responsibility (covered in the buildSchedules describe block below).
     expect(parseHourRange('6:00 pm - 12:30 am')).toEqual({open: '18:00', close: '00:30'});
+  });
+});
+
+describe('parseShowTimeSlot', () => {
+  test('parses a plain HH:MM:SS start time', () => {
+    expect(parseShowTimeSlot('13:00:00')).toEqual({start: '13:00:00'});
+  });
+
+  test('parses a HH:MM start time, padding the seconds', () => {
+    expect(parseShowTimeSlot('13:05')).toEqual({start: '13:05:00'});
+  });
+
+  test('parses the events-tab range shape into a start and an end', () => {
+    // Real payload: the halloween-2026 tab publishes a continuous window
+    // rather than individual performance times.
+    expect(parseShowTimeSlot('11:00:00-17:00:00')).toEqual({start: '11:00:00', end: '17:00:00'});
+  });
+
+  test('tolerates whitespace and dash variants around the range separator', () => {
+    expect(parseShowTimeSlot(' 11:00 - 17:00 ')).toEqual({start: '11:00:00', end: '17:00:00'});
+    expect(parseShowTimeSlot('11:00:00\u201317:00:00')).toEqual({start: '11:00:00', end: '17:00:00'});
+  });
+
+  test('keeps only the start when the range end is not after the start', () => {
+    expect(parseShowTimeSlot('17:00:00-11:00:00')).toEqual({start: '17:00:00'});
+  });
+
+  test('rejects out-of-range clock components rather than passing them on', () => {
+    expect(parseShowTimeSlot('25:00:00')).toBeNull();
+    expect(parseShowTimeSlot('12:60:00')).toBeNull();
+    expect(parseShowTimeSlot('12:00:60')).toBeNull();
+  });
+
+  test('rejects text that is not a time at all', () => {
+    expect(parseShowTimeSlot('')).toBeNull();
+    expect(parseShowTimeSlot('All day')).toBeNull();
+    expect(parseShowTimeSlot('11:00:00-')).toBeNull();
+    expect(parseShowTimeSlot('10:00:00-12:00:00-14:00:00')).toBeNull();
+  });
+
+  test('rejects non-string input', () => {
+    expect(parseShowTimeSlot(null)).toBeNull();
+    expect(parseShowTimeSlot(undefined)).toBeNull();
+    expect(parseShowTimeSlot(1300)).toBeNull();
   });
 });
 
@@ -716,6 +761,57 @@ describe('buildLiveData', () => {
     const attraction = live.find((l) => l.id === 'attraction_node-1');
     expect(attraction.status).toBe('OPERATING');
     expect(attraction.queue.STANDBY.waitTime).toBe(10);
+  });
+
+  test('a range timeSlot does not reject the whole live-data build and take wait times with it', async () => {
+    // Regression: Ocean Park's halloween-2026 tab publishes a window
+    // ("11:00:00-17:00:00") in timeSlot instead of a start time. Handed
+    // straight to constructDateTime() that produced an Invalid Date and a
+    // RangeError that rejected buildLiveData() outright, so one event item
+    // zeroed out every attraction wait time as well as every show.
+    const probe = new Probe({
+      attractions: [mkAttraction({queueTime: {text: ' 10  mins'}})],
+      scheduleItems: [{title: 'Bulu Boo Trick-or-Treat Party', timeSlot: ['11:00:00-17:00:00']}],
+    });
+
+    const live = await probe.liveData();
+    const attraction = live.find((l) => l.id === 'attraction_node-1');
+    expect(attraction.status).toBe('OPERATING');
+    expect(attraction.queue.STANDBY.waitTime).toBe(10);
+  });
+
+  test('a range timeSlot still running is OPERATING with both a start and an end time', async () => {
+    // "now" is noon; the window runs 11:00-17:00, so it is mid-run.
+    const probe = new Probe({
+      scheduleItems: [{title: 'Bulu Boo Trick-or-Treat Party', timeSlot: ['11:00:00-17:00:00']}],
+    });
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'show_bulu-boo-trick-or-treat-party');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.showtimes).toHaveLength(1);
+    expect(entry.showtimes[0].startTime.startsWith('2026-07-07T11:00')).toBe(true);
+    expect(entry.showtimes[0].endTime.startsWith('2026-07-07T17:00')).toBe(true);
+  });
+
+  test('a range timeSlot that has already finished is CLOSED', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'Bulu Boo Trick-or-Treat Party', timeSlot: ['09:00:00-10:00:00']}],
+    });
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'show_bulu-boo-trick-or-treat-party');
+    expect(entry.status).toBe('CLOSED');
+    expect(entry.showtimes).toBeUndefined();
+  });
+
+  test('an unparseable timeSlot is dropped without losing the other slots of the same show', async () => {
+    const probe = new Probe({
+      scheduleItems: [{title: 'All Star Jam', timeSlot: ['Weather permitting', '13:00:00']}],
+    });
+    const live = await probe.liveData();
+    const entry = live.find((l) => l.id === 'show_all-star-jam');
+    expect(entry.status).toBe('OPERATING');
+    expect(entry.showtimes).toHaveLength(1);
+    expect(entry.showtimes[0].startTime.startsWith('2026-07-07T13:00')).toBe(true);
   });
 
   test('an attractions-fetch failure degrades to no attraction wait times without losing show live data', async () => {

--- a/src/parks/oceanpark/oceanpark.ts
+++ b/src/parks/oceanpark/oceanpark.ts
@@ -50,7 +50,7 @@ import {cache} from '../../cache.js';
 import {http, HTTPObj} from '../../http.js';
 import {inject} from '../../injector.js';
 import {destinationController} from '../../destinationRegistry.js';
-import {formatInTimezone, formatDate, constructDateTime, hostnameFromUrl} from '../../datetime.js';
+import {formatDate, constructDateTime, hostnameFromUrl} from '../../datetime.js';
 import {TagBuilder} from '../../tags/index.js';
 import type {Entity, LiveData, EntitySchedule, ScheduleEntry} from '@themeparks/typelib';
 import {AttractionTypeEnum} from '@themeparks/typelib';
@@ -357,6 +357,55 @@ export function parseQueueMinutes(text: string | null | undefined): number | nul
   if (!m) return null;
   const n = Number(m[1]);
   return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/**
+ * Parse one `timeSlot` entry from the daily-schedule feed.
+ *
+ * Nearly every entry is a single start time ("13:00:00"). Event-tab items are
+ * sometimes a continuous window instead ("11:00:00-17:00:00" — the
+ * halloween-2026 tab's Bulu Boo Trick-or-Treat Party), which is a range, not
+ * a start time. Handing that string straight to constructDateTime() built an
+ * Invalid Date and threw a bare RangeError out of buildLiveData(), so one
+ * event item took every attraction wait time down with it on every sync.
+ *
+ * Returns null for anything that is not a valid time or time range, so no
+ * unvalidated feed text ever reaches date construction. A range whose end is
+ * not after its start is nonsense (the park does not run past midnight), so
+ * the end is discarded and only the start kept.
+ */
+export function parseShowTimeSlot(raw: unknown): {start: string; end?: string} | null {
+  if (typeof raw !== 'string') return null;
+
+  const parts = raw.trim().split(/\s*[-\u2013\u2014]\s*/);
+  if (parts.length > 2) return null;
+
+  const start = normaliseClockTime(parts[0]);
+  if (!start) return null;
+  if (parts.length === 1) return {start};
+
+  const end = normaliseClockTime(parts[1]);
+  if (!end) return null;
+  if (end <= start) {
+    console.warn(`[OceanPark] range timeSlot "${raw}" ends at or before it starts; keeping the start only`);
+    return {start};
+  }
+
+  return {start, end};
+}
+
+/** "13:5" style sloppiness is rejected; "13:05" and "13:05:00" both normalise to "13:05:00". */
+function normaliseClockTime(text: string): string | null {
+  const m = text.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (!m) return null;
+
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  const sec = m[3] === undefined ? 0 : Number(m[3]);
+  if (h > 23 || min > 59 || sec > 59) return null;
+
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(h)}:${pad(min)}:${pad(sec)}`;
 }
 
 /** Parse a "10:00 am - 7:00 pm" style range into 24h HH:mm strings. */
@@ -803,15 +852,30 @@ export class OceanParkHongKong extends Destination {
 
     // Shows — group today's programme entries by slug (same grouping
     // buildEntityList uses, so ids always agree) and emit remaining
-    // showtimes. No explicit end time is published, only a start.
+    // showtimes. Most entries are a bare start time; event-tab entries can be
+    // a start-to-end window instead, which carries a real end time.
     const showGroups = groupShowsBySlug(scheduleItems);
     const now = Date.now();
     for (const [slug, group] of showGroups) {
       const showtimes = group.items
         .flatMap(entry => entry.timeSlot ?? [])
-        .map(t => formatInTimezone(new Date(constructDateTime(today, t, TIMEZONE)), TIMEZONE, 'iso'))
-        .filter(iso => new Date(iso).getTime() >= now)
-        .map(iso => ({type: 'Performance Time', startTime: iso}));
+        .map(raw => {
+          const slot = parseShowTimeSlot(raw);
+          if (!slot) {
+            console.warn(`[OceanPark] show "${group.title}": unrecognised timeSlot ${JSON.stringify(raw)}; dropping that slot`);
+            return null;
+          }
+          return {
+            type: 'Performance Time',
+            startTime: constructDateTime(today, slot.start, TIMEZONE),
+            ...(slot.end ? {endTime: constructDateTime(today, slot.end, TIMEZONE)} : {}),
+          };
+        })
+        .filter((s): s is {type: string; startTime: string; endTime?: string} => s !== null)
+        // A window that has started but not yet finished is still running, so
+        // an all-day event stays listed until its end time instead of
+        // vanishing a second after it opens.
+        .filter(s => new Date(s.endTime ?? s.startTime).getTime() >= now);
 
       const ld: LiveData = {
         id: `show_${slug}`,


### PR DESCRIPTION
## What broke

Ocean Park's live data has been rejecting outright since the Halloween 2026 programme went up on the daily-schedule feed.

Most programme entries publish a single start time in `timeSlot`:

```json
{"title": "Roving Band (Near Lagoon Platform)", "timeSlot": ["10:00:00", "11:20:00", ...]}
```

Event-tab entries can publish a continuous window instead:

```json
{"title": "Bulu Boo Trick-or-Treat Party", "tab": "halloween-2026", "timeSlot": ["11:00:00-17:00:00"]}
```

That string went straight into `constructDateTime()`, which split it on `:` into five parts, built `new Date("2026-09-10T11:00:00-17:00:00Z")` — an Invalid Date — and threw `RangeError: Invalid time value` out of `buildLiveData()`. One event item therefore rejected the entire live-data build: every attraction wait time and every showtime, on every cycle, for as long as the item sits on today's programme. It is currently on all seven days the feed publishes ahead.

## The fix

- `parseShowTimeSlot()` validates and normalises each entry first: `HH:MM` / `HH:MM:SS`, or a start-to-end range. Out-of-range clock components and anything that isn't a time return null.
- A range now carries a real `endTime` through to the showtimes — the feed does publish an end for these, we just had nowhere to put it.
- The "still upcoming" filter uses the end when there is one, so a window that has started but not finished stays listed instead of vanishing a second after it opens.
- Anything unparseable is dropped with a warning rather than reaching date construction.
- `constructDateTime()` now names the date, time and timezone it choked on instead of throwing a bare `Invalid time value` from inside `Intl` — that error told you nothing about which park or field produced it.

## Verification

- 12 new unit tests (8 on the parser, 4 on `buildLiveData`), including the exact production payload as a regression test. Red before the fix, green after.
- Full suite: 2460 passed.
- `npm run dev -- oceanparkhongkong` — was 3/4 with `getLiveData: Invalid time value`, now 4/4 with 63 live entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)