### PR TITLE
docs(parcasterix): paxLatencies thins with the season, it is not year-round

### DIFF
--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -308,10 +308,12 @@ export class ParcAsterix extends Destination {
    *
    * 0.2 puts it back the other way: more than about a fifth of the tracked set
    * gone at once is distrusted, roughly thirteen attractions. Nothing is lost
-   * by being strict here — `paxLatencies` lists every attraction year-round, so
-   * an attraction going absent is already an anomaly rather than a retirement,
-   * and the absence the gate genuinely exists for (a show losing its POI row)
-   * is one or two entities, well under `liveEntityRetirementMinBulk`.
+   * by being strict here. An attraction leaving `paxLatencies` is usually
+   * seasonal rather than a retirement — on 2026-09-10 eight went at once, five
+   * Peur sur le Parc, two Noel Gaulois — and a seasonal departure wants a
+   * CLOSED row anyway, which is what the gate produces. The absence the gate
+   * genuinely exists for (a show losing its POI row) is one or two entities,
+   * well under `liveEntityRetirementMinBulk`.
    */
   protected liveEntityRetirementMaxFraction = 0.2;
 
@@ -1112,12 +1114,19 @@ export class ParcAsterix extends Destination {
     const observed = new Set(latencies.map((entry) => String(entry.drupalId)));
     const attractions = poi.filter((item) => item._type === 'attraction').length;
 
-    // `paxLatencies` carries every attraction year-round, closed ones included
-    // through the winter shutdown, so a short one is a broken poll and never a
-    // shut park. Counting it against the package's own attraction total keeps
-    // that self-calibrating as the park adds and drops rides, and catches the
-    // partial regeneration an emptiness check misses: a bill of one attraction
-    // out of fifty would otherwise close every show in the park.
+    // `paxLatencies` shrinks with the season rather than listing everything
+    // year-round: on 2026-09-10 it went 50 -> 42 in one step as the Halloween
+    // and Christmas attractions left, and a deep-off-season capture from
+    // 2026-03-30, five days before opening, still carried 44 of them. So it
+    // thins, it does not empty, and a *short* bill is still a broken poll
+    // rather than a shut park.
+    //
+    // Counting it against the package's own attraction total is what makes
+    // that safe, because both lists move together — the same day the bill went
+    // to 42, the package went to 41. An absolute floor would have tripped on
+    // an ordinary seasonal transition. The fraction also catches the partial
+    // regeneration an emptiness check misses: a bill of one attraction out of
+    // fifty would otherwise close every show in the park.
     const corroborated = attractions > 0
       && latencies.length >= attractions * MIN_ATTRACTION_BILL_FRACTION;
 


### PR DESCRIPTION
Comments only, no behaviour change. Found by a sampler that has been watching the feed since #553.

## The claim that was wrong

Two comments stated that `paxLatencies` lists every attraction year-round, closed ones included through the winter shutdown. Both are the stated reasoning behind a threshold, so a future reader could reasonably build on them.

On 2026-09-10 the bill went **50 → 42** in one step. The eight that left were all out of season:

```
31374 The Catacombs            31385 The Infernal Cauldrons
31379 The Tomb of the Gods      34631 The Forest of No Return
31384 The Hellish Pompeii       31375 Viking Ice Rink
31380 Gardens of Father Christmas    31386 Obelix's Slide
```

Five Peur sur le Parc, two Noël Gaulois, one other. Every one had been present-but-never-open the day before, `isOpen: false` with a null latency throughout. So the bill prunes out-of-season attractions exactly as `paxSchedules` prunes out-of-season shows — the two behave the same way, which is not what the comments said.

## The substance holds, for a better reason

Verified against the live feed on an uncached fetch:

```
package attractions:  41   (was 50)
paxLatencies entries: 42   (was 50)
absent from latencies: 0
```

**Both lists moved together.** The same day the bill went to 42, the package's own attraction count went to 41. That is what makes counting the bill against the package total safe, and it is a stronger argument for the fractional design than the comment was making: an absolute floor would have tripped on an ordinary seasonal transition.

A deep-off-season capture from 2026-03-30, five days before the season opened, still carried 44 entries. The list thins; it does not empty. A *short* bill remains a broken poll rather than a shut park, so `MIN_ATTRACTION_BILL_FRACTION` is untouched and `corroborated` still holds comfortably at 42 of 41.

`parkIsBusy` is unaffected — it divides by the package count, not the bill's — and 4 open against 41 stays well below the quorum.

## The retirement comment

Corrected in the same direction. It said an attraction going absent is "already an anomaly rather than a retirement". Seasonal departure makes absence normal, and a seasonal departure wants a CLOSED row anyway, which is what the gate produces. `liveEntityRetirementMaxFraction` is unchanged: eight absent against roughly sixty tracked is well inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
