### PR TITLE
fix(parcasterix): let the calendar alone decide a closed day's shows

### DIFF
--- a/src/parks/parcasterix/__tests__/showAbsence.test.ts
+++ b/src/parks/parcasterix/__tests__/showAbsence.test.ts
@@ -293,7 +293,15 @@ describe('Parc Asterix dark-show guards', () => {
   // The bill rolls at local midnight while a Halloween night still has an hour
   // to run, and a show physically mid-performance would otherwise be absent
   // from a bill for a day that has not started.
-  it('closes nothing in the after-midnight tail of an event night', async () => {
+  /**
+   * This was named for an event night and fixtured as an ordinary 10:00-18:00
+   * day, so what kept it silent at 01:30 was the ride-feed veto rather than
+   * anything about event nights. With the veto gone it asserts the real rule:
+   * at 01:30 on a day carrying no hours, nothing is running and the shows are
+   * dark. A genuine event night — one whose entry closes after midnight — is
+   * covered by the mid-session test, which reads its bill straight through.
+   */
+  it('closes the shows after midnight when no session is running', async () => {
     vi.setSystemTime(new Date('2026-10-17T23:30:00Z')); // 01:30 Europe/Paris
     const live = await stubbedPark(
       ATTRACTIONS,
@@ -301,7 +309,8 @@ describe('Parc Asterix dark-show guards', () => {
       [...ATTRACTION_POI, show(31483), show(31513)],
     ).getLiveData();
 
-    expect(live.filter((l) => l.status === 'CLOSED' && !l.queue)).toEqual([]);
+    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
   // The bill served overnight is the last open day's and is not rewritten for
@@ -324,7 +333,13 @@ describe('Parc Asterix dark-show guards', () => {
 
   // The small hours are different: an event night's bill is still that night's
   // and still correct, so its performances must keep publishing.
-  it('keeps publishing performances in the after-midnight tail', async () => {
+  /**
+   * Same mislabelling: an ordinary day's calendar, read at 01:30. A bill entry
+   * timed 00:45 is a leftover from the default programme, not a performance in
+   * progress, and publishing it asserts a show on a day with no session. The
+   * real after-midnight case is the mid-session one below.
+   */
+  it('does not publish a leftover overnight performance on a dark day', async () => {
     vi.setSystemTime(new Date('2026-10-17T23:30:00Z')); // 01:30 Europe/Paris
     const live = await stubbedPark(
       ATTRACTIONS,
@@ -332,8 +347,8 @@ describe('Parc Asterix dark-show guards', () => {
       [...ATTRACTION_POI, show(31483), show(31513)],
     ).getLiveData();
 
-    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
-    expect(live.find((l) => l.id === '31513')).toBeUndefined();
+    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
   it('resumes closing once the park has opened', async () => {
@@ -364,7 +379,19 @@ describe('Parc Asterix dark-show guards', () => {
     expect(live.find((l) => l.id === '31483')?.showtimes).toBeUndefined();
   });
 
-  it('publishes nothing about shows when a closed calendar meets open rides', async () => {
+  /**
+   * The case that removed the veto. On 2026-09-10, a closed day, eleven real
+   * rides came up between 17:42 and 18:03 for what looked like a private
+   * evening event, while the bill was still the out-of-hours default it had
+   * been serving for twenty-three hours. The old rule read the busy rides as
+   * proof the calendar was wrong and republished that bill, asserting eighteen
+   * performances on a day the park was shut to the public.
+   *
+   * Rides running for a private booking is no evidence that the show programme
+   * was rewritten. The rides publish as OPERATING from the feed, which is
+   * true; the shows stay closed, which is also true.
+   */
+  it('closes the shows on a closed day even when every ride reports open', async () => {
     const live = await stubbedPark(
       ATTRACTIONS,
       [performance('31483')],
@@ -372,8 +399,8 @@ describe('Parc Asterix dark-show guards', () => {
       closedToday,
     ).getLiveData();
 
-    expect(live.find((l) => l.id === '31483')).toMatchObject({status: 'OPERATING'});
-    expect(live.find((l) => l.id === '31513')).toBeUndefined();
+    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
   });
 
   // The live path never used to touch the offline package. Putting a 23MB ZIP
@@ -475,18 +502,21 @@ describe('Parc Asterix polling response', () => {
 });
 
 /**
- * The live feed's veto over a closed calendar has to mean "the park is
- * evidently busy", not "at least one open flag is set".
+ * A closed day is decided by the calendar alone.
  *
- * Four POIs here — three playgrounds and a walk-through, none of which take a
- * queue — report `isOpen: true` around the clock and have never carried a
- * latency. Measured over 284 samples spanning a full operating day: out of
- * hours the open count was exactly those 4 of 50 every time, in hours 37 to 40.
- * Under a `some(isOpen)` veto those four alone held the veto open permanently,
- * which made the closed-day branch unreachable for this park — including
- * through the 40-day November shutdown.
+ * The ride feed used to hold a veto here, on the reasoning that a calendar
+ * claiming closed while attractions report open is a calendar to distrust.
+ * Two separate observations killed it. Four POIs — three playgrounds and a
+ * walk-through, none of which take a queue — report open around the clock and
+ * never carry a latency, which held the veto open permanently and made this
+ * branch unreachable. Raising the bar to a quorum fixed that, and then on
+ * 2026-09-10 eleven real rides came up on a closed day for a private event and
+ * crossed the quorum in twenty-one minutes.
+ *
+ * The vote was truthful both times. It was answering the wrong question: ride
+ * activity is not evidence about whether the show bill was rewritten.
  */
-describe('the closed-day veto needs a quorum', () => {
+describe('a closed day closes the shows', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
@@ -495,36 +525,37 @@ describe('the closed-day veto needs a quorum', () => {
   });
   afterEach(() => vi.useRealTimers());
 
-  /** The stuck four: open, but never a latency between them. */
-  const stuckOpen = ATTRACTION_IDS.slice(0, 2).map((id) => latency(String(id), true, null));
-  const shut = ATTRACTION_IDS.slice(2).map((id) => latency(String(id), false, null));
+  const openRides = (n: number) => [
+    ...ATTRACTION_IDS.slice(0, n).map((id) => latency(String(id), true, 15)),
+    ...ATTRACTION_IDS.slice(n).map((id) => latency(String(id), false, null)),
+  ];
 
-  it('closes the shows on a closed day when only the stuck flags are open', async () => {
+  it.each([0, 2, 10, 20])(
+    'closes the shows with %i rides reporting open',
+    async (openN) => {
+      const live = await stubbedPark(
+        openRides(openN),
+        [performance('31483')],
+        [...ATTRACTION_POI, show(31483), show(31513)],
+        closedToday,
+      ).getLiveData();
+
+      expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+      expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+    },
+  );
+
+  /** The rides themselves stay truthful — only the show decision changed. */
+  it('still publishes the open rides as operating', async () => {
     const live = await stubbedPark(
-      [...stuckOpen, ...shut],
+      openRides(11),
       [performance('31483')],
       [...ATTRACTION_POI, show(31483), show(31513)],
       closedToday,
     ).getLiveData();
 
-    // The bill still lists 31483, but the park is shut today, so it is not
-    // republished — and both shows are closed.
-    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
-    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
-  });
-
-  it('still lets a genuinely busy park veto a calendar that says closed', async () => {
-    const busy = ATTRACTION_IDS.map((id) => latency(String(id), true, 15));
-    const live = await stubbedPark(
-      busy,
-      [performance('31483')],
-      [...ATTRACTION_POI, show(31483), show(31513)],
-      closedToday,
-    ).getLiveData();
-
-    // The calendar is the thing to distrust here, so the bill is published.
-    expect(live.find((l) => l.id === '31483')?.status).toBe('OPERATING');
-    expect(live.find((l) => l.id === '31513')).toBeUndefined();
+    const ride = live.find((l) => l.id === String(ATTRACTION_IDS[0]));
+    expect(ride?.status).toBe('OPERATING');
   });
 });
 
@@ -539,7 +570,7 @@ describe('showBillAuthority', () => {
   const at = (iso: string) => new Date(iso);
 
   it('reads the bill once the park has opened', () => {
-    expect(showBillAuthority(at('2026-09-09T08:30:00Z'), 'Europe/Paris', [TODAY], true))
+    expect(showBillAuthority(at('2026-09-09T08:30:00Z'), 'Europe/Paris', [TODAY]))
       .toBe('read-bill'); // 10:30 local
   });
 
@@ -548,7 +579,7 @@ describe('showBillAuthority', () => {
   // "was not on that day", not "is not on today".
   it('calls the bill stale between the small hours and opening', () => {
     for (const utc of ['2026-09-09T04:30:00Z', '2026-09-09T06:00:00Z', '2026-09-09T07:28:00Z']) {
-      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], false)).toBe('stale');
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY])).toBe('stale');
     }
   });
 
@@ -562,37 +593,45 @@ describe('showBillAuthority', () => {
       openingTime: '2026-10-17T19:00:00+02:00',
       closingTime: '2026-10-18T01:00:00+02:00',
     };
-    expect(showBillAuthority(at('2026-10-17T22:30:00Z'), 'Europe/Paris', [night], false))
+    expect(showBillAuthority(at('2026-10-17T22:30:00Z'), 'Europe/Paris', [night]))
       .toBe('unknown'); // 00:30 local on the 18th, which carries no hours
   });
 
-  it('stays silent in the after-midnight tail of an event night', () => {
+  /**
+   * Once the night's own closing time has passed, the tail is over. The 18th
+   * carries no hours of its own, so nothing is running and the shows are dark.
+   * While it *is* running, the mid-session test above keeps the bill readable.
+   */
+  it('calls the shows dark once an event night has actually closed', () => {
     const night = {
       date: '2026-10-17',
       type: 'TICKETED_EVENT',
       openingTime: '2026-10-17T19:00:00+02:00',
       closingTime: '2026-10-18T01:00:00+02:00',
     };
-    expect(showBillAuthority(at('2026-10-17T23:30:00Z'), 'Europe/Paris', [night], true))
-      .toBe('unknown'); // 01:30 local on the 18th
+    expect(showBillAuthority(at('2026-10-17T23:30:00Z'), 'Europe/Paris', [night]))
+      .toBe('all-dark'); // 01:30 local on the 18th, half an hour after close
   });
 
   // Closed days carry no hours, so they never reach the calendar. The bill
   // keeps serving the last open day's programme straight through them.
   it('calls every show dark on a day the park does not operate', () => {
-    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY], false))
+    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY]))
       .toBe('all-dark');
   });
 
-  // A calendar that says closed while the rides say open is a calendar to
-  // distrust, not a park to close.
-  it('defers to the live feed when it contradicts a closed calendar', () => {
-    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY], true))
-      .toBe('unknown');
+  /**
+   * The ride feed no longer gets a say. It held a veto here until a private
+   * event on 2026-09-10 put eleven real rides up on a closed day and turned
+   * that veto into eighteen advertised performances on a shut park.
+   */
+  it('closes the shows on a closed day regardless of ride activity', () => {
+    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY]))
+      .toBe('all-dark');
   });
 
   it('admits it cannot tell with no calendar at all', () => {
-    expect(showBillAuthority(at('2026-09-09T10:00:00Z'), 'Europe/Paris', [], false))
+    expect(showBillAuthority(at('2026-09-09T10:00:00Z'), 'Europe/Paris', []))
       .toBe('unknown');
   });
 
@@ -608,7 +647,7 @@ describe('showBillAuthority', () => {
   it('calls the bill stale in the small hours of an ordinary open day', () => {
     // 00:30 and 03:00 local on the 9th, a day that opens at 10:00.
     for (const utc of ['2026-09-08T22:30:00Z', '2026-09-09T01:00:00Z']) {
-      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], false)).toBe('stale');
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY])).toBe('stale');
     }
   });
 
@@ -619,13 +658,13 @@ describe('showBillAuthority', () => {
    */
   it('calls every show dark from midnight on a closed day', () => {
     // 00:30 local on the 10th; the calendar has the 9th and stops.
-    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY], false))
+    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY]))
       .toBe('all-dark');
   });
 
-  it('still lets the live feed veto a closed calendar in the small hours', () => {
-    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY], true))
-      .toBe('unknown');
+  it('closes the shows in the small hours of a closed day too', () => {
+    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY]))
+      .toBe('all-dark');
   });
 
   /**
@@ -635,7 +674,7 @@ describe('showBillAuthority', () => {
    */
   it('does not treat a day that has already closed as still running', () => {
     const yesterday = hours('2026-09-08', '10:00:00', '18:00:00');
-    expect(showBillAuthority(at('2026-09-08T22:30:00Z'), 'Europe/Paris', [yesterday, TODAY], false))
+    expect(showBillAuthority(at('2026-09-08T22:30:00Z'), 'Europe/Paris', [yesterday, TODAY]))
       .toBe('stale'); // 00:30 on the 9th, the 8th shut six hours ago
   });
 
@@ -649,14 +688,14 @@ describe('showBillAuthority', () => {
   it('calls the bill stale once the park has closed', () => {
     // 18:30, 20:00 and 23:45 local on a day that shuts at 18:00.
     for (const utc of ['2026-09-09T16:30:00Z', '2026-09-09T18:00:00Z', '2026-09-09T21:45:00Z']) {
-      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], true)).toBe('stale');
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY])).toBe('stale');
     }
   });
 
   it('still reads the bill right up to closing', () => {
-    expect(showBillAuthority(at('2026-09-09T15:59:00Z'), 'Europe/Paris', [TODAY], true))
+    expect(showBillAuthority(at('2026-09-09T15:59:00Z'), 'Europe/Paris', [TODAY]))
       .toBe('read-bill'); // 17:59 local, one minute before the 18:00 close
-    expect(showBillAuthority(at('2026-09-09T16:01:00Z'), 'Europe/Paris', [TODAY], true))
+    expect(showBillAuthority(at('2026-09-09T16:01:00Z'), 'Europe/Paris', [TODAY]))
       .toBe('stale');     // 18:01 local
   });
 
@@ -685,7 +724,7 @@ describe('showBillAuthority', () => {
       openingTime: '2026-10-17T19:00:00+02:00',
       closingTime: '2026-10-18T01:00:00+02:00',
     };
-    expect(showBillAuthority(at('2026-10-17T21:00:00Z'), 'Europe/Paris', [night], true))
+    expect(showBillAuthority(at('2026-10-17T21:00:00Z'), 'Europe/Paris', [night]))
       .toBe('read-bill'); // 23:00 local on the 17th, the night is running
   });
 
@@ -698,9 +737,9 @@ describe('showBillAuthority', () => {
       closingTime: '2026-10-18T01:00:00+02:00',
     };
     const nextDayOpen = hours('2026-10-18', '10:00:00', '18:00:00');
-    expect(showBillAuthority(at('2026-10-17T22:59:00Z'), 'Europe/Paris', [night, nextDayOpen], false))
+    expect(showBillAuthority(at('2026-10-17T22:59:00Z'), 'Europe/Paris', [night, nextDayOpen]))
       .toBe('unknown'); // 00:59 local, one minute of the night left
-    expect(showBillAuthority(at('2026-10-17T23:01:00Z'), 'Europe/Paris', [night, nextDayOpen], false))
+    expect(showBillAuthority(at('2026-10-17T23:01:00Z'), 'Europe/Paris', [night, nextDayOpen]))
       .toBe('stale');   // 01:01 local, the night is over and the 18th opens at 10:00
   });
 });

--- a/src/parks/parcasterix/__tests__/showAbsence.test.ts
+++ b/src/parks/parcasterix/__tests__/showAbsence.test.ts
@@ -79,17 +79,31 @@ const openToday = () => [openDay(new Date().toISOString().slice(0, 10))];
  */
 const closedToday = () => [openDay('2026-09-06'), openDay('2026-09-12')];
 
+const todayStr = () => new Date().toISOString().slice(0, 10);
+
+/**
+ * A day carries no hours for two reasons that look identical in the calendar
+ * and demand opposite behaviour: the park's legend said it is shut, or we could
+ * not read the legend and dropped the day. `closedDates` is the park's own
+ * attestation, so a fixture has to say which case it is.
+ */
+const attestedClosed = () => [todayStr()];
+/** The park said nothing we could read about today. Not evidence of anything. */
+const unreadable = () => [];
+
 function stubbedPark(
   latencies: ReturnType<typeof latency>[],
   schedules: ReturnType<typeof performance>[],
   poi: POIEntry[],
   calendar: () => any[] = openToday,
+  closedDates: () => string[] = attestedClosed,
 ): ParcAsterix {
   const park = new ParcAsterix();
   vi.spyOn(park as any, 'getPolling').mockResolvedValue({latencies, schedules});
   vi.spyOn(park as any, 'getPOIData').mockImplementation(async () => ({
     poi,
     calendar: calendar(),
+    closedDates: closedDates(),
   }));
   return park;
 }
@@ -307,6 +321,10 @@ describe('Parc Asterix dark-show guards', () => {
       ATTRACTIONS,
       [],
       [...ATTRACTION_POI, show(31483), show(31513)],
+      openToday,
+      // The 18th is attested closed. Named rather than derived, because the
+      // park's day has already rolled to the 18th while UTC is still the 17th.
+      () => ['2026-10-18'],
     ).getLiveData();
 
     expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
@@ -345,6 +363,8 @@ describe('Parc Asterix dark-show guards', () => {
       ATTRACTIONS,
       [performance('31483', [{at: '00:45:00', startAt: null, endAt: null}])],
       [...ATTRACTION_POI, show(31483), show(31513)],
+      openToday,
+      () => ['2026-10-18'],
     ).getLiveData();
 
     expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
@@ -554,8 +574,139 @@ describe('a closed day closes the shows', () => {
       closedToday,
     ).getLiveData();
 
+    // Full row: a status-only assertion would pass on a row that had lost its
+    // queue, which is the half of the ride data that actually matters.
     const ride = live.find((l) => l.id === String(ATTRACTION_IDS[0]));
-    expect(ride?.status).toBe('OPERATING');
+    expect(ride).toMatchObject({
+      id: String(ATTRACTION_IDS[0]),
+      status: 'OPERATING',
+      queue: {STANDBY: {waitTime: 15}},
+    });
+  });
+});
+
+/**
+ * A day with no hours is not self-explaining.
+ *
+ * The calendar is reconstructed by regex from free-form legend text: type D
+ * reads "Theme Park closed" and yields nothing, while type A reads "10:00 a.m.
+ * to 6:00 p.m." and yields a range. A legend the patterns miss also yields
+ * nothing, so before this distinction existed an unreadable operating day was
+ * indistinguishable from an attested closed one — and `all-dark` does not stay
+ * silent, it closes every show id including the ones the bill names as
+ * performing. That publishes CLOSED over a correct bill.
+ *
+ * Verified against the live package on 2026-09-11: all eight forward day types
+ * parse, and D is the only one with no clock time in its legend.
+ */
+describe('a day with no hours: attested closed vs unreadable', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    CacheLib.clearByClassName('ParcAsterix', {includePersistent: true});
+    vi.useFakeTimers();
+    vi.setSystemTime(DAYTIME);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('closes the shows when the park attests the day is closed', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483')],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+      closedToday,
+      attestedClosed,
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')).toEqual({id: '31483', status: 'CLOSED'});
+    expect(live.find((l) => l.id === '31513')).toEqual({id: '31513', status: 'CLOSED'});
+  });
+
+  /**
+   * The failure this exists to prevent. Same calendar gap, but the park never
+   * said the day was closed — we simply could not read it. The bill names
+   * 31483 as performing, and closing it would contradict a correct upstream.
+   */
+  it('says nothing about shows when the day is merely unreadable', async () => {
+    const live = await stubbedPark(
+      ATTRACTIONS,
+      [performance('31483')],
+      [...ATTRACTION_POI, show(31483), show(31513)],
+      closedToday,
+      unreadable,
+    ).getLiveData();
+
+    expect(live.find((l) => l.id === '31483')?.status).toBe('OPERATING');
+    expect(live.find((l) => l.id === '31513')).toBeUndefined();
+  });
+
+  it('leaves the wait times alone either way', async () => {
+    for (const dates of [attestedClosed, unreadable]) {
+      const live = await stubbedPark(
+        ATTRACTIONS,
+        [],
+        [...ATTRACTION_POI, show(31483)],
+        closedToday,
+        dates,
+      ).getLiveData();
+      expect(live.filter((l) => l.id.startsWith('313')).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+/**
+ * The calendar parser had no tests at all, and it is the sole authority for
+ * closing every show in the park.
+ */
+describe('calendar legend parsing', () => {
+  const park = new ParcAsterix();
+  const parse = (labels: Record<string, string>) =>
+    (park as any).parseCalendarLabels(
+      Object.entries(labels).map(([k, value]) => ({key: `calendar.dateType.legend.${k}`, value})),
+    ) as {hoursMap: Record<string, unknown[]>; closedTypes: Set<string>};
+
+  // Verbatim from the live package, 2026-09-11.
+  const LIVE = {
+    A: '10:00 a.m. to 6:00 p.m.',
+    B: '10:00 a.m. - 7:00 p.m. Peur sur le Parc',
+    C: '10:00 a.m. - 10:00 p.m. Été Gaulois',
+    D: 'Theme Park closed',
+    G: '11:00 a.m. - 8:00 p.m. Noël Gaulois',
+    H: '10:00 a.m. - 7:00 p.m.',
+    I: '10am - 10pm',
+    J: 'Daytime 9:00 a.m. - 6:00 p.m. and Evening 7:00 p.m. - 1:00 a.m. Peur sur le Parc',
+    L: '11:00 a.m. - 7:00 p.m. Noël Gaulois on 24 and 31 December',
+    M: '7pm - 01am',
+  };
+
+  it('reads every day type the park currently publishes', () => {
+    const {hoursMap, closedTypes} = parse(LIVE);
+    for (const type of ['A', 'B', 'C', 'G', 'H', 'I', 'J', 'L', 'M']) {
+      expect(hoursMap[type]?.length, `type ${type}`).toBeGreaterThan(0);
+    }
+    expect(closedTypes.has('D')).toBe(true);
+    expect(hoursMap.D).toBeUndefined();
+  });
+
+  it('keeps both ranges of a two-session day', () => {
+    expect(parse(LIVE).hoursMap.J).toHaveLength(2);
+  });
+
+  /**
+   * A legend that carries a clock time but no readable range is a parser gap,
+   * not a closure. Classing it as closed is what would publish CLOSED over a
+   * performing show — these are the wordings most likely to appear next.
+   */
+  it.each([
+    ['en-dash separator', '10h–18h'],
+    ['French connector', 'de 10h à 18h'],
+    ['open-ended', 'from 7 p.m. until late'],
+  ])('does not read %s as a closed day', (_name, value) => {
+    const {closedTypes} = parse({X: value});
+    expect(closedTypes.has('X')).toBe(false);
+  });
+
+  it('reads a closure worded with a date but no time as closed', () => {
+    expect(parse({X: 'Closed, reopens 12 December'}).closedTypes.has('X')).toBe(true);
   });
 });
 
@@ -570,7 +721,7 @@ describe('showBillAuthority', () => {
   const at = (iso: string) => new Date(iso);
 
   it('reads the bill once the park has opened', () => {
-    expect(showBillAuthority(at('2026-09-09T08:30:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-09T08:30:00Z'), 'Europe/Paris', [TODAY], new Set()))
       .toBe('read-bill'); // 10:30 local
   });
 
@@ -579,7 +730,7 @@ describe('showBillAuthority', () => {
   // "was not on that day", not "is not on today".
   it('calls the bill stale between the small hours and opening', () => {
     for (const utc of ['2026-09-09T04:30:00Z', '2026-09-09T06:00:00Z', '2026-09-09T07:28:00Z']) {
-      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY])).toBe('stale');
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], new Set())).toBe('stale');
     }
   });
 
@@ -593,7 +744,7 @@ describe('showBillAuthority', () => {
       openingTime: '2026-10-17T19:00:00+02:00',
       closingTime: '2026-10-18T01:00:00+02:00',
     };
-    expect(showBillAuthority(at('2026-10-17T22:30:00Z'), 'Europe/Paris', [night]))
+    expect(showBillAuthority(at('2026-10-17T22:30:00Z'), 'Europe/Paris', [night], new Set()))
       .toBe('unknown'); // 00:30 local on the 18th, which carries no hours
   });
 
@@ -609,14 +760,14 @@ describe('showBillAuthority', () => {
       openingTime: '2026-10-17T19:00:00+02:00',
       closingTime: '2026-10-18T01:00:00+02:00',
     };
-    expect(showBillAuthority(at('2026-10-17T23:30:00Z'), 'Europe/Paris', [night]))
+    expect(showBillAuthority(at('2026-10-17T23:30:00Z'), 'Europe/Paris', [night], new Set(['2026-10-18'])))
       .toBe('all-dark'); // 01:30 local on the 18th, half an hour after close
   });
 
   // Closed days carry no hours, so they never reach the calendar. The bill
   // keeps serving the last open day's programme straight through them.
   it('calls every show dark on a day the park does not operate', () => {
-    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY], new Set(['2026-09-10'])))
       .toBe('all-dark');
   });
 
@@ -626,12 +777,12 @@ describe('showBillAuthority', () => {
    * that veto into eighteen advertised performances on a shut park.
    */
   it('closes the shows on a closed day regardless of ride activity', () => {
-    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-10T10:00:00Z'), 'Europe/Paris', [TODAY], new Set(['2026-09-10'])))
       .toBe('all-dark');
   });
 
   it('admits it cannot tell with no calendar at all', () => {
-    expect(showBillAuthority(at('2026-09-09T10:00:00Z'), 'Europe/Paris', []))
+    expect(showBillAuthority(at('2026-09-09T10:00:00Z'), 'Europe/Paris', [], new Set()))
       .toBe('unknown');
   });
 
@@ -647,7 +798,7 @@ describe('showBillAuthority', () => {
   it('calls the bill stale in the small hours of an ordinary open day', () => {
     // 00:30 and 03:00 local on the 9th, a day that opens at 10:00.
     for (const utc of ['2026-09-08T22:30:00Z', '2026-09-09T01:00:00Z']) {
-      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY])).toBe('stale');
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], new Set())).toBe('stale');
     }
   });
 
@@ -658,12 +809,12 @@ describe('showBillAuthority', () => {
    */
   it('calls every show dark from midnight on a closed day', () => {
     // 00:30 local on the 10th; the calendar has the 9th and stops.
-    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY], new Set(['2026-09-10'])))
       .toBe('all-dark');
   });
 
   it('closes the shows in the small hours of a closed day too', () => {
-    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-09T22:30:00Z'), 'Europe/Paris', [TODAY], new Set(['2026-09-10'])))
       .toBe('all-dark');
   });
 
@@ -674,7 +825,7 @@ describe('showBillAuthority', () => {
    */
   it('does not treat a day that has already closed as still running', () => {
     const yesterday = hours('2026-09-08', '10:00:00', '18:00:00');
-    expect(showBillAuthority(at('2026-09-08T22:30:00Z'), 'Europe/Paris', [yesterday, TODAY]))
+    expect(showBillAuthority(at('2026-09-08T22:30:00Z'), 'Europe/Paris', [yesterday, TODAY], new Set()))
       .toBe('stale'); // 00:30 on the 9th, the 8th shut six hours ago
   });
 
@@ -688,14 +839,14 @@ describe('showBillAuthority', () => {
   it('calls the bill stale once the park has closed', () => {
     // 18:30, 20:00 and 23:45 local on a day that shuts at 18:00.
     for (const utc of ['2026-09-09T16:30:00Z', '2026-09-09T18:00:00Z', '2026-09-09T21:45:00Z']) {
-      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY])).toBe('stale');
+      expect(showBillAuthority(at(utc), 'Europe/Paris', [TODAY], new Set())).toBe('stale');
     }
   });
 
   it('still reads the bill right up to closing', () => {
-    expect(showBillAuthority(at('2026-09-09T15:59:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-09T15:59:00Z'), 'Europe/Paris', [TODAY], new Set()))
       .toBe('read-bill'); // 17:59 local, one minute before the 18:00 close
-    expect(showBillAuthority(at('2026-09-09T16:01:00Z'), 'Europe/Paris', [TODAY]))
+    expect(showBillAuthority(at('2026-09-09T16:01:00Z'), 'Europe/Paris', [TODAY], new Set()))
       .toBe('stale');     // 18:01 local
   });
 
@@ -724,7 +875,7 @@ describe('showBillAuthority', () => {
       openingTime: '2026-10-17T19:00:00+02:00',
       closingTime: '2026-10-18T01:00:00+02:00',
     };
-    expect(showBillAuthority(at('2026-10-17T21:00:00Z'), 'Europe/Paris', [night]))
+    expect(showBillAuthority(at('2026-10-17T21:00:00Z'), 'Europe/Paris', [night], new Set()))
       .toBe('read-bill'); // 23:00 local on the 17th, the night is running
   });
 
@@ -737,9 +888,9 @@ describe('showBillAuthority', () => {
       closingTime: '2026-10-18T01:00:00+02:00',
     };
     const nextDayOpen = hours('2026-10-18', '10:00:00', '18:00:00');
-    expect(showBillAuthority(at('2026-10-17T22:59:00Z'), 'Europe/Paris', [night, nextDayOpen]))
+    expect(showBillAuthority(at('2026-10-17T22:59:00Z'), 'Europe/Paris', [night, nextDayOpen], new Set()))
       .toBe('unknown'); // 00:59 local, one minute of the night left
-    expect(showBillAuthority(at('2026-10-17T23:01:00Z'), 'Europe/Paris', [night, nextDayOpen]))
+    expect(showBillAuthority(at('2026-10-17T23:01:00Z'), 'Europe/Paris', [night, nextDayOpen], new Set()))
       .toBe('stale');   // 01:01 local, the night is over and the 18th opens at 10:00
   });
 });

--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -165,20 +165,6 @@ export function buildLocalisedName(item: POIEntry): LocalisedString {
  */
 const MIN_ATTRACTION_BILL_FRACTION = 0.5;
 
-/**
- * Fraction of the park's attractions that must report open before the live
- * feed is allowed to veto a calendar that says the park is shut.
- *
- * `some(isOpen)` is not enough. Four POIs here — three playgrounds and a
- * walk-through, none of which take a queue — report `isOpen: true` around the
- * clock and have never once carried a latency. Measured over 284 samples
- * spanning a full operating day: out of hours the open count was exactly those
- * 4 of 50, every time; in hours it ran 37 to 40. A quarter sits in the middle
- * of that gap with room on both sides, and asking for a quorum rather than a
- * single vote is what makes the veto mean "the park is evidently busy" instead
- * of "at least one flag is stuck on".
- */
-const MIN_OPEN_FRACTION = 0.25;
 
 
 /**
@@ -200,9 +186,22 @@ const MIN_OPEN_FRACTION = 0.25;
  * performs — and that one matters, because a retained bill means the closed
  * days are exactly when the stale programme looks most like a live one.
  *
- * `parkIsBusy` is the live feed's own vote, and it only ever vetoes: a calendar
- * claiming today is closed while attractions report themselves open is a
- * calendar to distrust, not a park to close.
+ * The ride feed gets no vote on this. It used to: a calendar claiming today is
+ * closed while attractions reported themselves open was treated as a calendar
+ * to distrust. That conflates "the park is busy" with "the bill is about
+ * today", and the two come apart exactly where it matters. On 2026-09-10, a
+ * closed day, eleven real rides came up between 17:42 and 18:03 for what looked
+ * like a private evening event, while `paxConfiguration` still said
+ * `parkOpen: false` and the bill was the same out-of-hours default it had been
+ * serving for twenty-three hours. The rides were genuinely running and the vote
+ * was truthful; it was simply an answer to a different question. Eleven rides
+ * open for a corporate booking is no evidence that the show programme was
+ * rewritten.
+ *
+ * So on a day with no public session the shows are dark, whatever the rides are
+ * doing. A private event's rides still publish as OPERATING from
+ * `paxLatencies`, which is true, while its shows stay CLOSED, which is also
+ * true. Feed health is a separate question and `corroborated` still answers it.
  *
  * The four answers separate two things that look alike and are not. `stale`
  * means the bill is known to be about a day that has passed, so neither its
@@ -215,7 +214,6 @@ export function showBillAuthority(
   now: Date,
   timezone: string,
   calendar: ScheduleEntry[],
-  parkIsBusy: boolean,
 ): 'all-dark' | 'read-bill' | 'stale' | 'unknown' {
   if (calendar.length === 0) return 'unknown';
 
@@ -237,7 +235,7 @@ export function showBillAuthority(
 
   // Closed days carry no hours and so never reach the calendar at all.
   const todaysHours = calendar.filter((entry) => entry.date === today);
-  if (todaysHours.length === 0) return parkIsBusy ? 'unknown' : 'all-dark';
+  if (todaysHours.length === 0) return 'all-dark';
 
   // The bill is only about today while today is happening. Outside the park's
   // own hours the feed serves a default programme instead — eight shows in the
@@ -1062,18 +1060,10 @@ export class ParcAsterix extends Destination {
 
     // Whether the bill is about today at all, and what to publish when it is
     // not. See showBillAuthority.
-    // The feed's own vote on whether the park is actually busy, used only to
-    // veto a calendar that says otherwise. It needs a quorum: see
-    // MIN_OPEN_FRACTION for the four POIs whose open flag never clears.
-    const openCount = latencies.filter((entry) => entry.isOpen).length;
-    const parkIsBusy = attractions > 0
-      && openCount >= attractions * MIN_OPEN_FRACTION;
-
     const authority = showBillAuthority(
       new Date(),
       this.timezone,
       calendar,
-      parkIsBusy,
     );
 
     const showIds = poi

--- a/src/parks/parcasterix/parcasterix.ts
+++ b/src/parks/parcasterix/parcasterix.ts
@@ -214,6 +214,7 @@ export function showBillAuthority(
   now: Date,
   timezone: string,
   calendar: ScheduleEntry[],
+  closedDates: ReadonlySet<string>,
 ): 'all-dark' | 'read-bill' | 'stale' | 'unknown' {
   if (calendar.length === 0) return 'unknown';
 
@@ -235,7 +236,17 @@ export function showBillAuthority(
 
   // Closed days carry no hours and so never reach the calendar at all.
   const todaysHours = calendar.filter((entry) => entry.date === today);
-  if (todaysHours.length === 0) return 'all-dark';
+  // No hours today, and two very different reasons land here: the park's own
+  // legend said there is no session, or we could not read what it said and
+  // dropped the day. Only the first is evidence about the park.
+  //
+  // The difference matters because `all-dark` is not silence. It closes every
+  // show id, including the ones today's bill names as performing. Asserting
+  // that over a correct bill because a legend was reworded would be a worse
+  // failure than the staleness this whole mechanism exists to prevent.
+  if (todaysHours.length === 0) {
+    return closedDates.has(today) ? 'all-dark' : 'unknown';
+  }
 
   // The bill is only about today while today is happening. Outside the park's
   // own hours the feed serves a default programme instead — eight shows in the
@@ -494,7 +505,7 @@ export class ParcAsterix extends Destination {
   // so a deploy picks up localised names immediately instead of serving
   // half-a-day of stale single-language ones.
   @cache({ttlSeconds: 43200, cacheVersion: 2}) // 12h
-  async getPOIData(): Promise<{poi: POIEntry[]; calendar: ScheduleEntry[]}> {
+  async getPOIData(): Promise<{poi: POIEntry[]; calendar: ScheduleEntry[]; closedDates: string[]}> {
     const resp = await this.fetchPackageZip();
     const buffer = await resp.arrayBuffer();
 
@@ -515,6 +526,7 @@ export class ParcAsterix extends Destination {
     const allPOI: POIEntry[] = [];
     const byId = new Map<number, POIEntry>();
     let calendar: ScheduleEntry[] = [];
+    let closedDates: string[] = [];
     let primaryLoaded = false;
 
     for (const culture of cultures) {
@@ -533,6 +545,9 @@ export class ParcAsterix extends Destination {
           byId.set(item.drupal_id, item);
         }
         calendar = result.calendar;
+        // @cache stores JSON, and a Set does not survive that round trip, so
+        // this travels as an array and is rebuilt where it is used.
+        closedDates = [...result.closedDates];
         continue;
       }
 
@@ -554,7 +569,7 @@ export class ParcAsterix extends Destination {
       }
     }
 
-    return {poi: allPOI, calendar};
+    return {poi: allPOI, calendar, closedDates};
   }
 
   /**
@@ -564,7 +579,7 @@ export class ParcAsterix extends Destination {
   private loadSqliteDatabase(
     data: Buffer,
     culture: string,
-  ): {poi: POIEntry[]; calendar: ScheduleEntry[]} {
+  ): {poi: POIEntry[]; calendar: ScheduleEntry[]; closedDates: Set<string>} {
     const tmpFile = join(tmpdir(), `pax_${culture}_${Date.now()}.sqlite`);
     writeFileSync(tmpFile, data);
 
@@ -625,11 +640,14 @@ export class ParcAsterix extends Destination {
 
       db.close();
 
-      // Parse calendar labels into hours map
-      const hoursMap = this.parseCalendarLabels(labels);
+      // Parse calendar labels into an hours map, plus the day types whose
+      // legend positively states the park is shut.
+      const {hoursMap, closedTypes} = this.parseCalendarLabels(labels);
 
       // Build calendar entries
-      const calendar = this.buildCalendarEntries(calendarItems, hoursMap);
+      const {entries: calendar, closedDates} = this.buildCalendarEntries(
+        calendarItems, hoursMap, closedTypes,
+      );
 
       // Build POI list. Every localised database also carries a `title_fr`
       // column holding the original French name, so a single database is
@@ -670,7 +688,7 @@ export class ParcAsterix extends Destination {
         })),
       ];
 
-      return {poi, calendar};
+      return {poi, calendar, closedDates};
     } finally {
       try {
         unlinkSync(tmpFile);
@@ -719,8 +737,9 @@ export class ParcAsterix extends Destination {
    */
   private parseCalendarLabels(
     labels: SqliteLabel[],
-  ): Record<string, TimeRange[]> {
+  ): {hoursMap: Record<string, TimeRange[]>; closedTypes: Set<string>} {
     const hoursMap: Record<string, TimeRange[]> = {};
+    const closedTypes = new Set<string>();
 
     const connector = '\\s*(?:-|to)\\s*';
     const postfix = '(?:am|pm|a\\.m|p\\.m|h|hr)\\.?';
@@ -738,9 +757,22 @@ export class ParcAsterix extends Destination {
       ),
     ];
 
+    // A legend carrying no clock time at all is the park saying there is no
+    // session that day — type D reads "Theme Park closed". One carrying clock
+    // times we then failed to pair into a range is a legend we could not read,
+    // which is a different thing and must never be published as a closure.
+    // Built from the same tokens as the range patterns, so the two can never
+    // disagree about what a time looks like.
+    const anyTime = new RegExp(`(?:${withMinutes})|(?:${withoutMinutes})`, 'i');
+
     for (const label of labels) {
       const key = label.key.replace('calendar.dateType.legend.', '');
       if (hoursMap[key]) continue;
+
+      if (!anyTime.test(label.value)) {
+        closedTypes.add(key);
+        continue;
+      }
 
       for (const pattern of patterns) {
         const matches = label.value.match(pattern);
@@ -757,7 +789,7 @@ export class ParcAsterix extends Destination {
       }
     }
 
-    return hoursMap;
+    return {hoursMap, closedTypes};
   }
 
   /**
@@ -766,15 +798,34 @@ export class ParcAsterix extends Destination {
   private buildCalendarEntries(
     calendarItems: SqliteCalendarItem[],
     hoursMap: Record<string, TimeRange[]>,
-  ): ScheduleEntry[] {
+    closedTypes: Set<string>,
+  ): {entries: ScheduleEntry[]; closedDates: Set<string>} {
     const entries: ScheduleEntry[] = [];
+    const closedDates = new Set<string>();
+    const unreadable = new Map<string, number>();
 
     for (const item of calendarItems) {
       const hours = hoursMap[item.type];
-      if (!hours) continue;
-
       // SQLite day field may include time portion ("2026-04-04 00:00:00")
       const dateStr = item.day.split(' ')[0];
+
+      // A day with no hours leaves the calendar either way, so its absence
+      // cannot tell the caller whether the park said "closed" or whether we
+      // failed to read what it said. Those two demand opposite behaviour — one
+      // closes every show in the park, the other must publish nothing at all —
+      // so the distinction is carried out rather than inferred from a gap.
+      //
+      // An empty range list is the same case by a quieter route: a legend that
+      // matched a pattern but whose ranges all failed to parse leaves `[]`,
+      // which is truthy and would otherwise sail past a `!hours` check.
+      if (!hours || hours.length === 0) {
+        if (closedTypes.has(item.type)) {
+          closedDates.add(dateStr);
+        } else {
+          unreadable.set(item.type, (unreadable.get(item.type) ?? 0) + 1);
+        }
+        continue;
+      }
 
       for (const range of hours) {
         if (!range.start || !range.end) continue;
@@ -806,7 +857,18 @@ export class ParcAsterix extends Destination {
       }
     }
 
-    return entries;
+    // Loud on purpose. A day type we cannot read is how an operating day comes
+    // to look exactly like a closed one, and the only thing worse than that
+    // happening is it happening quietly.
+    for (const [type, days] of unreadable) {
+      console.warn(
+        `[${this.constructor.name}] calendar day type '${type}' yielded no ` +
+        `readable hours and does not read as closed — ${days} day(s) dropped. ` +
+        `Shows on those days publish nothing rather than closing.`,
+      );
+    }
+
+    return {entries, closedDates};
   }
 
   // ── Entity building ──────────────────────────────────────────
@@ -916,8 +978,9 @@ export class ParcAsterix extends Destination {
     // closures rather than publishing nothing.
     let poi: POIEntry[] = [];
     let calendar: ScheduleEntry[] = [];
+    let closedDates: string[] = [];
     try {
-      ({poi, calendar} = await this.getPOIData());
+      ({poi, calendar, closedDates} = await this.getPOIData());
     } catch (err) {
       console.warn(
         `[${this.constructor.name}] offline package unavailable, ` +
@@ -1064,6 +1127,7 @@ export class ParcAsterix extends Destination {
       new Date(),
       this.timezone,
       calendar,
+      new Set(closedDates),
     );
 
     const showIds = poi


### PR DESCRIPTION
Follow-up to #558, which raised the fence rather than removing it. Caught live tonight by the sampler.

## What happened, 2026-09-10 (a closed day)

| Paris | open rides | ratio vs 41 |
|---|---|---|
| ≤17:39 | 4 | 0.098 |
| 17:42 | 5 | 0.122 |
| 17:48 | 7 | 0.171 |
| 17:54 | 8 | 0.195 |
| **18:03** | **11** | **0.268 — quorum crossed** |
| 18:06 | 12 | 0.293 |

Real headline rides: SOS Hieroglyphix, Osiris Convolvulis, By Toutatis!, The Tower of Edifis, The Flight of Ibis. Meanwhile `paxConfiguration` said `parkOpen: false`, the package calendar said type D, and the bill was the same out-of-hours default it had been serving for twenty-three hours.

Almost certainly a private evening event. The veto flipped, `all-dark` became `unknown`, and the build was about to republish that default programme as **eighteen performances on a day the park is shut to the public** — the state #558 cleared this morning, re-entered from the numerator instead of the denominator.

## The joint

`parkIsBusy` conflates *"the park is busy"* with *"the bill is about today"*. Both times it has misfired it was reporting truthfully; it was simply answering a different question. Eleven rides running for a corporate booking is no evidence that the show programme was rewritten.

So the calendar decides this on its own:

```ts
if (todaysHours.length === 0) return 'all-dark';
```

A private event now publishes its rides as OPERATING from `paxLatencies`, which is true, while its shows stay CLOSED, which is also true.

## Why not just raise the threshold again

Eleven of forty-one is a real fraction by any threshold that still catches a dead feed — and catching a dead feed is the only thing the quorum existed for. Raising it trades this failure for that one. Feed health is a separate question that `corroborated` already answers, so `MIN_OPEN_FRACTION` goes.

## The trade being made

The veto protected one case: a calendar that wrongly omits an operating day would force-close every show while they perform. That risk is bounded — the package calendar is the park's own and publishes weeks ahead, and it is cached 12h — and it fails toward *missing* information rather than *fabricated* information. The failure being removed has now fired twice in two days.

## Tests

Three tests named for the after-midnight tail of an event night were fixtured as ordinary 10:00–18:00 days, so what kept them silent at 01:30 was the veto, not anything about event nights — they were passing for the wrong reason. They now assert the real rule: at 01:30 on a day carrying no hours, nothing is running and the shows are dark. A genuine event night, whose entry closes after midnight, is covered by the mid-session test and reads its bill straight through, unchanged.

2465 pass. Live run mid-event: **12 rides operating, all 13 shows closed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
